### PR TITLE
EOS-14050: Run CSM config state at the end of unboxing.

### DIFF
--- a/cli/src/factory_ops/unboxing/init
+++ b/cli/src/factory_ops/unboxing/init
@@ -318,13 +318,13 @@ echo -n "Configuring Cortx RAS services on server B.............................
 salt "srvnode-1" state.apply components.sspl.config.commons ${salt_opts}; sleep 5
 echo "Ok." | tee -a ${LOG_FILE}
 
-# echo -n "Configuring CSM services on Server B........................................" | tee -a ${LOG_FILE}
-# salt "srvnode-2" state.apply components.csm.config ${salt_opts}; sleep 5
-# echo "Ok." | tee -a ${LOG_FILE}
+echo -n "Configuring CSM services on Server B........................................" | tee -a ${LOG_FILE}
+salt "srvnode-2" state.apply components.csm.config ${salt_opts}; sleep 5
+echo "Ok." | tee -a ${LOG_FILE}
 
-# echo -n "Configuring CSM services on Server A........................................" | tee -a ${LOG_FILE}
-# salt "srvnode-1" state.apply components.csm.config ${salt_opts}; sleep 5
-# echo "Ok." | tee -a ${LOG_FILE}
+echo -n "Configuring CSM services on Server A........................................" | tee -a ${LOG_FILE}
+salt "srvnode-1" state.apply components.csm.config ${salt_opts}; sleep 5
+echo "Ok." | tee -a ${LOG_FILE}
 
 echo "Removing Lustre URL (RedHat) from Salt configuration" | tee -a ${LOG_FILE}
 provisioner pillar_set commons/repo/lustre \"\" --logfile --logfile-filename ${LOG_FILE}; sleep 2


### PR DESCRIPTION
Need to run CSM config state at the end of boxing as the system maintenance page of CSM shows the old hostnames.
Signed-off-by: root <root@ssc-vm-c-1394.colo.seagate.com>

Signed-off-by: root <root@ssc-vm-c-1394.colo.seagate.com>