### PR TITLE
[EOS-11307] hardens logic of pip3 over system based installation

### DIFF
--- a/api/python/provisioner/__metadata__.py
+++ b/api/python/provisioner/__metadata__.py
@@ -1,5 +1,5 @@
 __title__ = 'cortx-prvsnr'
-__version__ = '0.27.0'
+__version__ = '0.28.0'
 __author__ = "Seagate"
 __author_email__ = 'support@seagate.com'  # TODO
 __maintainer__ = 'Seagate'

--- a/api/python/provisioner/srv/salt/provisioner/api_install.sls
+++ b/api/python/provisioner/srv/salt/provisioner/api_install.sls
@@ -1,16 +1,23 @@
-prvsnrusers:
-  group.present
-
-# TODO IMPROVE EOS-8473 consider states instead
-user_salt_roots_created:
-  cmd.script:
-    - source: salt://provisioner/files/post_setup.sh
+m2crypto_precompiled_installed:
+  pkg.installed:
+    - pkgs:
+      - python36-m2crypto
 
 api_installed:
   pip.installed:
     - name: /opt/seagate/cortx/provisioner/api/python
     - bin_env: /usr/bin/pip3
-    - upgrade: True
+    - upgrade: False  # to reuse already installed dependencies
+                      # that may come from rpm repositories
+
+prvsnrusers:
+  group.present
+
+
+# TODO IMPROVE EOS-8473 consider states instead
+api_post_setup_applied:
+  cmd.script:
+    - source: salt://provisioner/files/post_setup.sh
 
 salt_dynamic_modules_synced:
   cmd.run:


### PR DESCRIPTION
fixes possible issues with api installation when salt and its dependencies are already installed from system packages repositories