### PR TITLE
[WIP] EOS-14658: add debug-level logging for stonith resources

### DIFF
--- a/srv/components/ha/corosync-pacemaker/config/stonith.sls
+++ b/srv/components/ha/corosync-pacemaker/config/stonith.sls
@@ -33,12 +33,12 @@ Remove stonith id stonith-c2 if already present:
 # Ref: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters
 Prepare for stonith on node-1:
   cmd.run:
-    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-1']['bmc']['secret']) }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s 
+    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-1']['bmc']['secret']) }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 debug-file='/var/log/cluster/stonith-c1.log' op monitor interval=10s 
     - unless: pcs stonith show stonith-c1
 
 Prepare for stonith on node-2:
   cmd.run:
-    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-2']['bmc']['secret']) }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s
+    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-2']['bmc']['secret']) }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 debug-file='/var/log/cluster/stonith-c2.log' op monitor interval=10s
     - unless: pcs stonith show stonith-c2
 
 Apply stonith for node-1:

--- a/srv/components/system/logrotate/files/etc/logrotate.d/fence_agents
+++ b/srv/components/system/logrotate/files/etc/logrotate.d/fence_agents
@@ -1,0 +1,10 @@
+# Stonith resources represented by fence_ipmilan resource agent.
+/var/log/cluster/stonith-c*.log {
+    missingok
+    daily
+    copytruncate
+    rotate 7
+    notifempty
+    size 10M
+    compress
+}


### PR DESCRIPTION
This feature makes fence agent to log everything with debug level to
dedicated file.
Enhanced logging is required to investigate stonith-related issues when
fencing device is (suddenly) unavailable.

Signed-off-by: Andrei Zheregelia <andrei.zheregelia@seagate.com>