### PR TITLE
[LDR-R1]  EOS-13836 ldap backend db mdb max size to be reduced to 10GB

### DIFF
--- a/srv/components/misc_pkgs/openldap/files/cfg_ldap.ldif
+++ b/srv/components/misc_pkgs/openldap/files/cfg_ldap.ldif
@@ -30,7 +30,7 @@ olcRootDN: cn=admin,dc=seagate,dc=com
 dn: olcDatabase={2}{{db}},cn=config
 changetype: modify
 add: olcDbMaxSize
-olcDbMaxSize: 32212254720
+olcDbMaxSize: 10737418240
 
 dn: olcDatabase={2}{{db}},cn=config
 changetype: modify


### PR DESCRIPTION
EOS-13836 ldap backend db mdb max size to be reduced to 10GB
Changes made in s3 and simillar changes needs to be done in provisioner cortx-1.0 
s3 PR : https://github.com/Seagate/cortx-s3server/pull/272/files
