### PR TITLE
Unit tests filter

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -19,12 +19,34 @@ It is based on [pytest](http://doc.pytest.org/en/latest/contents.html) and [test
 
 ## Run tests
 
-- `pytest -l -v test`
+- `pytest -l -v`
+
+
+### Run unit tests only
+
+There is a subset of tests that verifies some scoped logic in a way
+of [unit testing](https://en.wikipedia.org/wiki/Unit_testing).
+
+These tests are:
+- safe to run on a local host since they don't require any virtual environment
+- fast, usually will end in a minute or less
+
+To filter that tests `unit` marker is available:
+
+- `pytest -m unit --collect-only` will show all unit tests available
+- `pytest -m unit` will run the tests
+
+To mark a test as a unit you may:
+
+- use the `unit` marker
+- use the `unit` fixture (a good way to mark a bunch of tests)
+
 
 ### Useful Options
 
 - `pytest ... test/<path-to-some-test-module>` to run tests only for some test module
 - `-k pattern` to filter test by name, parameters etc.
+- `-m expr` to filter tests by marker
 - `-n auto` to run multiple tests processes in parallel using available CPU cores (check [pytest-xdist](https://docs.pytest.org/en/3.0.1/xdist.html))
 - `--log-cli-level <LOG-LEVEL>` to pass logs to stdout/stderr
 

--- a/test/api/python/integration/test_api.py
+++ b/test/api/python/integration/test_api.py
@@ -187,9 +187,8 @@ def test_set_network(
     run_test(mhosteosnode1)
 
 
-# TODO DOC example how to parametrize cluster/singlenode:
-# - dynamic markers
-# - dynamic fixtures
+# TODO DOC example how to parametrize cluster/singlenode
+# TODO DOC dynamic markers, dynamic fixtures
 @pytest.mark.timeout(1200)
 @pytest.mark.isolated
 @pytest.mark.parametrize(

--- a/test/api/python/provisioner/conftest.py
+++ b/test/api/python/provisioner/conftest.py
@@ -6,6 +6,11 @@ from provisioner import (
 )
 
 
+@pytest.fixture(scope='session', autouse=True)
+def unit():
+    pass
+
+
 @pytest.fixture
 def pillar_dir(monkeypatch, tmpdir_function):
     pillar_dir = tmpdir_function / 'pillar'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@ import docker
 import time
 import json
 import attr
-from typing import Iterable
 from pathlib import Path
 from collections import defaultdict
 
@@ -315,7 +314,6 @@ def pytest_configure(config):
     )
 
 
-
 prvsnr_pytest_options = {
     # TODO might be useful to test in multiple at once
     "base-env": dict(
@@ -352,6 +350,33 @@ prvsnr_pytest_options = {
 def pytest_addoption(parser):
     for name, params in prvsnr_pytest_options.items():
         parser.addoption("--" + name, **params)
+
+
+# TODO DOC how to modify tests collections
+# TODO DOC how to apply markers dynamically so it woudl impact comllection
+def pytest_collection_modifyitems(session, config, items):
+    for item in items:
+        if "unit" in item.fixturenames:
+            item.add_marker(pytest.mark.unit)
+        elif "integration1" in item.fixturenames:
+            item.add_marker(pytest.mark.integration1)
+        else:
+            item.add_marker(pytest.mark.integration2)
+
+
+@pytest.fixture(scope='session')
+def unit():
+    pass
+
+
+@pytest.fixture(scope='session')
+def integration1():
+    pass
+
+
+@pytest.fixture(scope='session')
+def integration2():
+    pass
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
- `-m unit` will filter unit tests
- `unit` fixture helps to mark a group of tests as unit ones
- adds short docs about unit tests