### PR TITLE
EOS-13717: Round maxconn up instead of down in haproxy.cfg

### DIFF
--- a/srv/components/ha/haproxy/files/haproxy.cfg
+++ b/srv/components/ha/haproxy/files/haproxy.cfg
@@ -8,7 +8,7 @@ global
 
     chroot      /var/lib/haproxy
     pidfile     /var/run/haproxy.pid
-    maxconn     {{ 150 // salt['pillar.get']('haproxy:nbproc', 2) }}
+    maxconn     {{ (150 / salt['pillar.get']('haproxy:nbproc', 2)) | round(0, 'ceil') | int }}
     user        haproxy             #Haproxy running under user and group "haproxy"
     group       haproxy
 {% if "physical" in grains['virtual'] %}


### PR DESCRIPTION
Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>

This addresses EOS-13717.  Issue there is: current implementation before the fix will do "floor division", and so maxconn calculated will be smaller than needed.  We have to have total at least 150 connections per node, and with floor division we're getting less than that (nmbproc=12, 150 // 12 = 12, so total = nbproc * maxconn = 12*12 = 144, less than 150).

So I'm changing this to do round-up division, which will give expected results.