### PR TITLE
Added consul install in deploy script and set roaming ip to 127.0.0.1 in VMs

### DIFF
--- a/cli/src/auto-deploy-vm
+++ b/cli/src/auto-deploy-vm
@@ -291,7 +291,7 @@ update_pillar()
     # Update cluster.sls
     echo -e "\n\t***** INFO: Updating cluster.sls *****" 2>&1 | tee -a $LOG_FILE
     provisioner pillar_set cluster/srvnode-1/hostname \"`hostname -f`\"
-    provisioner pillar_set cluster/srvnode-1/network/data_nw/roaming_ip \"\"
+    provisioner pillar_set cluster/srvnode-1/network/data_nw/roaming_ip \"127.0.0.1\"
 
     if [[ "$mgmt_din_opt" == true ]]; then
         provisioner pillar_set cluster/srvnode-1/network/mgmt_nw/iface \"$mgmt_din\"
@@ -319,7 +319,7 @@ update_pillar()
 
     if [[ "$singlenode" == false ]]; then
         provisioner pillar_set cluster/srvnode-2/hostname \"$srvnode_2_host\"
-        provisioner pillar_set cluster/srvnode-2/network/data_nw/roaming_ip \"\"
+        provisioner pillar_set cluster/srvnode-2/network/data_nw/roaming_ip \"127.0.0.1\"
         
         if [[ "$mgmt_din_opt" == true ]]; then
             provisioner pillar_set cluster/srvnode-2/network/mgmt_nw/iface \"$mgmt_din\"

--- a/cli/src/deploy
+++ b/cli/src/deploy
@@ -69,6 +69,7 @@ prereq_states=(
     "misc_pkgs.elasticsearch"
     "misc_pkgs.kibana"
     "misc_pkgs.statsd"
+    "misc_pkgs.consul.install"
 )
 
 # states to be applied in desired sequence

--- a/cli/src/deploy-vm
+++ b/cli/src/deploy-vm
@@ -64,6 +64,7 @@ prereq_states=(
         "misc_pkgs.kibana"
         "misc_pkgs.statsd"
         "misc_pkgs.lustre"
+        "misc_pkgs.consul.install"
     )
 
 iopath_states=(


### PR DESCRIPTION
1. Added consul install in deploy script
2. Set roaming ip for vm as 127.0.0.1 as it is required by sspl for healthmap generation incase of VM environment since no HA

Signed-off-by: sradhanand.pati <sradhanand.pati@seagate.com>