### PR TITLE
EOS-13072: Disable firewalld during bootstrap

### DIFF
--- a/api/python/provisioner/srv/salt/firewall/init.sls
+++ b/api/python/provisioner/srv/salt/firewall/init.sls
@@ -17,6 +17,7 @@
 
 include:
   - .prepare
-  - .install
-  - .config
-  - .start
+#   - .install
+#   - .config
+#   - .start
+  - .stop


### PR DESCRIPTION
---------------------------------------------------------------
salt-ssh being used during bootstrap fails when network restarts
as a follow-up action for firewall config.

Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>