### PR TITLE
[EOS-14258] default username is user for kibana 

### DIFF
--- a/srv/components/misc_pkgs/kibana/files/kibana.yml.j2
+++ b/srv/components/misc_pkgs/kibana/files/kibana.yml.j2
@@ -43,7 +43,7 @@
 # the username and password that the Kibana server uses to perform maintenance on the Kibana
 # index at startup. Your Kibana users still need to authenticate with Elasticsearch, which
 # is proxied through the Kibana server.
-#elasticsearch.username: "kibana"
+#elasticsearch.username: "user"
 #elasticsearch.password: "pass"
 
 # Enables SSL and paths to the PEM-format SSL certificate and SSL key files, respectively.


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

Kept default user and pass same as kibana.yml so that in diff it will not show password.