### PR TITLE
EOS-14050: Unboxing misc fixes

### DIFF
--- a/cli/src/factory_ops/unboxing/init
+++ b/cli/src/factory_ops/unboxing/init
@@ -226,10 +226,9 @@ echo -n "Updating new VIPs in haproxy configuration.............................
 salt "*" state.apply components.ha.haproxy.config ${salt_opts}
 echo "Done." | tee -a ${LOG_FILE}
 
-# TODO: Updating VIP in CSM HA needs mechanism to avoid repo creation in csm.prepare
-#echo -n "Updating Management VIP in CSM HA configuration file........................" | tee -a ${LOG_FILE}
-#salt "*" state.apply components.csm.ha.config ${salt_opts}
-#echo "Done." | tee -a ${LOG_FILE}
+echo -n "Updating Management VIP in CSM HA configuration file........................" | tee -a ${LOG_FILE}
+salt "*" state.apply components.csm.render_ha_template ${salt_opts}
+echo "Done." | tee -a ${LOG_FILE}
 
 if command -v pcs ; then
     echo "Starting Cortx cluster" 2>&1 | tee -a ${LOG_FILE}
@@ -283,6 +282,10 @@ echo "Ok." | tee -a ${LOG_FILE}
 echo -n "Configuring Cortx RAS services on server B.................................." | tee -a ${LOG_FILE}
 salt "srvnode-1" state.apply components.sspl.config.commons ${salt_opts}; sleep 5
 echo "Ok." | tee -a ${LOG_FILE}
+
+echo -n "Configuring the CSM........................................................." | tee -a ${LOG_FILE}
+salt "*" state.apply components.csm.unboxing ${salt_opts}
+echo "Done." | tee -a ${LOG_FILE}
 
 echo "Restarting the cluster resources.........." | tee -a ${LOG_FILE}
 echo -n "ClusterIP.............................." | tee -a ${LOG_FILE}

--- a/cli/src/factory_ops/unboxing/init
+++ b/cli/src/factory_ops/unboxing/init
@@ -205,11 +205,21 @@ check_salt_services
 update_salt_minion
 update_cluster_sls "${management_vip}" "${cluster_vip}" "${static_data_ip_a}" "${static_data_ip_b}"
 
+echo -n "Clean the Salt cache........................................................" | tee -a ${LOG_FILE}
 salt '*' saltutil.clear_cache ${salt_opts}
+sleep 2
+echo -n "Refreshing the Salt modules................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.refresh_modules ${salt_opts}
+sleep 2
+echo -n "Syncing all states for Salt................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.sync_all ${salt_opts}
+sleep 2
+echo -n "Refreshing the Salt pillar.................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.refresh_pillar ${salt_opts}
+sleep 2
+echo -n "Refreshing the grains......................................................." | tee -a ${LOG_FILE}
 salt '*' saltutil.refresh_grains ${salt_opts}
+sleep 2
 
 # After unboxing, the IP addresses in haproxy need to be updated
 echo -n "Updating new VIPs in haproxy configuration.................................." | tee -a ${LOG_FILE}

--- a/cli/src/factory_ops/unboxing/pre_unbox
+++ b/cli/src/factory_ops/unboxing/pre_unbox
@@ -1173,7 +1173,7 @@ pre_unbox()
 
     #3. Get the controller IPs from user as an input
     #TODO: Remove this when enclosure communication is switched to in-band.
-    ctrl_ip_addr_get_set
+    #ctrl_ip_addr_get_set
 
     echo "Checking the servers connectivity" | tee -a ${LOG_FILE}
     hosts_resolution_check

--- a/srv/components/csm/render_ha_template.sls
+++ b/srv/components/csm/render_ha_template.sls
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+{% if 'single' not in pillar['cluster']['type'] %}
+Render CSM ha input params template:
+  file.managed:
+    - name: /opt/seagate/cortx/ha/conf/build-ees-ha-csm-args.yaml
+    - source: salt://components/csm/files/ha-params.tmpl
+    - template: jinja
+    - mode: 444
+    - makedirs: True
+{% endif %}

--- a/srv/components/csm/unboxing.sls
+++ b/srv/components/csm/unboxing.sls
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+#CSM Configuration and Initialization
+Stage - Post Install CSM:
+  cmd.run:
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/csm/conf/setup.yaml', 'csm:post_install')
+
+Stage - Config CSM:
+  cmd.run:
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/csm/conf/setup.yaml', 'csm:config')
+    - require:
+      - Stage - Post Install CSM
+
+Stage - Init CSM:
+  cmd.run:
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/csm/conf/setup.yaml', 'csm:init')
+    - require:
+      - Add csm user to certs group


### PR DESCRIPTION
Following fixes added in this patch:
1. Don't prompt for controller IPs as they are configured in-band now.
2. Add sleep between consecutive Salt commands
3. Run CSM post install, config and init scripts during unboxing.