### PR TITLE
EOS-13323: Fix FW update failure - exit from trap handler with correct return code.

### DIFF
--- a/srv/components/controller/files/scripts/controller-cli.sh
+++ b/srv/components/controller/files/scripts/controller-cli.sh
@@ -29,17 +29,20 @@ export tmpdir="$logdir/_ctrl_cli_tmp"
 export logfile=$logdir/controller-cli.log
 
 function trap_handler {
-    echo "***** FAILED!! *****"
-    echo "For more details see $logfile"
+    echo "***** FAILED!! *****" | tee -a $logfile
+    echo "For more details see $logfile" | tee -a $logfile
+    echo "Exiting from trap_handler" >> $logfile
     exit 2
 }
 
 function trap_handler_exit {
-    if [[ $? -eq 1 ]]; then
-        echo "***** FAILED!! *****"
-        echo "For more details see $logfile"
+    ret=$?
+    if [[ $ret -ne 0 ]]; then
+        echo "***** FAILED!! *****" | tee -a $logfile
+        echo "For more details see $logfile" | tee -a $logfile
     else
-        exit $?
+        echo "Exiting with ret code: $ret" >> $logfile
+        exit $ret
     fi
 }
 


### PR DESCRIPTION
Controller-cli script always exit with return code 1, the issue was
in the trap handler, it was exiting with the exit code 1 regardles of
the actual exit code.