### PR TITLE
[EOS-13675]: Rethink storage_type value detection method

### DIFF
--- a/Cortx-ProvisionerQuickstartGuide.md
+++ b/Cortx-ProvisionerQuickstartGuide.md
@@ -656,8 +656,6 @@ In such scenarios the destroy may get stuck somewhere due to some unknown reason
           		storage_enclosure:
             		id: storage_node_1            # equivalent to fqdn for server node
             		type: RBOD                    # Type of enclosure. E.g. RBOD
-            		controller:
-              		type: gallium               # Type of controller on storage node. E.g. gallium/indium/sati
               		primary_mc:
                 		ip: 127.0.0.1
                 		port: 80

--- a/api/python/provisioner/commands/configure_setup.py
+++ b/api/python/provisioner/commands/configure_setup.py
@@ -133,6 +133,7 @@ class StorageEnclosureParamsValidation:
     secondary_mc_ip: str = StorageEnclosureParams.secondary_mc_ip
     controller_user: str = StorageEnclosureParams.controller_user
     controller_secret: str = StorageEnclosureParams.controller_secret
+    controller_type: str = StorageEnclosureParams.controller_type
     _optional_param = []
 
     def __attrs_post_init__(self):
@@ -200,9 +201,9 @@ class ConfigureSetup(CommandParserFillerMixin):
         params = {}
         for key in input:
             val = key.split(".")
-            if val[-1] in [
+            if len(val) > 1 and val[-1] in [
                 'ip', 'user', 'secret', 'ipaddr', 'iface', 'gateway',
-                'netmask', 'public_ip_addr'
+                'netmask', 'public_ip_addr', 'type'
             ]:
                 params[f'{val[-2]}_{val[-1]}'] = input[key]
             else:

--- a/api/python/provisioner/commands/get_setup_info.py
+++ b/api/python/provisioner/commands/get_setup_info.py
@@ -213,7 +213,8 @@ class GetSetupInfo(CommandParserFillerMixin):
 
         return res
 
-    def _detect_storage_type(self):
+    @staticmethod
+    def _detect_storage_type():
         """
         Private method to determine storage type based on system configuration
 

--- a/api/python/provisioner/commands/get_setup_info.py
+++ b/api/python/provisioner/commands/get_setup_info.py
@@ -16,7 +16,6 @@
 #
 
 import logging
-from collections import defaultdict
 from typing import Type, Union
 
 from . import CommandParserFillerMixin, RunArgsEmpty

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -302,9 +302,11 @@ class StorageType(Enum):
     VIRTUAL = "virtual"
     JBOD = "JBOD"
     # standard enclosure with 5 units with 84 disks
-    ENCLOSURE = "RBOD"
+    ENCLOSURE = "5u84"
+    PODS = "PODS"
     RBOD = "RBOD"
     EBOD = "EBOD"
+    OTHER = "Other"
 
 
 class ServerType(Enum):

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -295,18 +295,7 @@ class DistrType(Enum):
 # API for remote execution
 SUPPORTED_REMOTE_COMMANDS = frozenset({'cortxcli'})
 
-
-class StorageType(Enum):
-    """Class-enumeration for supported and existing storage types"""
-
-    VIRTUAL = "virtual"
-    JBOD = "JBOD"
-    # standard enclosure with 5 units with 84 disks
-    ENCLOSURE = "5u84"
-    PODS = "PODS"
-    RBOD = "RBOD"
-    EBOD = "EBOD"
-    OTHER = "Other"
+OTHER_STORAGE_TYPE = "Other"
 
 
 class ServerType(Enum):
@@ -314,13 +303,6 @@ class ServerType(Enum):
 
     VIRTUAL = "virtual"
     PHYSICAL = "physical"
-
-
-class ControllerTypes(Enum):
-    """Class-enumeration for controller type's values"""
-    GALLIUM = "gallium"
-    INDIUM = "indium"
-    SATI = "sati"
 
 
 # Constant block for setup info fields

--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -469,6 +469,9 @@ class StorageEnclosureParams():
     controller_secret: str = ParamGroupInputBase._attr_ib(
         _param_group, descr=" Controller password"
     )
+    controller_type: str = ParamGroupInputBase._attr_ib(
+        _param_group, descr=" Controller type"
+    )
 
 
 @attr.s(auto_attribs=True)

--- a/pillar/components/samples/generic_config.ini
+++ b/pillar/components/samples/generic_config.ini
@@ -8,6 +8,7 @@ controller.primary_mc.ip=10.0.0.1
 controller.secondary_mc.ip=10.0.0.2
 controller.user=manage
 controller.secret='!manage'
+controller.type=
 
 [srvnode-1]
 hostname=srvnodes-1.localhost

--- a/pillar/components/samples/template.yml
+++ b/pillar/components/samples/template.yml
@@ -83,7 +83,6 @@ cluster:
 storage_enclosure:
   id: storage_node_1                  # equivalent to fqdn for server node
   controller:
-    type: gallium                     # Type of controller on storage node. E.g. gallium/indium/sati
     primary_mc:
       ip: 10.0.0.2
       port: 80

--- a/pillar/components/storage_enclosure.sls
+++ b/pillar/components/storage_enclosure.sls
@@ -17,9 +17,9 @@
 
 storage_enclosure:
     id: storage_node_1            # equivalent to fqdn for server node
-    type: RBOD                    # RBOD/Other
+    type: RBOD                    # RBOD/JBOD/Virtual/Other
     controller:
-      type: gallium               # Type of controller on storage node. E.g. gallium/indium/sati
+      type: null
       primary_mc:
         ip: 10.0.0.2
         port: 80


### PR DESCRIPTION
Change logic for storage_type detection. Use pillar based approach the first(values fills from user's **config.ini**). If it fails, use smart detection approach for that. Update **storage_enclosure/type** pillar value if it was missed originally.