### PR TITLE
[EOS-14063]: Delete nic parameter for ClusterIP resource creation

### DIFF
--- a/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
+++ b/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
@@ -15,7 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-{% if "primary" in grains['roles'] 
+{% if "primary" in grains['roles']
   and pillar['cluster']['cluster_ip']
   and "physical" in grains['virtual']
 %}
@@ -38,7 +38,7 @@ Update ClusterIP:
 
 Setup ClusterIP resouce:
   cmd.run:
-    - name: pcs resource create ClusterIP ocf:heartbeat:IPaddr2 ip={{ pillar['cluster']['cluster_ip'] }} mac=$(echo "01:00:5e:`echo {{ grains['hwaddr_interfaces'][data_if] }} | cut -d ":" -f 1-3`") nic={{ data_if }} op monitor interval=30s
+    - name: pcs resource create ClusterIP ocf:heartbeat:IPaddr2 ip={{ pillar['cluster']['cluster_ip'] }} mac=$(echo "01:00:5e:`echo {{ grains['hwaddr_interfaces'][data_if] }} | cut -d ":" -f 1-3`") op monitor interval=30s
 
 Add stickiness metadata to ClusterIP resource:
   cmd.run:


### PR DESCRIPTION
Based on parameters description for IPaddr2 resource agent in source code:
  
> https://github.com/ClusterLabs/resource-agents/blob/e3c89b03fc8c696498b62b2c2ba807f78842a941/heartbeat/IPaddr2#L172-L181

and this answer in the official GitHub Issues page of the `pcs` tool:
 > https://github.com/ClusterLabs/pcs/issues/144

I decided to delete the `nic` parameter for the `pcs resource create ClusterIP` command in cluster_ip.sls

if omit `nic` parameter, it trigger the IPaddr2 resource agent itself to figure out what interface should be used based on the node routing table. To determine network interfaces the IPaddr2 uses script `/usr/lib/ocf/lib/heartbeat/findif.sh` and following logic of IPaddr2 script:
>  https://github.com/ClusterLabs/resource-agents/blob/e3c89b03fc8c696498b62b2c2ba807f78842a941/heartbeat/IPaddr2#L532-L554