### PR TITLE
EOS-15043: assign prefix/subnet mask to cluster-ip and mgmt-vip

### DIFF
--- a/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
+++ b/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
@@ -38,11 +38,7 @@ Update ClusterIP:
 
 Setup ClusterIP resouce:
   cmd.run:
-    - name: pcs resource create ClusterIP ocf:heartbeat:IPaddr2 ip={{ pillar['cluster']['cluster_ip'] }} mac=$(echo "01:00:5e:`echo {{ grains['hwaddr_interfaces'][data_if] }} | cut -d ":" -f 1-3`") nic={{ data_if }} op monitor interval=30s
-
-Update ClusterIP:
-  cmd.run:
-    - name: pcs resource update ClusterIP cidr_netmask=$(echo `ip addr show { data_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;}')
+    - name: pcs resource create ClusterIP ocf:heartbeat:IPaddr2 ip={{ pillar['cluster']['cluster_ip'] }} mac=$(echo "01:00:5e:`echo {{ grains['hwaddr_interfaces'][data_if] }} | cut -d ":" -f 1-3`") nic={{ data_if }} op monitor interval=30s cidr_netmask=$(echo `ip addr show { data_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;}')
 
 Add stickiness metadata to ClusterIP resource:
   cmd.run:

--- a/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
+++ b/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
@@ -40,6 +40,11 @@ Setup ClusterIP resouce:
   cmd.run:
     - name: pcs resource create ClusterIP ocf:heartbeat:IPaddr2 ip={{ pillar['cluster']['cluster_ip'] }} mac=$(echo "01:00:5e:`echo {{ grains['hwaddr_interfaces'][data_if] }} | cut -d ":" -f 1-3`") nic={{ data_if }} op monitor interval=30s
 
+Update ClusterIP:
+  cmd.run:
+    - name: pcs resource update ClusterIP cidr_netmask=$(echo `ip addr show { data_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;})
+    - onlyif: pcs resource show ClusterIP
+
 Add stickiness metadata to ClusterIP resource:
   cmd.run:
     - name: pcs resource meta ClusterIP resource-stickiness=0

--- a/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
+++ b/srv/components/ha/corosync-pacemaker/config/cluster_ip.sls
@@ -42,8 +42,7 @@ Setup ClusterIP resouce:
 
 Update ClusterIP:
   cmd.run:
-    - name: pcs resource update ClusterIP cidr_netmask=$(echo `ip addr show { data_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;})
-    - onlyif: pcs resource show ClusterIP
+    - name: pcs resource update ClusterIP cidr_netmask=$(echo `ip addr show { data_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;}')
 
 Add stickiness metadata to ClusterIP resource:
   cmd.run:

--- a/srv/components/ha/corosync-pacemaker/config/mgmt_vip.sls
+++ b/srv/components/ha/corosync-pacemaker/config/mgmt_vip.sls
@@ -17,9 +17,16 @@
 
 {% if 'primary' in grains['roles'] 
   and pillar['cluster']['mgmt_vip'] %}
+
+{% if 'mgmt0' in grains['ip4_interfaces'] and grains['ip4_interfaces']['mgmt0'] %}
+  {%- set mgmt_if = 'mgmt0' -%}
+{% else %}
+  {%- set mgmt_if = pillar['cluster'][grains['id']]['network']['mgmt_nw']['iface'][0] -%}
+{% endif %}
+
 Update Management VIP:
   cmd.run:
-    - name: pcs resource update kibana-vip ip={{ pillar['cluster']['mgmt_vip'] }}
+    - name: pcs resource update kibana-vip ip={{ pillar['cluster']['mgmt_vip'] }} cidr_netmask=$(echo `ip addr show { mgmt_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;})
 
 {% else %}
 

--- a/srv/components/ha/corosync-pacemaker/config/mgmt_vip.sls
+++ b/srv/components/ha/corosync-pacemaker/config/mgmt_vip.sls
@@ -26,7 +26,7 @@
 
 Update Management VIP:
   cmd.run:
-    - name: pcs resource update kibana-vip ip={{ pillar['cluster']['mgmt_vip'] }} cidr_netmask=$(echo `ip addr show { mgmt_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;})
+    - name: pcs resource update kibana-vip ip={{ pillar['cluster']['mgmt_vip'] }} cidr_netmask=$(echo `ip addr show { mgmt_if } | grep "inet\b" | awk '{print $2}' | cut -d "/" -f2` | awk '{print $1;}')
 
 {% else %}
 


### PR DESCRIPTION
modified cluster-ip.sls and mgmt-vip.sls with following changes.
1) cluster-ip.sls : Assigned original interface's(cluster/srvnode-1/data_nw/interface[0]) prefix/subnet-mask to virtual IP created with IP address as Cluster IP. enp175's subnet mask/prefix is assigned to virtual IP created.
2) mgmt-vip.sls: Assigned original interface's(cluster/srvnode-1/mgmt_nw/interface[0]) prefix/subnet-mask to virtual IP created with IP address as Managment IP. eno1's subnet mask/prefix is assigned to virtual IP created.
