### PR TITLE
[EOS-14140] light pillar set/get using salt-call --local wrapper

### DIFF
--- a/api/python/provisioner/__main__.py
+++ b/api/python/provisioner/__main__.py
@@ -106,7 +106,7 @@ def _generate_logfile_filename(cmd):
     return (config.LOG_ROOT_DIR / f'{cmd}.{ts}.{pid}.{threadid}.log')
 
 
-def _set_logging(output_type, log_args=None, other_args=None):
+def _set_logging(output_type, log_args=None, other_args=None):  # noqa: C901
     if log_args is None:
         log_args = log.LogArgs()
 

--- a/api/python/provisioner/__metadata__.py
+++ b/api/python/provisioner/__metadata__.py
@@ -16,7 +16,7 @@
 #
 
 __title__ = 'cortx-prvsnr'
-__version__ = '0.40.0'
+__version__ = '0.41.0'
 __author__ = "Seagate"
 __author_email__ = 'support@seagate.com'  # TODO
 __maintainer__ = 'Seagate'

--- a/api/python/provisioner/commands/__init__.py
+++ b/api/python/provisioner/commands/__init__.py
@@ -199,13 +199,6 @@ class RunArgsConfigureCortx:
             }
         }, default=False
     )
-    local: bool = attr.ib(
-        metadata={
-            inputs.METADATA_ARGPARSER: {
-                'help': "use local salt client (salt-call --local)"
-            }
-        }, default=False
-    )
 
 
 @attr.s(auto_attribs=True)

--- a/api/python/provisioner/commands/__init__.py
+++ b/api/python/provisioner/commands/__init__.py
@@ -106,6 +106,16 @@ class RunArgsUpdate:
     dry_run: bool = RunArgs.dry_run
 
 
+@attr.s(auto_attribs=True)
+class RunArgsPillarGet(RunArgsBase):
+    local: bool = RunArgs.local
+
+
+@attr.s(auto_attribs=True)
+class RunArgsPillarSet(RunArgsUpdate):
+    local: bool = RunArgs.local
+
+
 # TODO DRY
 @attr.s(auto_attribs=True)
 class RunArgsFWUpdate:
@@ -189,6 +199,13 @@ class RunArgsConfigureCortx:
             }
         }, default=False
     )
+    local: bool = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "use local salt client (salt-call --local)"
+            }
+        }, default=False
+    )
 
 
 @attr.s(auto_attribs=True)
@@ -236,6 +253,7 @@ class RunArgsUser:
 @attr.s(auto_attribs=True)
 class PillarGet(CommandParserFillerMixin):
     input_type: Type[inputs.PillarKeysList] = inputs.PillarKeysList
+    _run_args_type = RunArgsPillarGet
 
     @classmethod
     def from_spec(
@@ -243,9 +261,12 @@ class PillarGet(CommandParserFillerMixin):
     ):
         return cls(input_type=getattr(inputs, input_type))
 
-    def run(self, *args, targets: str = ALL_MINIONS, **kwargs):
+    def run(
+        self, *args, targets: str = ALL_MINIONS, local: bool = False,
+        **kwargs
+    ):
         pi_keys = self.input_type.from_args(*args, **kwargs)
-        pillar_resolver = PillarResolver(targets=targets)
+        pillar_resolver = PillarResolver(targets=targets, local=local)
 
         if len(pi_keys):
             res_raw = pillar_resolver.get(pi_keys)
@@ -262,7 +283,7 @@ class PillarSet(CommandParserFillerMixin):
     # TODO at least either pre or post should be defined
     input_type: Type[inputs.PillarInputBase] = inputs.PillarInputBase
 
-    _run_args_type = RunArgsUpdate
+    _run_args_type = RunArgsPillarSet
 
     # TODO input class type
     @classmethod
@@ -276,7 +297,9 @@ class PillarSet(CommandParserFillerMixin):
     # TODO
     # - class for pillar file
     # - caching (load once)
-    def run(self, *args, targets=ALL_MINIONS, dry_run=False, **kwargs):
+    def run(
+        self, *args, targets=ALL_MINIONS, dry_run=False, local=False, **kwargs
+    ):
         # static validation
         if len(args) == 1 and isinstance(args[0], self.input_type):
             input_data = args[0]
