### PR TITLE
Update default rabbitmq's conf file instead of creating new conf file

### DIFF
--- a/srv/components/misc_pkgs/rabbitmq/config/base.sls
+++ b/srv/components/misc_pkgs/rabbitmq/config/base.sls
@@ -64,12 +64,12 @@ Restart rabbitmq service:
 # logrotate.d config: DO NOT REMOVE
 Setup logrotate policy for rabbitmq-server:
   file.managed:
-  - name: /etc/logrotate_hourly.d/rabbitmq-server
+  - name: /etc/logrotate.d/rabbitmq-server
   - source: salt://components/misc_pkgs/rabbitmq/files/rabbitmq-server
   - keep_source: True
   - user: root
   - group: root
-  - requrie:
+  - require:
     - Install RabbitMQ
 
 Copy Erlang cookie:

--- a/srv/components/misc_pkgs/rabbitmq/files/rabbitmq-server
+++ b/srv/components/misc_pkgs/rabbitmq/files/rabbitmq-server
@@ -3,6 +3,8 @@
     rotate 7
     compress
     delaycompress
+    dateext
+    dateformat -%Y-%m-%d-%s.log
     notifempty
     sharedscripts
     size 20M

--- a/srv/components/system/logrotate/files/etc/logrotate_hw.d/provisioner
+++ b/srv/components/system/logrotate/files/etc/logrotate_hw.d/provisioner
@@ -35,7 +35,7 @@
 /var/log/seagate/provisioner/prvsnr*.log
 {
     su root prvsnrusers
-    dailyly
+    daily
     size 10M
     missingok
     rotate 15


### PR DESCRIPTION
Observed that another rabbitmq's conf file is getting created after rpm's installation at /etc/logrotate.d/ location.
So, Updating logrotate configuration in the default conf file instead of creating new conf file at /etc/logrotate_hourly.d/ location.
Also, did another improvement changes related to log rotate.

Signed-off-by: Vijay Thakkar <vijaykumar.thakkar@seagate.com>