### PR TITLE
[EOS-6078] adds base logic for sw update repo dynamic validation

### DIFF
--- a/api/python/provisioner/commands/__init__.py
+++ b/api/python/provisioner/commands/__init__.py
@@ -474,8 +474,9 @@ class SetSWUpdateRepo(Set):
     # TODO at least either pre or post should be defined
     input_type: Type[inputs.SWUpdateRepo] = inputs.SWUpdateRepo
 
+    @staticmethod
     def _prepare_repo_for_apply(
-        self, repo: inputs.SWUpdateRepo, enabled: bool = True
+        repo: inputs.SWUpdateRepo, enabled: bool = True
     ):
         # if local - copy the repo to salt user file root
         # TODO consider to use symlink instead
@@ -491,8 +492,9 @@ class SetSWUpdateRepo(Set):
             if not enabled:
                 repo.repo_params = dict(enabled=False)
 
-    def dynamic_validation(self, repo: inputs.SWUpdateRepo, targets: str):
+    def dynamic_validation(self, params: inputs.SWUpdateRepo, targets: str):
         metadata = {}
+        repo = params
 
         if repo.is_special():
             logger.info(
@@ -520,7 +522,7 @@ class SetSWUpdateRepo(Set):
         #     minions
         try:
             logger.debug(
-                f"Configuring update candidate repo for validation"
+                "Configuring update candidate repo for validation"
             )
             self._prepare_repo_for_apply(candidate_repo, enabled=False)
 
@@ -550,7 +552,9 @@ class SetSWUpdateRepo(Set):
         return repo.metadata
 
     # TODO rollback
-    def _run(self, repo: inputs.SWUpdateRepo, targets: str):
+    def _run(self, params: inputs.SWUpdateRepo, targets: str):
+        repo = params
+
         logger.info(f"Configuring update repo: release {repo.release}")
         self._prepare_repo_for_apply(repo, enabled=True)
 

--- a/api/python/provisioner/commands/__init__.py
+++ b/api/python/provisioner/commands/__init__.py
@@ -47,7 +47,8 @@ from ..config import (
     PRVSNR_CLI_DIR,
     CONTROLLER_BOTH,
     SSL_CERTS_FILE,
-    SEAGATE_USER_HOME_DIR, SEAGATE_USER_FILEROOT_DIR_TMPL
+    SEAGATE_USER_HOME_DIR, SEAGATE_USER_FILEROOT_DIR_TMPL,
+    REPO_CANDIDATE_NAME
 )
 from ..pillar import (
     KeyPath,
@@ -414,12 +415,16 @@ class Set(CommandParserFillerMixin):
 
         pillar_updater.update(params)
         try:
+            logger.debug('Applying pre states')
             StatesApplier.apply(self.pre_states)
             try:
+                logger.debug('Applying pillar changes')
                 pillar_updater.apply()
+
+                logger.debug('Applying post states')
                 StatesApplier.apply(self.post_states)
             except Exception:
-                logger.exception('Failed to apply changes')
+                logger.warning('Failed to apply changes, starting rollback')
                 # TODO more solid rollback
                 pillar_updater.rollback()
                 pillar_updater.apply()
@@ -431,6 +436,9 @@ class Set(CommandParserFillerMixin):
             StatesApplier.apply(self.post_states)
             raise
 
+    def dynamic_validation(self, params, targets):
+        pass
+
     # TODO
     # - class for pillar file
     # - caching (load once)
@@ -441,11 +449,12 @@ class Set(CommandParserFillerMixin):
         else:
             params = self.input_type.from_args(*args, **kwargs)
 
-        # TODO dynamic validation
-        if dry_run:
-            return
+        res = self.dynamic_validation(params, targets)
 
-        self._run(params, targets)
+        if dry_run:
+            return res
+
+        return self._run(params, targets)
 
 
 # assumtions / limitations
@@ -465,20 +474,89 @@ class SetSWUpdateRepo(Set):
     # TODO at least either pre or post should be defined
     input_type: Type[inputs.SWUpdateRepo] = inputs.SWUpdateRepo
 
-    # TODO rollback
-    def _run(self, params: inputs.SWUpdateRepo, targets: str):
+    def _prepare_repo_for_apply(
+        self, repo: inputs.SWUpdateRepo, enabled: bool = True
+    ):
         # if local - copy the repo to salt user file root
         # TODO consider to use symlink instead
-        if params.is_local():
-            dest = PRVSNR_USER_FILES_SWUPDATE_REPOS_DIR / params.release
+        if repo.is_local():
+            dest = PRVSNR_USER_FILES_SWUPDATE_REPOS_DIR / repo.release
 
-            if not params.is_dir():  # iso file
+            if not repo.is_dir():  # iso file
                 dest = dest.with_name(dest.name + '.iso')
 
-            copy_to_file_roots(params.source, dest)
+            logger.debug(f"Copying {repo.source} to file roots")
+            copy_to_file_roots(repo.source, dest)
+
+            if not enabled:
+                repo.repo_params = dict(enabled=False)
+
+    def dynamic_validation(self, repo: inputs.SWUpdateRepo, targets: str):
+        metadata = {}
+
+        if repo.is_special():
+            logger.info(
+                "Skipping update repo validation for special value: "
+                f"{repo.source}"
+            )
+            return
+
+        logger.info(
+            f"Validating update repo: release {repo.release}, "
+            f"source {repo.source}"
+        )
+
+        candidate_repo = inputs.SWUpdateRepo(
+            REPO_CANDIDATE_NAME, repo.source
+        )
+
+        # TODO IMPROVE VALIDATION
+        #   - there is no other candidate that is being verified
+
+        # TODO IMPROVE
+        #   - makes sense to try that only on local minion,
+        #     currently it's not convenient since may lead to
+        #     mess in release.sls pillar between all and specific
+        #     minions
+        try:
+            logger.debug(
+                f"Configuring update candidate repo for validation"
+            )
+            self._prepare_repo_for_apply(candidate_repo, enabled=False)
+
+            super()._run(candidate_repo, targets)
+
+            # TODO IMPROVE VALIDATION
+            # - yum --disablerepo="*" --enablerepo="sw_update_{candidate_repo.release}" list available  # noqa: E501
+            # - extract metadata from release info file, validate and assign,
+            #   validation:
+            #   - metadata is full enough (at least release information)
+            #   - there is no the same release repo already active EOS-13715
+            #   - (optionally) new version is higher then currently installed
+
+            logger.debug(f"Resolved metadata {metadata}")
+            repo.metadata = metadata
+
+            # TODO IMPROVE
+            # - set 'release' to version from resolved metadata,
+            #   that would make `release` param unnecessary at all
+            #   repo.release = ...
+        finally:
+            # remove the repo
+            candidate_repo.source = values.UNDEFINED
+            logger.info("Post-validation cleanup")
+            super()._run(candidate_repo, targets)
+
+        return repo.metadata
+
+    # TODO rollback
+    def _run(self, repo: inputs.SWUpdateRepo, targets: str):
+        logger.info(f"Configuring update repo: release {repo.release}")
+        self._prepare_repo_for_apply(repo, enabled=True)
 
         # call default set logic (set pillar, call related states)
-        super()._run(params, targets)
+        super()._run(repo, targets)
+        return repo.metadata
 
 
 # TODO IMPROVE EOS-8940 move to separate module

--- a/api/python/provisioner/commands/__init__.py
+++ b/api/python/provisioner/commands/__init__.py
@@ -512,7 +512,7 @@ class SetSWUpdateRepo(Set):
             REPO_CANDIDATE_NAME, repo.source
         )
 
-        # TODO IMPROVE VALIDATION
+        # TODO IMPROVE VALIDATION EOS-14350
         #   - there is no other candidate that is being verified
 
         # TODO IMPROVE
@@ -528,7 +528,7 @@ class SetSWUpdateRepo(Set):
 
             super()._run(candidate_repo, targets)
 
-            # TODO IMPROVE VALIDATION
+            # TODO IMPROVE VALIDATION EOS-6078
             # - yum --disablerepo="*" --enablerepo="sw_update_{candidate_repo.release}" list available  # noqa: E501
             # - extract metadata from release info file, validate and assign,
             #   validation:
@@ -539,7 +539,7 @@ class SetSWUpdateRepo(Set):
             logger.debug(f"Resolved metadata {metadata}")
             repo.metadata = metadata
 
-            # TODO IMPROVE
+            # TODO IMPROVE EOS-6078
             # - set 'release' to version from resolved metadata,
             #   that would make `release` param unnecessary at all
             #   repo.release = ...

--- a/api/python/provisioner/commands/get_setup_info.py
+++ b/api/python/provisioner/commands/get_setup_info.py
@@ -225,7 +225,7 @@ class GetSetupInfo(CommandParserFillerMixin):
         storage_enclosure_type = PillarKey(storage_enclosure_path / 'type')
         pillar_updater = PillarUpdater(config.ALL_MINIONS)
         pillar_updater.update((storage_enclosure_type, storage_type))
-        pillar_updater.dump()
+        pillar_updater.apply()
 
     def _get_storage_type(self):
         """

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -62,6 +62,9 @@ PRVSNR_PILLAR_CONFIG_INI = str(
     PRVSNR_FACTORY_PROFILE_DIR / 'srv/salt/provisioner/files/minions/all/config.ini'  # noqa: E501
 )
 
+
+REPO_CANDIDATE_NAME = 'candidate'
+
 # TODO EOS-12076 EOS-12334
 
 CORTX_SINGLE_ISO_DIR = 'cortx_single_iso'

--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -19,7 +19,7 @@ import logging
 from copy import deepcopy
 import ipaddress
 import functools
-from typing import List, Union, Any, Iterable, Tuple
+from typing import List, Union, Any, Iterable, Tuple, Dict
 from pathlib import Path
 
 from .vendor import attr
@@ -754,6 +754,8 @@ class SWUpdateRepo(ParamDictItemInputBase):
             )
         )
     )
+    _repo_params: Dict = attr.ib(init=False, default=attr.Factory(dict))
+    _metadata: Dict = attr.ib(init=False, default=attr.Factory(dict))
 
     @source.validator
     def _check_source(self, attribute, value):
@@ -803,7 +805,30 @@ class SWUpdateRepo(ParamDictItemInputBase):
         if self.is_special() or self.is_remote():
             return self.source
         else:
-            return 'iso' if self.source.is_file() else 'dir'
+            source = 'iso' if self.source.is_file() else 'dir'
+            if self._repo_params:
+                return {
+                    'source': source,
+                    'params': self._repo_params
+                }
+            else:
+                return source
+
+    @property
+    def repo_params(self):
+        return self._repo_params
+
+    @repo_params.setter
+    def repo_params(self, params: Dict):
+        self._repo_params = params
+
+    @property
+    def metadata(self):
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata: Dict):
+        self._metadata = metadata
 
     def is_special(self):
         return is_special(self.source)

--- a/srv/components/misc_pkgs/swupdate/repo/init.sls
+++ b/srv/components/misc_pkgs/swupdate/repo/init.sls
@@ -27,8 +27,8 @@
     {% if source %}
 
         {% if source is mapping %}
-            {% set source = source['source'] %}
             {% set repo_params = source.get('params', {}) %}
+            {% set source = source['source'] %}
         {% endif %}
 
 

--- a/srv/components/misc_pkgs/swupdate/repo/init.sls
+++ b/srv/components/misc_pkgs/swupdate/repo/init.sls
@@ -22,8 +22,15 @@
 
     {% set repo_dir = '/'.join(
         [pillar['release']['update']['base_dir'], release]) %}
+    {% set repo_params = {} %}
 
     {% if source %}
+
+        {% if source is mapping %}
+            {% set source = source['source'] %}
+            {% set repo_params = source.get('params', {}) %}
+        {% endif %}
+
 
         {% if source.startswith(('http://', 'https://')) %}
 
@@ -42,7 +49,7 @@ unexpected_repo_source:
 
         {% endif %}
 
-{{ repo_added(release, source, source_type) }}
+{{ repo_added(release, source, source_type, repo_params) }}
 
     {% else %}
 

--- a/srv/components/misc_pkgs/swupdate/repo/install.sls
+++ b/srv/components/misc_pkgs/swupdate/repo/install.sls
@@ -15,7 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-{% macro repo_added(release, source, source_type) %}
+{% macro repo_added(release, source, source_type, repo_params={}) %}
 
     {% from './iso/mount.sls' import repo_mounted with context %}
 
@@ -58,6 +58,7 @@ sw_update_repo_added_{{ release }}:
     {% else %}
     - baseurl: file://{{ source }}
     {% endif %}
+    - enabled: {{ repo_params.get('enabled', True) }}
     - gpgcheck: 0
     {% if source_type == 'iso' %}
     - require:

--- a/srv/components/misc_pkgs/swupdate/repo/teardown.sls
+++ b/srv/components/misc_pkgs/swupdate/repo/teardown.sls
@@ -40,4 +40,6 @@ sw_update_repo_absent_{{ release }}:
   pkgrepo.absent:
     - name: sw_update_{{ release }}
 
+# TODO IMPROVE EOS-14348 remove from file root as well
+
 {% endmacro %}


### PR DESCRIPTION
- sets the framework for set commands dynamic validation
- implements logic of temporarily dynamic configuration for a new repo candidate to allow safe pre-checks before actual repo activation