### PR TITLE
EOS-13902: Add missing SSL CRT definition to bind :443

### DIFF
--- a/srv/components/ha/haproxy/files/haproxy.cfg
+++ b/srv/components/ha/haproxy/files/haproxy.cfg
@@ -105,7 +105,7 @@ frontend main
     bind {{ pvt_ip }}:80
     bind {{ pvt_ip }}:443 ssl crt /etc/ssl/stx/stx.pem
     bind {{ pub_data_ip }}:80
-    bind {{ pub_data_ip }}:443
+    bind {{ pub_data_ip }}:443 ssl crt /etc/ssl/stx/stx.pem
 
     option forwardfor
     default_backend app-main


### PR DESCRIPTION
Signed-off-by: Ivan Tishchenko <ivan.tishchenko@seagate.com>