### PR TITLE
Install ftp and sshpass

### DIFF
--- a/srv/components/system/install.sls
+++ b/srv/components/system/install.sls
@@ -23,6 +23,8 @@ Install_base_packages:
       - bind-utils
       - python3
       - rsync
+      - ftp
+      - sshpass
     - reload_modules: True
 
 Install policy packages for SELinux:


### PR DESCRIPTION
Install ftp and sshpass packages as part of deployment, these packages are required for firmware update and support bundle feature.

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>