### PR TITLE
EOS-13330: lower stop-timeout for STONITH is too dangerous

### DIFF
--- a/srv/components/ha/corosync-pacemaker/config/stonith.sls
+++ b/srv/components/ha/corosync-pacemaker/config/stonith.sls
@@ -33,12 +33,12 @@ Remove stonith id stonith-c2 if already present:
 # Ref: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters
 Prepare for stonith on node-1:
   cmd.run:
-    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-1']['bmc']['secret']) }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s op stop timeout=10
+    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-1']['bmc']['secret']) }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s 
     - unless: pcs stonith show stonith-c1
 
 Prepare for stonith on node-2:
   cmd.run:
-    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-2']['bmc']['secret']) }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s op stop timeout=10
+    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-2']['bmc']['secret']) }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s
     - unless: pcs stonith show stonith-c2
 
 Apply stonith for node-1:


### PR DESCRIPTION
JIRA: https://jts.seagate.com/browse/EOS-13330

Setting smaller timeout for STONITH resources was not quite justified.
If (by any reason) STONITH resource can't be stopped within the given
timeout, Pacemaker will fence the node. This will definitely not make
failover/failback to happen faster.

Solution: revert #595
