### PR TITLE
EOS-13351, EOS-13355: M5 fixes uncovered during testing

### DIFF
--- a/cli/src/deploy-replacement
+++ b/cli/src/deploy-replacement
@@ -139,6 +139,10 @@ replacenode_states=(
     "ha.cortx-ha.replace_node.add_node"
 )
 
+post_replacement_states=(
+    "sspl.health_view"
+)
+
 # ToDo: Remove & Add node script here
 
 function usage {
@@ -224,7 +228,7 @@ function run_states {
                 || $state == "ha.cortx-ha.replace_node.refresh_config"
                 || $state == "ha.cortx-ha.replace_node.add_node"
                 || $state == "csm.refresh_config"
-                || $state == "ha.iostack-ha.refresh_config"
+                # || $state == "ha.iostack-ha.refresh_config"
             ]]; then
 
                 local local_node=$($cmd salt-call grains.get id --output=newline_values_only)

--- a/srv/components/sspl/health_view/config/generate.sls
+++ b/srv/components/sspl/health_view/config/generate.sls
@@ -16,7 +16,6 @@
 #
 
 include:
-  - components.sspl.install
   - components.sspl.config.commons
 
 {% set enclosure = '' %}


### PR DESCRIPTION
- Add logic to enable LVM SWAP before starting node-replacement.
- M5: Add SSPL post_install, config and healthview calls from provisioner side

Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>