### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/1919635cce7e4677b74976a81fdffe75)](https://www.codacy.com/gh/Seagate/cortx-prvsnr/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Seagate/cortx-prvsnr&amp;utm_campaign=Badge_Grade) [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://github.com/pujamudaliar/cortx-prvsnr/blob/add-license-slack-badge/LICENSE)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/1919635cce7e4677b74976a81fdffe75)](https://www.codacy.com/gh/Seagate/cortx-prvsnr/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Seagate/cortx-prvsnr&amp;utm_campaign=Badge_Grade) [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://github.com/Seagate/cortx-prvsnr/blob/main/LICENSE)
 
 # CORTX-Provisioner
 


### PR DESCRIPTION
Problem Statement: License link does not point to main repository License file.
Solution: In the License Badge, link changed to https://github.com/Seagate/cortx-prvsnr/blob/main/LICENSE
JIRA : https://jts.seagate.com/browse/EOS-13720

Signed-off-by:  Puja Mudaliar <puja.mudaliar@seagate.com>