### PR TITLE
Fixes in Boxing and Unboxing

### DIFF
--- a/cli/src/factory_ops/boxing/init
+++ b/cli/src/factory_ops/boxing/init
@@ -57,7 +57,7 @@ else
 fi
 
 # Set remote root login only through private ips
-update_ssh_settings
+#update_ssh_settings
 
 # Provisioner tasks
 #stop_rabbitmq_cluster #This is taken care for now by having internalhostnames

--- a/cli/src/factory_ops/unboxing/init
+++ b/cli/src/factory_ops/unboxing/init
@@ -205,11 +205,26 @@ check_salt_services
 update_salt_minion
 update_cluster_sls "${management_vip}" "${cluster_vip}" "${static_data_ip_a}" "${static_data_ip_b}"
 
+echo -n "Clean the Salt cache........................................................" | tee -a ${LOG_FILE}
 salt '*' saltutil.clear_cache ${salt_opts}
+echo "Ok." | tee -a ${LOG_FILE}
+sleep 2
+echo -n "Refreshing the Salt modules................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.refresh_modules ${salt_opts}
+echo "Ok." | tee -a ${LOG_FILE}
+sleep 2
+echo -n "Syncing all states for Salt................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.sync_all ${salt_opts}
+echo "Ok." | tee -a ${LOG_FILE}
+sleep 2
+echo -n "Refreshing the Salt pillar.................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.refresh_pillar ${salt_opts}
+echo "Ok." | tee -a ${LOG_FILE}
+sleep 2
+echo -n "Refreshing the grains......................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.refresh_grains ${salt_opts}
+echo "Ok." | tee -a ${LOG_FILE}
+sleep 2
 
 # After unboxing, the IP addresses in haproxy need to be updated
 echo -n "Updating new VIPs in haproxy configuration.................................." | tee -a ${LOG_FILE}

--- a/cli/src/factory_ops/unboxing/pre_unbox
+++ b/cli/src/factory_ops/unboxing/pre_unbox
@@ -1173,7 +1173,7 @@ pre_unbox()
 
     #3. Get the controller IPs from user as an input
     #TODO: Remove this when enclosure communication is switched to in-band.
-    ctrl_ip_addr_get_set
+    #ctrl_ip_addr_get_set
 
     echo "Checking the servers connectivity" | tee -a ${LOG_FILE}
     hosts_resolution_check

--- a/srv/components/system/config/sshd_boxing.sls
+++ b/srv/components/system/config/sshd_boxing.sls
@@ -15,4 +15,4 @@ Set private ips root login:
     - name: /etc/ssh/sshd_config
     - text:
       -  Match Address {{ private_ip_list|join(',') }}
-      -  "      PermitRootLogin yes"
+      -  "    PermitRootLogin yes"

--- a/srv/components/system/config/sshd_boxing.sls
+++ b/srv/components/system/config/sshd_boxing.sls
@@ -1,22 +1,16 @@
 {%- set private_ip_list = [] -%}
-{%- for node in (pillar['cluster']['node_list']) -%}
-{%- for srvnode, ip_data in salt['mine.get'](node, 'node_ip_addrs') | dictsort() %}
-{%- do private_ip_list.append(ip_data[pillar['cluster'][srvnode]['network']['data_nw']['iface'][1]][0]) %}
+{%- for node in pillar['cluster']['node_list'] -%}
+{%- do private_ip_list.append(pillar['cluster'][node]['network']['data_nw']['pvt_ip_addr']) %}
 {%- endfor %}
-{%- endfor %}
-
 Set PermitRootLogin:
   file.replace:
     - name: /etc/ssh/sshd_config
     - pattern: ^PermitRootLogin .*
     - repl: PermitRootLogin no
     - append_if_not_found: True
-
-
 Set private ips root login:
   file.append:
     - name: /etc/ssh/sshd_config
     - text:
       -  Match Address {{ private_ip_list|join(',') }}
-      -  "	PermitRootLogin yes"
-
+      -  "      PermitRootLogin yes"

--- a/srv/components/system/config/sshd_boxing.sls
+++ b/srv/components/system/config/sshd_boxing.sls
@@ -2,12 +2,14 @@
 {%- for node in pillar['cluster']['node_list'] -%}
 {%- do private_ip_list.append(pillar['cluster'][node]['network']['data_nw']['pvt_ip_addr']) %}
 {%- endfor %}
+
 Set PermitRootLogin:
   file.replace:
     - name: /etc/ssh/sshd_config
     - pattern: ^PermitRootLogin .*
     - repl: PermitRootLogin no
     - append_if_not_found: True
+
 Set private ips root login:
   file.append:
     - name: /etc/ssh/sshd_config


### PR DESCRIPTION
Added following fixes:
1. Add sleeps in between salt commands
2. Don't call function to prompt for controller IPs.
3. Don't disable root user.
    This fix is because somehow minion wasn't able to get/lost the private ipaddrs in its grain data.
    As discussed with @83bhp our private ip addr will be in static ip so we modified to fetch ipaddrs from cluster file.
    The patch to fix the root user disablement is now fixed but it needs additional fixes, so disabling it until the fixes from Beta branch are ported.