### PR TITLE
reverting rabbit autoheal config

### DIFF
--- a/srv/components/misc_pkgs/rabbitmq/config/base.sls
+++ b/srv/components/misc_pkgs/rabbitmq/config/base.sls
@@ -32,16 +32,6 @@ Set RabbitMQ environment:
     - watch_in:
       - Start RabbitMQ service
 
-Set RabbitMQ configuration:
-  file.replace:
-    - name: /etc/rabbitmq/rabbitmq.config
-    - pattern: '%% {cluster_partition_handling, ignore},'
-    - repl: '{cluster_partition_handling, autoheal}'
-    - require:
-      - Install RabbitMQ
-    - watch_in:
-      - Start RabbitMQ service
-
 Enable plugin rabbitmq_management:
   rabbitmq_plugin.enabled:
     - name: rabbitmq_management


### PR DESCRIPTION
causing issue with comma as below new config was added. Reverting for now.
{cluster_nodes, {['rabbit@srvnode-1', 'rabbit@srvnode-2'], disc}}