### PR TITLE
Beta: Install ftp and sshpass packages as part of deployment

### DIFF
--- a/srv/components/system/install.sls
+++ b/srv/components/system/install.sls
@@ -4,6 +4,8 @@ Install_base_packages:
       - sudo
       - ipmitool
       - python3
+      - ftp
+      - sshpass
     - reload_modules: True
 
 Install policy packages for SELinux:


### PR DESCRIPTION
These packages are required for firmware update and support bundle feature.

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>