### PR TITLE
EOS-13360: M5: Replace node gives CalledProcessError

### DIFF
--- a/api/python/provisioner/commands/replace_node.py
+++ b/api/python/provisioner/commands/replace_node.py
@@ -100,9 +100,20 @@ class ReplaceNode(SetupProvisioner):
         logger.info("Preparing user profile")
         run_subprocess_cmd(['rm', '-rf',  str(run_args.profile)])
         run_args.profile.parent.mkdir(parents=True, exist_ok=True)
+
+        # On some systems 'cp -i' alias, breaks the next step.
+        # This fix addresses it
         run_subprocess_cmd(
             [
-                'cp', '-r',
+                'alias',
+                '|', 'grep', '\"cp -i\"',
+                '&&', 'unalias', 'cp'
+            ]
+        )
+
+        run_subprocess_cmd(
+            [
+                'cp', '-fr',
                 str(config.PRVSNR_FACTORY_PROFILE_DIR),
                 str(run_args.profile)
             ]


### PR DESCRIPTION
Fixes:
```
2020-09-17 04:14:59,934 - ERROR - Failed to run cmd '['cp', '-r', '/var/lib/seagate/cortx/provisioner/shared/factory_profile', '/root/.provisioner/factory_profile']'
CalledProcessError(1, ['cp', '-r', '/var/lib/seagate/cortx/provisioner/shared/factory_profile', '/root/.provisioner/factory_profile'])
2020-09-17 04:14:59,954 - ERROR - provisioner failed
"CalledProcessError(1, ['cp', '-r', '/var/lib/seagate/cortx/provisioner/shared/factory_profile', '/root/.provisioner/factory_profile'])"
```

Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>