### PR TITLE
EOS-10145: Unmount swupdate /opt/seagate/eos/updates/ mounts

### DIFF
--- a/cli/src/destroy
+++ b/cli/src/destroy
@@ -224,39 +224,26 @@ fi
 
 if [[ "$remove_prvsnr" == true ]]; then
     l_info "Cleaning up Provisioner"
-    if [[ -f /usr/local/bin/salt ]]; then
-        l_info "Removing prvsnr api logs configuration from node-1"
-        salt 'srvnode-1' state.apply components.provisioner.teardown $salt_opts
-        l_info "Unmounting sw_update mounts if any from both nodes"
-        for build_mount in `findmnt -l --output=target | grep "/opt/seagate/cortx/updates/" || true`; do
-            salt '*' mount.umount name=$build_mount || true
-        done
-        l_info "Removing cortx packages from both nodes"
-        for pkg in `rpm -qa | grep cortx`; do
-            l_info "INFO: Removing ${pkg}"
-            salt '*' pkg.remove ${pkg} $salt_opts || true
-        done
-    else
-        l_info "Removing prvsnr api logs configuration from node-1"
-        rm -rf /etc/rsyslog.d/prvsnrfwd.conf || true
-        rm -rf /etc/rsyslog.d/2-prvsnrfwd.conf || true
 
-        l_info "Removing cortx packages from node-2"
-        ssh srvnode-2 'for pkg in `rpm -qa | grep cortx`; do\
-            echo "INFO: Removing ${pkg}"; yum -q remove -y ${pkg}; done'
-        l_info "Unmounting sw_update mounts if any from node-2"
-        ssh srvnode-2 'for build_mount in `findmnt -l --output=target | grep "/opt/seagate/cortx/updates" || true`; do\
-            umount $build_mount; done'
+    l_info "Removing prvsnr api logs configuration from node-1"
+    rm -rf /etc/rsyslog.d/prvsnrfwd.conf || true
+    rm -rf /etc/rsyslog.d/2-prvsnrfwd.conf || true
 
-        l_info "Removing cortx packages from node-1"
-        for pkg in `rpm -qa | grep cortx`; do\
-            l_info "INFO: Removing ${pkg}"; yum -q remove -y ${pkg}; 
-        done
-        l_info "Unmounting sw_update mounts if any from node-1"
-        for build_mount in `findmnt -l --output=target | grep "/opt/seagate/cortx/updates" || true`; do\
-            umount ${build_mount}; 
-        done
-    fi
+    l_info "Removing cortx packages from node-2"
+    ssh srvnode-2 'for pkg in `rpm -qa | grep cortx || true`; do\
+        echo "INFO: Removing ${pkg}"; yum -q remove -y ${pkg}; done'
+    l_info "Unmounting sw_update mounts if any from node-2"
+    ssh srvnode-2 'for build_mount in `findmnt -l --output=target | grep "/opt/seagate/cortx/updates" || true`; do\
+        umount $build_mount; done'
+
+    l_info "Removing cortx packages from node-1"
+    for pkg in `rpm -qa | grep cortx || true`; do
+        l_info "INFO: Removing ${pkg}"; yum -q remove -y ${pkg}
+    done
+    l_info "Unmounting sw_update mounts if any from node-1"
+    for build_mount in `findmnt -l --output=target | grep "/opt/seagate/cortx/updates" || true`; do
+        umount ${build_mount}
+    done
 
     l_info "Removing salt packages from node-2"
     ssh srvnode-2 "yum remove -y salt* || true; rm -rf /etc/salt"


### PR DESCRIPTION
Fix: sw update destroy scripts with remove-provisioner option is not able to remove "/opt/seagate/eos/updates/" path