@@ -291,7 +314,7 @@ class PillarSet(CommandParserFillerMixin):
         rollback_exc = None
 
         try:
-            pillar_updater = PillarUpdater(targets)
+            pillar_updater = PillarUpdater(targets, local=local)
             pillar_updater.update(input_data)
 
             try:

--- a/api/python/provisioner/commands/_basic.py
+++ b/api/python/provisioner/commands/_basic.py
@@ -35,6 +35,13 @@ class RunArgs:
             }
         }, default=False
     )
+    local: bool = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "use local salt client (salt-call --local)"
+            }
+        }, default=False
+    )
 
 
 @attr.s(auto_attribs=True)

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -48,15 +48,32 @@ PRVSNR_DATA_SHARED_DIR = Path('/var/lib/seagate/cortx/provisioner/shared')
 PRVSNR_DATA_LOCAL_DIR = Path('/var/lib/seagate/cortx/provisioner/local')
 
 PRVSNR_USER_SALT_DIR = PRVSNR_DATA_SHARED_DIR / 'srv'
-# PRVSNR_USER_LOCAL_SALT_DIR = PRVSNR_DATA_LOCAL_DIR / 'srv'
+PRVSNR_USER_LOCAL_SALT_DIR = PRVSNR_DATA_LOCAL_DIR / 'srv'
 PRVSNR_FACTORY_PROFILE_DIR = PRVSNR_DATA_SHARED_DIR / 'factory_profile'
 
 # reflects salt-master file_roots configuration
 PRVSNR_USER_FILEROOT_DIR = PRVSNR_USER_SALT_DIR / 'salt'
-# PRVSNR_USER_LOCAL_FILEROOT_DIR = PRVSNR_USER_LOCAL_SALT_DIR / 'salt'
+PRVSNR_USER_LOCAL_FILEROOT_DIR = PRVSNR_USER_LOCAL_SALT_DIR / 'salt'
 # reflects pillar/top.sls
 PRVSNR_USER_PILLAR_DIR = PRVSNR_USER_SALT_DIR / 'pillar'
