### PR TITLE
[EOS-15007] cortxub user configuration as a service user

### DIFF
--- a/api/python/provisioner/commands/setup_provisioner.py
+++ b/api/python/provisioner/commands/setup_provisioner.py
@@ -1738,6 +1738,18 @@ class SetupProvisioner(SetupCmdBase, CommandParserFillerMixin):
                     ), targets=run_args.primary.minion_id
                 )
 
+            logger.info(f"Generating a password for the service user")
+            service_user_password = str(uuid.uuid4()).split('-')[0]
+            ssh_client.cmd_run(
+                (
+                    'provisioner pillar_set'
+                    f' system/service_user/password '
+                    f' \'"{service_user_password}"\''
+                ),
+                targets=run_args.primary.minion_id,
+                secure=True
+            )
+
         if run_args.target_build:
             # TODO IMPROVE non idempotent now
             logger.info("Get release factory version")

--- a/api/python/provisioner/commands/setup_provisioner.py
+++ b/api/python/provisioner/commands/setup_provisioner.py
@@ -1738,7 +1738,7 @@ class SetupProvisioner(SetupCmdBase, CommandParserFillerMixin):
                     ), targets=run_args.primary.minion_id
                 )
 
-            logger.info(f"Generating a password for the service user")
+            logger.info("Generating a password for the service user")
             service_user_password = str(uuid.uuid4()).split('-')[0]
             ssh_client.cmd_run(
                 (

--- a/cli/src/factory_ops/boxing/init
+++ b/cli/src/factory_ops/boxing/init
@@ -109,14 +109,14 @@ else
 fi
 
 echo "INFO: Resolving service user credentials" | tee -a ${LOG_FILE}
-# FIXME these values might be encrypted
 service_user_name=$(salt-call pillar.get system:service_user:name --output=newline_values_only)
-service_user_secret=$(salt-call pillar.get system:service_user:password --output=newline_values_only)
+service_user_secret_encrypted=$(salt-call pillar.get system:service_user:password --output=newline_values_only)
+service_user_secret=$(salt-call lyveutil.decrypt system "$service_user_secret_encrypted" --output=newline_values_only)
 
 if [[ -z "$service_user_name" || -z "$service_user_secret" ]]; then
     msg="ERROR: credentials for a service user are not found"
     echo "$msg" | tee -a ${LOG_FILE}
-    die "$msg"
+    exit 1
 fi
 
 # Shutdown HA

--- a/cli/src/factory_ops/boxing/init
+++ b/cli/src/factory_ops/boxing/init
@@ -108,6 +108,17 @@ else
     cortxcli support_bundle generate manifest -c "manifest" 2>&1 | tee -a ${LOG_FILE}
 fi
 
+echo "INFO: Resolving service user credentials" | tee -a ${LOG_FILE}
+# FIXME these values might be encrypted
+service_user_name=$(salt-call pillar.get system:service_user:name --output=newline_values_only)
+service_user_secret=$(salt-call pillar.get system:service_user:password --output=newline_values_only)
+
+if [[ -z "$service_user_name" || -z "$service_user_secret" ]]; then
+    msg="ERROR: credentials for a service user are not found"
+    echo "$msg" | tee -a ${LOG_FILE}
+    die "$msg"
+fi
+
 # Shutdown HA
 if ! command -v pcs; then
     echo "ERROR: Command 'pcs' not found"
@@ -143,7 +154,7 @@ configure_service_port
 #Remove gluster fs mounts
 remove_gfs_mounts
 # Create user for unboxing
-create_unboxing_user
+dump_unboxing_data "$service_user_name" "$service_user_secret"
 
 # Create flag file
 boxing_flag $box_flag_file

--- a/cli/src/factory_ops/boxing/prov_tasks
+++ b/cli/src/factory_ops/boxing/prov_tasks
@@ -132,20 +132,14 @@ function update_ssh_settings {
 }
 
 
-function create_unboxing_user {
+function dump_unboxing_data {
     set -euE
+    _user="$1"
+    _secret="$2"
+
     _create_date=$(date '+%Y-%m-%d')
     _output_file="/root/Lyve_rack_SystemID_${_create_date}.txt"
-    _user="cortxub"
-    _secret=$(/usr/bin/uuidgen | cut -d- -f 5)
     _lr_serial=-
-
-    id $_user > /dev/null && {
-        userdel -r -f $_user
-    }
-    echo "INFO: Creating user for first time login" | tee -a ${LOG_FILE}
-    useradd --base-dir /tmp --inactive 2 --groups wheel --shell /usr/bin/bash --password $(openssl passwd -1 ${_secret}) cortxub
-    passwd -e $_user
 
     ###### Lyve Rack Serial Number ######
     echo -n "INFO: Getting Lyve Rack serial numbers " | tee -a ${LOG_FILE}

--- a/cli/src/factory_ops/unboxing/init
+++ b/cli/src/factory_ops/unboxing/init
@@ -370,13 +370,13 @@ lock_unboxing_user
 # FIXME the value might be encrypted
 service_user=$(salt srvnode-2 pillar.get system:service_user:name --output=newline_values_only)
 if [[ -n "$service_user" ]]; then
-    echo -n "Activating service user $service_user on the secondary node................." | tee -a ${LOG_FILE}
+    echo -n "Activating service user $service_user on the Server B node................." | tee -a ${LOG_FILE}
     salt "srvnode-2" state.single user.present name="$service_user" expire=-1 ${salt_opts}
     sleep 5     # Mindfulness break
     echo "Ok." | tee -a ${LOG_FILE}
 else
     # backward compatibility
-    echo -n "WARNING: Skipping service user activation on the secondary node, the user is not set" | tee -a ${LOG_FILE}
+    echo -n "WARNING: Skipping service user activation on the Server B node, the user is not set" | tee -a ${LOG_FILE}
 fi
 
 # Unboxing SUCCESS

--- a/cli/src/factory_ops/unboxing/init
+++ b/cli/src/factory_ops/unboxing/init
@@ -367,7 +367,6 @@ echo "Ok." | tee -a ${LOG_FILE}
 # lock unboxing user
 lock_unboxing_user
 
-# FIXME the value might be encrypted
 service_user=$(salt srvnode-2 pillar.get system:service_user:name --output=newline_values_only)
 if [[ -n "$service_user" ]]; then
     echo -n "Activating service user $service_user on the Server B node................." | tee -a ${LOG_FILE}

--- a/cli/src/factory_ops/unboxing/init
+++ b/cli/src/factory_ops/unboxing/init
@@ -367,6 +367,18 @@ echo "Ok." | tee -a ${LOG_FILE}
 # lock unboxing user
 lock_unboxing_user
 
+# FIXME the value might be encrypted
+service_user=$(salt srvnode-2 pillar.get system:service_user:name --output=newline_values_only)
+if [[ -n "$service_user" ]]; then
+    echo -n "Activating service user $service_user on the secondary node................." | tee -a ${LOG_FILE}
+    salt "srvnode-2" state.single user.present name="$service_user" expire=-1 ${salt_opts}
+    sleep 5     # Mindfulness break
+    echo "Ok." | tee -a ${LOG_FILE}
+else
+    # backward compatibility
+    echo -n "WARNING: Skipping service user activation on the secondary node, the user is not set" | tee -a ${LOG_FILE}
+fi
+
 # Unboxing SUCCESS
 remove_boxing_flag
 

--- a/srv/components/system/config/init.sls
+++ b/srv/components/system/config/init.sls
@@ -20,4 +20,5 @@ include:
   - components.system.config.hosts
   - components.system.config.journald
   - components.system.config.pillar_encrypt
+  - components.system.config.service_user
   - components.system.config.sshd


### PR DESCRIPTION
The logic:

- user is created at setup provisioner stage and the generated password is put into the pillar
  - on the second node the account would be disabled (expired)
- during the deployment stage it should be encrypted
- at boxing time the credentials are dumped as before to log file so one can extract them for the docs
  - (optionally) we may remove the password from pillar here if needed (one line change but I am not sure that we need that)
- at unboxing time the acoount on the secondary node is activated (expiration is set to 'never')