### PR TITLE
Improvised salt module usability: lyveutil.decrypt

### DIFF
--- a/srv/_modules/lyveutil.py
+++ b/srv/_modules/lyveutil.py
@@ -1,12 +1,12 @@
 # How to test:
 # salt-call saltutil.clear_cache && salt-call saltutil.sync_modules
-# salt-call lyveutil.decrypt "secret" "component"
+# salt-call lyveutil.decrypt "component" "secret"
 
 from salt import client
 
 from eos.utils.security.cipher import Cipher, CipherInvalidToken
 
-def decrypt(secret, component):
+def decrypt(component, secret):
     """ Decrypt secret.
 
     Args:

--- a/srv/components/controller/files/scripts/controller-cli.sh
+++ b/srv/components/controller/files/scripts/controller-cli.sh
@@ -433,7 +433,7 @@ main()
     if [[ "$update_fw" = true || "$restart_ctrl_opt" = true
         || "$shutdown_ctrl_opt" = true ]]; then
         echo "main(): Decrypting the password received from api" >> $logfile
-        pass=`salt-call lyveutil.decrypt ${pass} storage_enclosure --output=newline_values_only`
+        pass=`salt-call lyveutil.decrypt storage_enclosure ${pass} --output=newline_values_only`
         echo "main(): decrypted password: $pass" >> $logfile
         ssh_cred="$ssh_tool -p $pass"
         ssh_cmd="$ssh_base_cmd $ssh_opts $user@$host"

--- a/srv/components/ha/corosync-pacemaker/config/base.sls
+++ b/srv/components/ha/corosync-pacemaker/config/base.sls
@@ -3,7 +3,7 @@
 Update ha user:
   user.present:
     - name: {{ pillar['corosync-pacemaker']['user'] }}
-    - password: {{ salt['lyveutil.decrypt'](pillar['corosync-pacemaker']['secret'], 'corosync-pacemaker') }}
+    - password: {{ salt['lyveutil.decrypt']('corosync-pacemaker', pillar['corosync-pacemaker']['secret']) }}
     - hash_password: True
     - createhome: False
     - shell: /sbin/nologin
@@ -39,7 +39,7 @@ Authorize nodes:
       - {{ node_id }}
       {%- endfor %}
     - pcsuser: {{ pillar['corosync-pacemaker']['user'] }}
-    - pcspasswd: {{ salt['lyveutil.decrypt'](pillar['corosync-pacemaker']['secret'],'corosync-pacemaker') }}
+    - pcspasswd: {{ salt['lyveutil.decrypt']('corosync-pacemaker', pillar['corosync-pacemaker']['secret']) }}
     - extra_args:
       - '--force'
     - require:

--- a/srv/components/ha/corosync-pacemaker/config/stonith.sls
+++ b/srv/components/ha/corosync-pacemaker/config/stonith.sls
@@ -12,12 +12,12 @@ Remove stonith id stonith-c2 if already present:
 
 Prepare for stonith on node-1:
   cmd.run:
-    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt'](pillar['cluster']['srvnode-1']['bmc']['secret'], 'cluster') }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s 
+    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-1']['bmc']['secret']) }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s 
     - unless: pcs stonith show stonith-c1
 
 Prepare for stonith on node-2:
   cmd.run:
-    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt'](pillar['cluster']['srvnode-2']['bmc']['secret'], 'cluster') }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s
+    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-2']['bmc']['secret']) }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s
     - unless: pcs stonith show stonith-c2
 
 Apply stonith for node-1:

--- a/srv/components/misc_pkgs/build_ssl_cert_rpms/files/ssl/domain_input.conf
+++ b/srv/components/misc_pkgs/build_ssl_cert_rpms/files/ssl/domain_input.conf
@@ -4,4 +4,4 @@ s3_iam_endpoint=iam.seagate.com
 s3_sts_endpoint=sts.seagate.com
 s3_ip_address=127.0.0.1,::1
 openldap_domainname=localhost
-passphrase={{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }}
+passphrase={{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }}

--- a/srv/components/misc_pkgs/openldap/config/base.sls
+++ b/srv/components/misc_pkgs/openldap/config/base.sls
@@ -3,7 +3,7 @@ include:
 
 Configure OpenLDAP - Base config:
   cmd.run:
-    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/cfg_ldap.ldif
+    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/cfg_ldap.ldif
     - watch_in:
       - Restart slapd service
 
@@ -17,9 +17,9 @@ Remove existing file:
 
 Configure OpenLDAP - Schema:
   cmd.run:
-    - name: ldapadd -x -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/cn\=\{1\}s3user.ldif -H ldapi:///
+    - name: ldapadd -x -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/cn\=\{1\}s3user.ldif -H ldapi:///
     # - unless:
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "cn={1}s3user,cn=schema,cn=config"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "cn={1}s3user,cn=schema,cn=config"
     - require:
       - Remove existing file
     - watch_in:
@@ -27,13 +27,13 @@ Configure OpenLDAP - Schema:
 
 Configure OpenLDAP - Base data:
   cmd.run:
-    - name: ldapadd -x -D "cn=admin,dc=seagate,dc=com" -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ldap-init.ldif -H ldapi:///
+    - name: ldapadd -x -D "cn=admin,dc=seagate,dc=com" -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ldap-init.ldif -H ldapi:///
     # - unless:
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "dc=seagate,dc=com"
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "dc=s3,dc=seagate,dc=com"
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "ou=accounts,dc=s3,dc=seagate,dc=com"
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "ou=accesskeys,dc=s3,dc=seagate,dc=com"
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "ou=idp,dc=s3,dc=seagate,dc=com"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "dc=seagate,dc=com"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "dc=s3,dc=seagate,dc=com"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "ou=accounts,dc=s3,dc=seagate,dc=com"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "ou=accesskeys,dc=s3,dc=seagate,dc=com"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "ou=idp,dc=s3,dc=seagate,dc=com"
     - require:
       - Configure OpenLDAP - Schema
     - watch_in:
@@ -41,9 +41,9 @@ Configure OpenLDAP - Base data:
 
 Configure OpenLDAP - Add IAM admin:
   cmd.run:
-    - name: ldapadd -x -D 'cn=admin,dc=seagate,dc=com' -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/iam-admin.ldif -H ldapi:///
+    - name: ldapadd -x -D 'cn=admin,dc=seagate,dc=com' -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/iam-admin.ldif -H ldapi:///
     # - unless:
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "cn=sgiamadmin,dc=seagate,dc=com"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "cn=sgiamadmin,dc=seagate,dc=com"
     - require:
       - Configure OpenLDAP - Base data
     - watch_in:
@@ -51,7 +51,7 @@ Configure OpenLDAP - Add IAM admin:
 
 Configure OpenLDAP - Setup permissions for IAM admin:
   cmd.run:
-    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/iam-admin-access.ldif
+    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/iam-admin-access.ldif
     - require:
       - Configure OpenLDAP - Add IAM admin
     - watch_in:
@@ -59,10 +59,10 @@ Configure OpenLDAP - Setup permissions for IAM admin:
 
 Configure OpenLDAP - Enable IAM constraints:
   cmd.run:
-    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/iam-constraints.ldif
+    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/iam-constraints.ldif
     # - unless:
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "cn=module{0},cn=config"
-    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "olcOverlay=unique,olcDatabase={2}{{ pillar['openldap']['backend_db'] }},cn=config"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "cn=module{0},cn=config"
+    #   - ldapsearch -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap:// -b "olcOverlay=unique,olcDatabase={2}{{ pillar['openldap']['backend_db'] }},cn=config"
     - require:
       - Configure OpenLDAP - Setup permissions for IAM admin
     - watch_in:
@@ -70,7 +70,7 @@ Configure OpenLDAP - Enable IAM constraints:
 
 Configure OpenLDAP - Load ppolicy schema:
   cmd.run:
-    - name: ldapmodify -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -a -f /etc/openldap/schema/ppolicy.ldif -H ldapi:///
+    - name: ldapmodify -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -a -f /etc/openldap/schema/ppolicy.ldif -H ldapi:///
     - require:
       - Configure OpenLDAP - Enable IAM constraints
     - watch_in:
@@ -78,7 +78,7 @@ Configure OpenLDAP - Load ppolicy schema:
 
 Configure OpenLDAP - Load ppolicy module:
   cmd.run:
-    - name: ldapmodify -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -a -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ppolicymodule.ldif -H ldapi:///
+    - name: ldapmodify -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -a -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ppolicymodule.ldif -H ldapi:///
     - require:
       - Configure OpenLDAP - Load ppolicy schema
     - watch_in:
@@ -86,7 +86,7 @@ Configure OpenLDAP - Load ppolicy module:
 
 Configure OpenLDAP - Load ppolicy overlay:
   cmd.run:
-    - name: ldapmodify -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -a -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ppolicyoverlay.ldif -H ldapi:///
+    - name: ldapmodify -D "cn=admin,cn=config" -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -a -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ppolicyoverlay.ldif -H ldapi:///
     - require:
       - Configure OpenLDAP - Load ppolicy module
     - watch_in:
@@ -94,7 +94,7 @@ Configure OpenLDAP - Load ppolicy overlay:
 
 Configure OpenLDAP - password policy:
   cmd.run:
-    - name: ldapmodify -x -a -H ldapi:/// -D cn=admin,dc=seagate,dc=com -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ppolicy-default.ldif
+    - name: ldapmodify -x -a -H ldapi:/// -D cn=admin,dc=seagate,dc=com -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/ppolicy-default.ldif
     - require:
       - Configure OpenLDAP - Load ppolicy overlay
     - watch_in:

--- a/srv/components/misc_pkgs/openldap/files/ldap_gen_passwd.sh
+++ b/srv/components/misc_pkgs/openldap/files/ldap_gen_passwd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-{%- set openldap_admin_secret = salt['lyveutil.decrypt'](salt['pillar.get']('openldap:admin:secret', "seagate"), 'openldap') %}
-{%- set openldap_iam_secret = salt['lyveutil.decrypt'](salt['pillar.get']('openldap:iam_admin:secret', "ldapadmin"), 'openldap') %}
+{%- set openldap_admin_secret = salt['lyveutil.decrypt']('openldap', salt['pillar.get']('openldap:admin:secret', "seagate")) %}
+{%- set openldap_iam_secret = salt['lyveutil.decrypt']('openldap', salt['pillar.get']('openldap:iam_admin:secret', "ldapadmin")) %}
 
 ROOTDNPASSWORD="{{ openldap_admin_secret }}"
 LDAPADMINPASS="{{ openldap_iam_secret }}"

--- a/srv/components/misc_pkgs/openldap/replication/config.sls
+++ b/srv/components/misc_pkgs/openldap/replication/config.sls
@@ -6,13 +6,13 @@ include:
 {% if pillar['cluster']['type'] != "single" -%}
 Configure unique olcserver Id:
   cmd.run:
-    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/olcserverid.ldif && sleep 2
+    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/olcserverid.ldif && sleep 2
     - watch_in:
       - Restart slapd service
 
 Load provider module:
   cmd.run:
-    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/syncprov_mod.ldif && sleep 2
+    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/syncprov_mod.ldif && sleep 2
     - require:
       - Configure unique olcserver Id
     - watch_in:
@@ -20,7 +20,7 @@ Load provider module:
 
 Push Provider ldif for config replication:
   cmd.run:
-    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/syncprov_config.ldif && sleep 2
+    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/syncprov_config.ldif && sleep 2
     - require:
       - Load provider module
     - watch_in:
@@ -28,7 +28,7 @@ Push Provider ldif for config replication:
 
 Push config replication:
   cmd.run:
-    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/config.ldif && sleep 2
+    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/config.ldif && sleep 2
     - require:
       - Push Provider ldif for config replication
     - watch_in:
@@ -37,7 +37,7 @@ Push config replication:
 {% if "primary" in grains["roles"][0] -%}
 Push provider for data replication:
   cmd.run:
-    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/syncprov.ldif && sleep 2
+    - name: ldapadd -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/syncprov.ldif && sleep 2
     - require:
       - Push config replication
     - watch_in:
@@ -45,7 +45,7 @@ Push provider for data replication:
 
 Push data replication ldif:
   cmd.run:
-    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/data.ldif && sleep 2
+    - name: ldapmodify -Y EXTERNAL -H ldapi:/// -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -f /opt/seagate/cortx/provisioner/generated_configs/ldap/data.ldif && sleep 2
     - require:
       - Push provider for data replication
     - watch_in:

--- a/srv/components/misc_pkgs/openldap/replication/files/config.ldif
+++ b/srv/components/misc_pkgs/openldap/replication/files/config.ldif
@@ -31,7 +31,7 @@ olcSyncRepl: rid={{ "{0:03d}".format(100+loop.index) }}
   provider=ldap://{{ node }}:389/
   bindmethod=simple
   binddn="cn=admin,cn=config"
-  credentials={{ salt['lyveutil.decrypt'](salt['pillar.get']('openldap:admin:secret', "seagate"),'openldap') }}
+  credentials={{ salt['lyveutil.decrypt'](salt['pillar.get']('openldap', 'openldap:admin:secret', "seagate")) }}
   searchbase="cn=config"
   scope=sub
   schemachecking=on

--- a/srv/components/misc_pkgs/openldap/replication/files/data.ldif
+++ b/srv/components/misc_pkgs/openldap/replication/files/data.ldif
@@ -33,7 +33,7 @@ olcSyncRepl: rid={{ "{0:03d}".format(200+loop.index) }}
   provider=ldap://{{ node }}:389/
   bindmethod=simple
   binddn="cn=admin,dc=seagate,dc=com"
-  credentials={{ salt['lyveutil.decrypt'](salt['pillar.get']('openldap:admin:secret', "seagate"),'openldap') }}
+  credentials={{ salt['lyveutil.decrypt']('openldap', salt['pillar.get']('openldap:admin:secret', "seagate")) }}
   searchbase="dc=seagate,dc=com"
   scope=sub
   schemachecking=on

--- a/srv/components/misc_pkgs/openldap/replication/sanity_check.sls
+++ b/srv/components/misc_pkgs/openldap/replication/sanity_check.sls
@@ -34,6 +34,6 @@ Hostlist file:
 
 Replication sanity check:
   cmd.run:
-    - name: sh /opt/seagate/cortx/provisioner/generated_configs/ldap/check_ldap_replication.sh -s /opt/seagate/cortx/provisioner/generated_configs/ldap/hostlist.txt -p {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }}
+    - name: sh /opt/seagate/cortx/provisioner/generated_configs/ldap/check_ldap_replication.sh -s /opt/seagate/cortx/provisioner/generated_configs/ldap/hostlist.txt -p {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret'],) }}
     - onlyif: test -f /opt/seagate/cortx/provisioner/generated_configs/ldap/check_ldap_replication.sh
 {%- endif %}

--- a/srv/components/misc_pkgs/openldap/sanity_check.sls
+++ b/srv/components/misc_pkgs/openldap/sanity_check.sls
@@ -1,3 +1,3 @@
 Verify ldap certificates valid and slapd is running:
   cmd.run:
-    - name: ldapsearch -b "dc=s3,dc=seagate,dc=com" -x -w {{ salt['lyveutil.decrypt'](pillar['openldap']['admin']['secret'],'openldap') }} -D "cn=admin,dc=seagate,dc=com" -H ldap://
+    - name: ldapsearch -b "dc=s3,dc=seagate,dc=com" -x -w {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['admin']['secret']) }} -D "cn=admin,dc=seagate,dc=com" -H ldap://

--- a/srv/components/s3server/config.sls
+++ b/srv/components/s3server/config.sls
@@ -6,7 +6,7 @@ Stage - Post Install S3Server:
 
 # Update password in authserver.properties:
 #   cmd.run:
-#     - name: /opt/seagate/auth/scripts/enc_ldap_passwd_in_cfg.sh -l {{ salt['lyveutil.decrypt'](pillar['openldap']['iam_admin']['secret'],'openldap') }} -p /opt/seagate/auth/resources/authserver.properties
+#     - name: /opt/seagate/auth/scripts/enc_ldap_passwd_in_cfg.sh -l {{ salt['lyveutil.decrypt']('openldap', pillar['openldap']['iam_admin']['secret']) }} -p /opt/seagate/auth/resources/authserver.properties
 #     - onlyif: test -f /opt/seagate/auth/scripts/enc_ldap_passwd_in_cfg.sh
 #     - watch_in:
 #       - service: s3authserver

--- a/srv/components/system/config/pillar_encrypt.sls
+++ b/srv/components/system/config/pillar_encrypt.sls
@@ -1,6 +1,10 @@
 Encrypt_pillar:
   cmd.run:
-    - name: python3 /opt/seagate/cortx/provisioner/cli/pillar_encrypt
+    {% if salt['file.file_exists']("/opt/seagate/cortx/provisioner/cli/pillar_encrypt") %}
+    - name: python3 /opt/seagate/cortx/provisioner/cli/pillar_encrypt       # Prod env
+    {% else %}
+    - name: python3 /opt/seagate/cortx/provisioner/cli/src/pillar_encrypt   # Dev env
+    {% endif %}
 
 Refresh pillar data:
   module.run:


### PR DESCRIPTION
@83bhp, @SomwanshiAnjali ,
This change allows for command salt-call pillar.get openldap:iam_admin:secret --output=newline_values_only | xargs salt-call lyveutil.decrypt openldap to work.
This might need to go into Wiki.

PS: The following command works without this change:
salt-call pillar.get openldap:iam_admin:secret --output=newline_values_only | xargs -I {} salt-call lyveutil.decrypt {} openldap