-# PRVSNR_USER_LOCAL_PILLAR_DIR = PRVSNR_USER_LOCAL_SALT_DIR / 'pillar'
+PRVSNR_USER_LOCAL_PILLAR_DIR = PRVSNR_USER_LOCAL_SALT_DIR / 'pillar'
+
+# Notes:
+# 1. how salt's pillar roots organized:
+#   - salt searches for files in each root
+#   - if a file (with the same path, path is relative to pillar root)
+#     has been found in one of the previous roots - it is ignored
+#   - all found files are sorted alphabetically
+#   - then merge logic happens: later files win
+#     (e.g. file zzz.sls wins aaa.sls)
+# 2. why we nee prefixes:
+#   - we don't want the same pillar file paths in different roots
+#   - we need them to be sorted according to priorities we have in
+#     salt master/minion config files
+#     (e.g. default ones have less priority than user ones,
+#           shared user pillar has less priority than local one)
+PRVSNR_USER_PILLAR_PREFIX = 'uu_'
+PRVSNR_USER_LOCAL_PILLAR_PREFIX = 'zzz_'
 
 PRVSNR_PILLAR_CONFIG_INI = str(
     PRVSNR_FACTORY_PROFILE_DIR / 'srv/salt/provisioner/files/minions/all/config.ini'  # noqa: E501
@@ -98,24 +115,6 @@ PRVSNR_USER_FILES_SSL_CERTS_FILE = Path(
     'components/misc_pkgs/ssl_certs/files/stx.pem'
 )
 SSL_CERTS_FILE = Path('/etc/ssl/stx/stx.pem')
-
-# pillar structures
-PRVSNR_DEF_PILLAR_HOST_DIR_TMPL = str(
-    PRVSNR_PILLAR_DIR / 'minions/{minion_id}'
-)
-
-PRVSNR_USER_PILLAR_PREFIX = 'uu_'
-PRVSNR_USER_PILLAR_ALL_HOSTS_DIR = PRVSNR_USER_PILLAR_DIR / 'groups/all'
-PRVSNR_USER_PILLAR_HOST_DIR_TMPL = str(
-    PRVSNR_USER_PILLAR_DIR / 'minions/{minion_id}'
-)
-
-# PRVSNR_USER_LOCAL_PILLAR_ALL_HOSTS_DIR = (
-#    PRVSNR_USER_LOCAL_PILLAR_DIR / 'groups/all'
-# )
-# PRVSNR_USER_LOCAL_PILLAR_HOST_DIR_TMPL = str(
-#    PRVSNR_USER_LOCAL_PILLAR_DIR / 'minions/{minion_id}'
-# )
 
 GLUSTERFS_VOLUME_SALT_JOBS = Path('/srv/glusterfs/volume_salt_cache_jobs')
 GLUSTERFS_VOLUME_PRVSNR_DATA = Path('/srv/glusterfs/volume_prvsnr_data')

--- a/api/python/provisioner/paths.py
+++ b/api/python/provisioner/paths.py
@@ -33,6 +33,7 @@ class PillarPath:
     _all_hosts_dir: Path = attr.ib(init=False, default=None)
 
     def __attrs_post_init__(self):
+        """Post init logic."""
         self._host_dir_tmpl = str(self.base_dir / 'minions/{minion_id}')
         self._all_hosts_dir = self.base_dir / 'groups/all'
 

--- a/api/python/provisioner/paths.py
+++ b/api/python/provisioner/paths.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from pathlib import Path
+
+from . import config, utils
+from .vendor import attr
+
+
+@attr.s(auto_attribs=True)
+class PillarPath:
+    _base_dir: Path = attr.ib(
+        converter=utils.converter_path,
+        validator=utils.validator_path
+    )
+    _prefix: str = ''
+
+    _host_dir_tmpl: str = attr.ib(init=False, default=None)
+    _all_hosts_dir: Path = attr.ib(init=False, default=None)
+
+    def __attrs_post_init__(self):
+        self._host_dir_tmpl = str(self.base_dir / 'minions/{minion_id}')
+        self._all_hosts_dir = self.base_dir / 'groups/all'
+
+    @property
+    def base_dir(self):
+        return self._base_dir
+
+    @property
+    def prefix(self):
+        return self._prefix
+
+    @property
+    def host_dir_tmpl(self):
+        return self._host_dir_tmpl
+
+    @property
+    def all_hosts_dir(self):
+        return self._all_hosts_dir
+
+
+default_pillar = PillarPath(config.PRVSNR_PILLAR_DIR)
+
+user_shared_pillar = PillarPath(
+    config.PRVSNR_USER_PILLAR_DIR,
+    config.PRVSNR_USER_PILLAR_PREFIX
+)
+
+user_local_pillar = PillarPath(
+    config.PRVSNR_USER_LOCAL_PILLAR_DIR,
+    config.PRVSNR_USER_LOCAL_PILLAR_PREFIX
+)

--- a/api/python/provisioner/paths.py
+++ b/api/python/provisioner/paths.py
@@ -53,14 +53,14 @@ class PillarPath:
         return self._all_hosts_dir
 
 
-default_pillar = PillarPath(config.PRVSNR_PILLAR_DIR)
+DEFAULT_PILLAR = PillarPath(config.PRVSNR_PILLAR_DIR)
 
-user_shared_pillar = PillarPath(
+USER_SHARED_PILLAR = PillarPath(
     config.PRVSNR_USER_PILLAR_DIR,
     config.PRVSNR_USER_PILLAR_PREFIX
 )
 
-user_local_pillar = PillarPath(
+USER_LOCAL_PILLAR = PillarPath(
     config.PRVSNR_USER_LOCAL_PILLAR_DIR,
     config.PRVSNR_USER_LOCAL_PILLAR_PREFIX
 )

--- a/api/python/provisioner/pillar.py
+++ b/api/python/provisioner/pillar.py
@@ -26,10 +26,11 @@ from .utils import load_yaml, dump_yaml
 from .salt import pillar_get, pillar_refresh
 from .config import (
     ALL_MINIONS,
-    PRVSNR_PILLAR_DIR,
-    PRVSNR_USER_PILLAR_PREFIX,
-    PRVSNR_USER_PILLAR_ALL_HOSTS_DIR,
-    PRVSNR_USER_PILLAR_HOST_DIR_TMPL
+    PRVSNR_PILLAR_DIR
+)
+from .paths import (
+    user_shared_pillar,
+    user_local_pillar
 )
 # from .inputs import ParamGroupInputBase, ParamDictItemInputBase
 from .values import UNCHANGED, DEFAULT, MISSED, UNDEFINED
@@ -210,8 +211,15 @@ class PillarResolver:
 class PillarUpdater:
     targets: str = ALL_MINIONS
     local: bool = False
+
+    _pillar_path: Path = attr.ib(init=False, default=None)
     _pillars: Dict = attr.Factory(dict)
     _p_entries: List[PillarEntry] = attr.Factory(list)
+
+    def __attrs_post_init__(self):
+        self._pillar_path = (
+            user_local_pillar if self.local else user_shared_pillar
+        )
 
     @staticmethod
     def ensure_exists(path: Path):
@@ -220,11 +228,15 @@ class PillarUpdater:
             path.touch()
 
     @classmethod
-    def add_merge_prefix(cls, path: Path):
-        if path.name.startswith(PRVSNR_USER_PILLAR_PREFIX):
+    def add_merge_prefix(cls, path: Path, local=False):
+        pillar_path = (
+            user_local_pillar if local else user_shared_pillar
+        )
+
+        if path.name.startswith(pillar_path.prefix):
             return path
         else:
-            return path.with_name(f"{PRVSNR_USER_PILLAR_PREFIX}{path.name}")
+            return path.with_name(f"{pillar_path.prefix}{path.name}")
 
     # TODO create task
     # TODO test
@@ -289,13 +301,13 @@ class PillarUpdater:
     #       2-5. minion-value: set value for a minion
     def pillar(self, path: Path):
         if self.targets == ALL_MINIONS:
-            _path = PRVSNR_USER_PILLAR_ALL_HOSTS_DIR / path
+            _path = self._pillar_path.all_hosts_dir / path
         else:
             _path = Path(
-                PRVSNR_USER_PILLAR_HOST_DIR_TMPL.format(minion_id=self.targets)
+                self._pillar_path.host_dir_tmpl.format(minion_id=self.targets)
             ) / path
 
-        _path = self.add_merge_prefix(_path)
+        _path = self.add_merge_prefix(_path, local=self.local)
 
         if _path not in self._pillars:
             self._pillars[_path] = load_yaml(_path) if _path.exists() else {}
@@ -378,9 +390,9 @@ class PillarUpdater:
         reset: bool = False,
         pillar: Dict = None
     ):
+        # NOTE only shared dir is considered (possibly not always ok)
         path = (
-            PRVSNR_USER_PILLAR_ALL_HOSTS_DIR /
-            '{}.sls'.format(component)
+            user_shared_pillar / '{}.sls'.format(component)
         )
         if show:
             if not path.exists():

--- a/api/python/provisioner/pillar.py
+++ b/api/python/provisioner/pillar.py
@@ -179,12 +179,15 @@ class PillarEntry:
 @attr.s(auto_attribs=True)
 class PillarResolver:
     targets: str = ALL_MINIONS
+    local: bool = False
     _pillar: Dict = None
 
     @property
     def pillar(self):
         if self._pillar is None:
-            self._pillar = pillar_get(targets=self.targets)
+            self._pillar = pillar_get(
+                targets=self.targets, local=self.local
+            )
         return self._pillar
 
     def get(self, pi_keys: Iterable[PillarKeyAPI]):  # TODO return value
@@ -206,6 +209,7 @@ class PillarResolver:
 @attr.s(auto_attribs=True)
 class PillarUpdater:
     targets: str = ALL_MINIONS
+    local: bool = False
     _pillars: Dict = attr.Factory(dict)
     _p_entries: List[PillarEntry] = attr.Factory(list)
 

--- a/api/python/provisioner/pillar.py
+++ b/api/python/provisioner/pillar.py
@@ -29,8 +29,8 @@ from .config import (
     PRVSNR_PILLAR_DIR
 )
 from .paths import (
-    user_shared_pillar,
-    user_local_pillar
+    USER_SHARED_PILLAR,
+    USER_LOCAL_PILLAR
 )
 # from .inputs import ParamGroupInputBase, ParamDictItemInputBase
 from .values import UNCHANGED, DEFAULT, MISSED, UNDEFINED
@@ -218,7 +218,7 @@ class PillarUpdater:
 
     def __attrs_post_init__(self):
         self._pillar_path = (
-            user_local_pillar if self.local else user_shared_pillar
+            USER_LOCAL_PILLAR if self.local else USER_SHARED_PILLAR
         )
 
     @staticmethod
@@ -230,7 +230,7 @@ class PillarUpdater:
     @classmethod
     def add_merge_prefix(cls, path: Path, local=False):
         pillar_path = (
-            user_local_pillar if local else user_shared_pillar
+            USER_LOCAL_PILLAR if local else USER_SHARED_PILLAR
         )
 
         if path.name.startswith(pillar_path.prefix):
@@ -392,7 +392,7 @@ class PillarUpdater:
     ):
         # NOTE only shared dir is considered (possibly not always ok)
         path = (
-            user_shared_pillar / '{}.sls'.format(component)
+            USER_SHARED_PILLAR / '{}.sls'.format(component)
         )
         if show:
             if not path.exists():

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -45,7 +45,7 @@ def validator_path(instance, attribute, value):
         if attribute.default is not None:
             raise ValueError(f"{attribute.name} should be defined")
     elif not isinstance(value, Path):
-            raise TypeError(f"{attribute.name} should be a Path")
+        raise TypeError(f"{attribute.name} should be a Path")
 
 
 def validator_path_exists(instance, attribute, value):

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -39,12 +39,24 @@ logger = logging.getLogger(__name__)
 
 
 # TODO TEST
-def validator_path_exists(instance, attribute, value):
+
+def validator_path(instance, attribute, value):
     if value is None:
         if attribute.default is not None:
             raise ValueError(f"{attribute.name} should be defined")
-    elif not value.exists():
+    elif not isinstance(value, Path):
+            raise TypeError(f"{attribute.name} should be a Path")
+
+
+def validator_path_exists(instance, attribute, value):
+    validator_path(instance, attribute, value)
+
+    if value and not value.exists():
         raise ValueError(f"Path {value} doesn't exist")
+
+
+def converter_path(value):
+    return value if value is None else Path(str(value))
 
 
 def converter_path_resolved(value):

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -87,9 +87,9 @@ setup(
     install_requires=[
         'PyYAML',
         'salt==3001.1',  # FIXME 2019.2.0 is buggy,
-                       # 3000.3 lacks support of glusterfs 7.0 updated prompt
-                       # TODO update salt packages for provisioner
-                       # setup rpm as well
+                         # 3000.3 lacks support of glusterfs 7.0 updated prompt
+                         # TODO update salt packages for provisioner
+                         # setup rpm as well
     ],  # TODO
     setup_requires=([] + pytest_runner),
     extras_require={

--- a/srv/components/provisioner/salt_master/files/master
+++ b/srv/components/provisioner/salt_master/files/master
@@ -852,6 +852,7 @@ pillar_roots:
   base:
     - /var/lib/seagate/cortx/provisioner/local/srv/pillar  # new style
     - /var/lib/seagate/cortx/provisioner/shared/srv/pillar  # new style
+    - /srv/glusterfs/volume_prvsnr_data/srv/pillar  # fallback for read-only queries
     - /opt/seagate/cortx/provisioner/pillar
 
 # A list of paths to be recursively decrypted during pillar compilation.

--- a/srv/components/provisioner/salt_minion/files/minion
+++ b/srv/components/provisioner/salt_minion/files/minion
@@ -630,6 +630,7 @@ pillar_roots:
   base:
     - /var/lib/seagate/cortx/provisioner/local/srv/pillar  # new style
     - /var/lib/seagate/cortx/provisioner/shared/srv/pillar  # new style
+    - /srv/glusterfs/volume_prvsnr_data/srv/pillar  # fallback for read-only queries
     - /opt/seagate/cortx/provisioner/pillar
 
 


### PR DESCRIPTION
- provisioner `pillar_get` a `pillar_set` comands now supports `--local` option that will switch the mode to use `salt-call --local`
- also one more pillar root was added into account `/srv/glusterfs/volume_prvsnr_data/srv/pillar`
- it means that local mode would work for both read and write pillar requests even if salt and gluster services are not running:
  - set commands will update values in `/var/lib/seagate/cortx/provisioner/local/srv/pillar` (it is not shared via gluster)
  - get commands will take into account both gluster brick `/srv/glusterfs/volume_prvsnr_data/srv/pillar` and `/var/lib/seagate/cortx/provisioner/local/srv/pillar`