### PR TITLE
EOS-14658: add verbosity to stonith resources

### DIFF
--- a/srv/components/ha/corosync-pacemaker/config/stonith.sls
+++ b/srv/components/ha/corosync-pacemaker/config/stonith.sls
@@ -33,12 +33,12 @@ Remove stonith id stonith-c2 if already present:
 # Ref: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_high_availability_clusters/assembly_configuring-fencing-configuring-and-managing-high-availability-clusters
 Prepare for stonith on node-1:
   cmd.run:
-    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-1']['bmc']['secret']) }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s 
+    - name: pcs stonith create stonith-c1 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-1']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-1']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-1']['bmc']['secret']) }} delay=5 pcmk_host_list=srvnode-1 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 verbose=true op monitor interval=10s 
     - unless: pcs stonith show stonith-c1
 
 Prepare for stonith on node-2:
   cmd.run:
-    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-2']['bmc']['secret']) }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 op monitor interval=10s
+    - name: pcs stonith create stonith-c2 fence_ipmilan ipaddr={{ pillar['cluster']['srvnode-2']['bmc']['ip'] }} login={{ pillar['cluster']['srvnode-2']['bmc']['user'] }} passwd={{ salt['lyveutil.decrypt']('cluster', pillar['cluster']['srvnode-2']['bmc']['secret']) }} pcmk_host_list=srvnode-2 pcmk_host_check=static-list lanplus=true auth=PASSWORD power_timeout=40 verbose=true op monitor interval=10s
     - unless: pcs stonith show stonith-c2
 
 Apply stonith for node-1:


### PR DESCRIPTION
This makes fence_ipmilan to log messages to system log about power
status.
Note: --debug-file option represented by debug_file option is more
appropriate here, however actual tests showed that it is working only
along with verbose option and does not prevent logging to syslog.
Also debug_file option does not pass validation and requires --force to
be applied when stonith resource is created. This looks fishy, thus
unreliable.

Signed-off-by: Andrei Zheregelia <andrei.zheregelia@seagate.com>