### PR TITLE
EOS-14184: By-pass config.ini validation

### DIFF
--- a/api/python/provisioner/commands/setup_provisioner.py
+++ b/api/python/provisioner/commands/setup_provisioner.py
@@ -1008,7 +1008,14 @@ class SetupProvisioner(SetupCmdBase, CommandParserFillerMixin):
         salt_logger.setLevel(logging.WARNING)
 
         # Config file validation against CLI args (Fail-Fast)
-        node_hostname_validator(run_args.nodes, run_args.config_path)
+        if run_args.config_path:
+            node_hostname_validator(run_args.nodes, run_args.config_path)
+        else:
+            # config.ini was not provided, possible replace_node call
+            logger.warning(
+                "config.ini was not provided, possible replace_node call."
+                "Skipping validation."
+            )
 
         # generate setup name
         setup_location = self.setup_location(run_args)

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -230,14 +230,6 @@ def node_hostname_validator(
     nodes,
     config_path
 ):
-    # config.ini was not provided, possible replace_node call
-    if not config_path:
-        logger.warning(
-            "config.ini was not provided, possible replace_node call."
-            "Skipping validation."
-        )
-        return
-
     node_dict = {}
     for node in nodes:
         node_dict[node.minion_id] = node.host

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -230,6 +230,14 @@ def node_hostname_validator(
     nodes,
     config_path
 ):
+    # config.ini was not provided, possible replace_node call
+    if not config_path:
+        logger.warning(
+            "config.ini was not provided, possible replace_node call."
+            "Skipping validation."
+        )
+        return
+
     node_dict = {}
     for node in nodes:
         node_dict[node.minion_id] = node.host


### PR DESCRIPTION
--------------------------------------------------------
EOS-14184: By-pass config.ini validation for replace_node

Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>