### PR TITLE
EOS-8905: Integrate with cortx-hare and cortx-ha [Re-apply]

### DIFF
--- a/cli/src/deploy
+++ b/cli/src/deploy
@@ -10,7 +10,7 @@ export LOG_FILE
 
 . $BASEDIR/common_utils/functions.sh
 
-l_info "***** Running $0 *****" 
+l_info "***** Running $0 *****"
 
 function trap_handler {
     echo "***** FAILED!! *****"
@@ -155,8 +155,8 @@ function run_states {
         done
     else
         for state in ${states[@]}; do
-            if [[ "$state" == "ha.corosync-pacemaker" 
-                || "$state" == "system.storage" 
+            if [[ "$state" == "ha.corosync-pacemaker"
+                || "$state" == "system.storage"
                 || "$state" == "sspl"
                 || "$state" == "csm"
                 ]]; then

--- a/cli/src/destroy
+++ b/cli/src/destroy
@@ -26,12 +26,6 @@ remove_prereqs=false
 remove_system=false
 remove_prvsnr=false
 
-ha_states=(
-    "ha.ees_ha"
-    "ha.corosync-pacemaker"
-    "hare"
-)
-
 controlpath_states=(
 # states to be applied in desired sequence
     "ha.cortx-ha"
@@ -39,6 +33,12 @@ controlpath_states=(
     "uds"
     "csm"
     "sspl"
+)
+
+ha_states=(
+    "ha.ees_ha"
+    "ha.corosync-pacemaker"
+    "hare"
 )
 
 iopath_states=(

--- a/cli/src/recovery_ops/storage_metadata_reset
+++ b/cli/src/recovery_ops/storage_metadata_reset
@@ -48,7 +48,9 @@ function trigger_hare_reset {
     _linfo "Starting metadata reset using Hare utility: hare-m0reset."
     _linfo "*****************************************************************"
     
-    bash /opt/seagate/cortx/hare/libexec/prov-m0-reset /var/lib/hare/cluster.yaml /var/lib/hare/build-ees-ha-args.yaml 2>&1 | tee -a ${LOG_FILE} || (
+    /opt/seagate/cortx/ha/conf/script/prov-m0-reset \
+        /var/lib/hare/cluster.yaml \
+        /opt/seagate/cortx/ha/conf/build-ees-ha-args.yaml 2>&1 | tee -a ${LOG_FILE} || (
         _lerror "Script *hare-m0reset* failed to execute. Check log file: ${LOG_FILE}"
     )
 

--- a/srv/components/csm/prepare.sls
+++ b/srv/components/csm/prepare.sls
@@ -20,7 +20,7 @@ Add CSM repo:
 {% if 'single' not in pillar['cluster']['type'] %}
 Render CSM ha input params template:
   file.managed:
-    - name: /var/lib/hare/build-ees-ha-csm-args.yaml
+    - name: /opt/seagate/cortx/ha/conf/build-ees-ha-csm-args.yaml
     - source: salt://components/csm/files/ha-params.tmpl
     - template: jinja
     - mode: 444

--- a/srv/components/ha/cortx-ha/ha_cleanup.sls
+++ b/srv/components/ha/cortx-ha/ha_cleanup.sls
@@ -1,7 +1,4 @@
 {% if pillar['cluster'][grains['id']]['is_primary'] %}
-include:
-  - components.ha.ees_ha.prepare
-
 Run cortx-ha ha setup:
   cmd.run:
     - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup.yaml', 'ha:ha-cleanup')

--- a/srv/components/ha/ees_ha/config.sls
+++ b/srv/components/ha/ees_ha/config.sls
@@ -5,13 +5,13 @@ include:
 
 Post install for EES HA cluster:
   cmd.run:
-    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/hare/conf/setup-ha.yaml', 'hare:post_install')
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup-ees.yaml', 'ees-ha:post_install')
 
 Config for EES HA cluster:
   cmd.run:
-    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/hare/conf/setup-ha.yaml', 'hare:config')
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup-ees.yaml', 'ees-ha:config')
 
 start EES HA cluster:
   cmd.run:
-    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/hare/conf/setup-ha.yaml', 'hare:init')
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup-ees.yaml', 'ees-ha:init')
 {% endif %}

--- a/srv/components/ha/ees_ha/post_update.sls
+++ b/srv/components/ha/ees_ha/post_update.sls
@@ -1,5 +1,5 @@
 {% if salt["pillar.get"]('cluster:{0}:is_primary'.format(grains['id']), false) %}
 Stage - Post Update Hare:
   cmd.run:
-    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/hare/conf/setup-ha.yaml', 'hare:post_update')
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup-ees.yaml', 'ees-ha:post_update')
 {% endif %}

--- a/srv/components/ha/ees_ha/prepare.sls
+++ b/srv/components/ha/ees_ha/prepare.sls
@@ -1,6 +1,6 @@
 Render ha input params template:
   file.managed:
-    - name: /var/lib/hare/build-ees-ha-args.yaml
+    - name: /opt/seagate/cortx/ha/conf/build-ees-ha-args.yaml
     - source: salt://components/ha/ees_ha/files/ha-params.tmpl
     - template: jinja
     - mode: 444

--- a/srv/components/ha/ees_ha/sanity_test.sls
+++ b/srv/components/ha/ees_ha/sanity_test.sls
@@ -1,5 +1,5 @@
 {% if salt["pillar.get"]('cluster:{0}:is_primary'.format(grains['id']), false) %}
 start EES HA cluster:
   cmd.run:
-    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/hare/conf/setup-ha.yaml', 'hare:test')
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup-ees.yaml', 'ees-ha:test')
 {% endif %}

--- a/srv/components/ha/ees_ha/teardown.sls
+++ b/srv/components/ha/ees_ha/teardown.sls
@@ -1,7 +1,7 @@
 {% if salt["pillar.get"]('cluster:{0}:is_primary'.format(grains['id']), false) %}
 Remove Cortx-HA resources:
   cmd.run:
-    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/hare/conf/setup-ha.yaml', 'hare:reset')
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup-ees.yaml', 'ees-ha:reset')
     - order: 1
 {% endif %}
 Delete ees_ha checkpoint flag:

--- a/srv/components/uds/ha.sls
+++ b/srv/components/uds/ha.sls
@@ -1,7 +1,7 @@
 {% if pillar['cluster'][grains['id']]['is_primary'] %}
 Setup UDS HA:
   cmd.run:
-    - name: /opt/seagate/cortx/hare/libexec/build-ees-ha-uds
+    - name: /opt/seagate/cortx/ha/conf/script/build-ees-ha-uds
 {% else %}
 No post install for UDS:
   test.show_notification:

--- a/srv/components/uds/ha_cleanup.sls
+++ b/srv/components/uds/ha_cleanup.sls
@@ -1,8 +1,8 @@
 {% if pillar['cluster'][grains['id']]['is_primary'] %}
 Teardown UDS HA:
   cmd.run:
-    - name: /opt/seagate/cortx/hare/libexec/prov-ha-uds-reset
-    - onlyif: test -x /opt/seagate/cortx/hare/libexec/prov-ha-uds-reset
+    - name: /opt/seagate/cortx/ha/conf/script/prov-ha-uds-reset
+    - onlyif: test -x /opt/seagate/cortx/ha/conf/script/prov-ha-uds-reset
 {% else %}
 No post install for UDS:
   test.show_notification:


### PR DESCRIPTION
Hare's HA scripts have been moved to `cortx-ha` RPM.
Update sls files correspondingly.