### PR TITLE
[EOS-15022][part 1] improves salt wrapper abstractions

### DIFF
--- a/api/python/provisioner/__main__.py
+++ b/api/python/provisioner/__main__.py
@@ -189,7 +189,7 @@ def _set_logging(output_type, log_args=None, other_args=None):  # noqa: C901
 def _main():
     global output_type
 
-    parsed_args = cli_parser.parse_args()
+    parsed_args = cli_parser.parse_args(commands=commands)
 
     output_type = parsed_args.kwargs.pop('output')
 

--- a/api/python/provisioner/_api.py
+++ b/api/python/provisioner/_api.py
@@ -21,6 +21,7 @@ import logging
 from .salt import auth_init as _auth_init
 from .api_spec import api_spec
 from .runner import SimpleRunner
+from .commands import commands
 
 
 # TODO
@@ -46,7 +47,7 @@ def run(command: str, *args, nowait=False, **kwargs):
     kwargs.pop('username', None)
     kwargs.pop('eauth', None)
     logger.debug("Executing command {}".format(command))
-    return SimpleRunner(nowait=nowait).run(command, *args, **kwargs)
+    return SimpleRunner(commands, nowait=nowait).run(command, *args, **kwargs)
 
 
 def _api_wrapper(fun):

--- a/api/python/provisioner/api_spec.yaml
+++ b/api/python/provisioner/api_spec.yaml
@@ -98,6 +98,8 @@ cmd_run:
   type: CmdRun
 configure_setup:
   type: ConfigureSetup
+salt:
+  type: SaltClient
 
 # setup commands
 setup_provisioner:

--- a/api/python/provisioner/commands/_basic.py
+++ b/api/python/provisioner/commands/_basic.py
@@ -58,7 +58,7 @@ class CommandParserFillerMixin:
         return ret if type(ret) is list else [ret]
 
     @classmethod
-    def fill_parser(cls, parser):
+    def fill_parser(cls, parser, parents=None):
         for arg_type in cls._run_args_types():
             inputs.ParserFiller.fill_parser(arg_type, parser)
 

--- a/api/python/provisioner/commands/check.py
+++ b/api/python/provisioner/commands/check.py
@@ -574,7 +574,7 @@ class Check(CommandParserFillerMixin):
             cmd = _PSWDLESS_SSH_CHECK_CMD_TMPL.format(user=user,
                                                       hostname=addr)
             try:
-                _res = cmd_run(cmd, targets=targets)
+                _ = cmd_run(cmd, targets=targets)
             except SaltCmdResultError:
                 res.set_fail(checked_target=targets,
                              comment=(f"{cfg.CheckVerdict.FAIL.value}: "

--- a/api/python/provisioner/commands/salt.py
+++ b/api/python/provisioner/commands/salt.py
@@ -1,0 +1,179 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import Type
+import logging
+import argparse
+
+from ..vendor import attr
+from .. import (
+    inputs
+)
+from ..cli_parser import KeyValueListAction
+
+from ..salt_api import (
+    SaltLocalClient,
+    SaltRunnerClient,
+    SaltCallerClient,
+    SaltLocalCallerClient,
+    SaltSSHClient
+)
+
+from . import (
+    CommandParserFillerMixin
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True)
+class RunArgsSaltFun:
+    fun: str = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "salt function to run"
+                )
+            }
+        }
+    )
+    fun_args: str = attr.ib(
+        kw_only=True,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "salt fun key-value arguments"
+                ),
+                'metavar': 'ARG',
+                'nargs': '+',
+            }
+        },
+        default=None
+    )
+    fun_kwargs: str = attr.ib(
+        kw_only=True,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "salt fun keyword arguments"
+                ),
+                'metavar': 'KEY=VALUE',
+                'nargs': '+',
+                'action': KeyValueListAction
+            }
+        },
+        default=None
+    )
+    kwargs: str = attr.ib(
+        kw_only=True,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "salt client keyword arguments"
+                ),
+                'metavar': 'KEY=VALUE',
+                'nargs': '+',
+                'action': KeyValueListAction
+            }
+        },
+        default=None
+    )
+    secure: bool = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "mask secrets in logs"
+                )
+            }
+        },
+        default=False
+    )
+
+
+@attr.s(auto_attribs=True)
+class SaltClient(CommandParserFillerMixin):
+    input_type: Type[inputs.NoParams] = inputs.NoParams
+    _run_args_type = RunArgsSaltFun
+
+    clients = {
+        'salt': SaltLocalClient,
+        'runner': SaltRunnerClient,
+        'caller': SaltCallerClient,
+        'local': SaltLocalCallerClient,
+        'ssh': SaltSSHClient
+    }
+
+    @classmethod
+    def fill_parser(cls, parser, parents=None):
+        if parents is None:
+            parents = []
+
+        parser_common = argparse.ArgumentParser(add_help=False)
+        super().fill_parser(parser_common)
+
+        parents.append(parser_common)
+
+        subparsers = parser.add_subparsers(
+            dest='client',
+            title='clients',
+            description='valid clients'
+        )
+
+        for cl_name, cl_t in cls.clients.items():
+            subparser = subparsers.add_parser(
+                cl_name, description='{} configuration'.format(cl_name),
+                help='{} client help'.format(cl_name), parents=parents,
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            )
+            inputs.ParserFiller.fill_parser(cl_t, subparser)
+
+    @classmethod
+    def extract_positional_args(cls, kwargs):
+        client_t = cls.clients[kwargs.pop('client')]
+        _args = [client_t]
+
+        args, kwargs = super().extract_positional_args(kwargs)
+        _args.extend(args)
+
+        args, kwargs = inputs.ParserFiller.extract_positional_args(
+            client_t, kwargs
+        )
+        _args.extend(args)
+
+        return _args, kwargs
+
+    def run(self, client_t, fun, *args, **kwargs):
+        client_kwargs = {
+            k: kwargs.pop(k) for k in list(kwargs)
+            if k in attr.fields_dict(client_t)
+        }
+
+        run_args = RunArgsSaltFun(fun, **{
+            k: kwargs.pop(k) for k in list(kwargs)
+            if k in attr.fields_dict(RunArgsSaltFun)
+        })
+
+        client = client_t(*args, **client_kwargs)
+
+        return client.run(
+            run_args.fun,
+            run_args.fun_args,
+            run_args.fun_kwargs,
+            run_args.secure,
+            **(run_args.kwargs or {})
+        )

--- a/api/python/provisioner/commands/salt.py
+++ b/api/python/provisioner/commands/salt.py
@@ -157,7 +157,8 @@ class SaltClient(CommandParserFillerMixin):
 
         return _args, kwargs
 
-    def run(self, client_t, fun, *args, **kwargs):
+    @staticmethod
+    def run(client_t, fun, *args, **kwargs):
         client_kwargs = {
             k: kwargs.pop(k) for k in list(kwargs)
             if k in attr.fields_dict(client_t)

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -83,6 +83,8 @@ PRVSNR_PILLAR_CONFIG_INI = str(
 REPO_CANDIDATE_NAME = 'candidate'
 RELEASE_INFO_FILE = 'RELEASE.INFO'
 
+SALT_ROSTER_DEFAULT = '/etc/salt/roster'
+
 # TODO EOS-12076 EOS-12334
 
 CORTX_SINGLE_ISO_DIR = 'cortx_single_iso'
@@ -119,6 +121,8 @@ SSL_CERTS_FILE = Path('/etc/ssl/stx/stx.pem')
 GLUSTERFS_VOLUME_SALT_JOBS = Path('/srv/glusterfs/volume_salt_cache_jobs')
 GLUSTERFS_VOLUME_PRVSNR_DATA = Path('/srv/glusterfs/volume_prvsnr_data')
 
+GLUSTERFS_VOLUME_FILEROOT_DIR = GLUSTERFS_VOLUME_PRVSNR_DATA / 'srv/salt'
+GLUSTERFS_VOLUME_PILLAR_DIR = GLUSTERFS_VOLUME_PRVSNR_DATA / 'srv/pillar'
 
 SEAGATE_USER_HOME_DIR = Path('/opt/seagate/users')
 SEAGATE_USER_FILEROOT_DIR_TMPL = str(

--- a/api/python/provisioner/fileroot.py
+++ b/api/python/provisioner/fileroot.py
@@ -1,0 +1,121 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+from typing import Any, Union
+from pathlib import Path
+
+from .vendor import attr
+from .paths import FileRootPath
+from .salt_api.runner import SaltRunnerClient
+from . import utils, config
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True)
+class FileRoot:
+    _root: FileRootPath = config.USER_SHARED_FILEROOT
+    refresh_on_update: bool = True
+    _runner_client: SaltRunnerClient = attr.ib(init=False, default=None)
+
+    def __attrs_post_init__(self):
+        self._runner_client = SaltRunnerClient()
+
+    def refresh(self):
+        # TODO DOC
+        # ensure it would be visible for salt-master / salt-minions
+        # TODO makes sense to move to client, so ssh and runner clients
+        #      may do that in a different way
+        self._runner_client.run(
+            'fileserver.clear_file_list_cache',
+            fun_kwargs=dict(backend='roots')
+        )
+
+    @property
+    def root(self):
+        return self._root
+
+    def path(self, r_path: Union[str, Path]):
+        return self._root.path(r_path)
+
+    def exists(self, r_path: Union[str, Path]):
+        return self.path(r_path).exists()
+
+    def read(self, r_path: Union[str, Path], text: bool = True):
+        path = self.path(r_path)
+        return path.read_text() if text else path.read_bytes()
+
+    def read_yaml(self, r_path: Union[str, Path]):
+        return utils.load_yaml(self.path(r_path))
+
+    # TODO make idempotent
+    def write(self, r_path: Union[str, Path], data: Any, text: bool = True):
+        path = self.path(r_path)
+
+        if text:
+            path.write_text(data)
+        else:
+            path.write_bytes(data)
+
+        if self.refresh_on_update:
+            self.refresh()
+
+    # TODO make idempotent
+    def write_yaml(self, r_path: Union[str, Path], data: Any):
+        utils.dump_yaml(self.path(r_path), data)
+
+    # FIXME mostly duplicates salt:copy_to_file_roots
+    def copy(
+        self, source: Union[str, Path], r_dest: Union[str, Path],
+    ):
+        source = Path(str(source))
+        dest = self.path(r_dest)
+
+        if not source.exists():
+            raise ValueError('{} not found'.format(source))
+
+        if source.is_dir():
+            # TODO
+            #  - file.recurse expects only dirs from salt-master file roots
+            #    (salt://), need to find another alternative to respect
+            #    indempotence
+            # StateFunExecuter.execute(
+            #     'file.recurse',
+            #     fun_kwargs=dict(
+            #       source=str(params.source),
+            #       name=str(dest)
+            #     )
+            # )
+            self._runner_client.cmd_run(
+                "mkdir -p {0} && rm -rf {2} && cp -R {1} {2}"
+                .format(dest.parent, source, dest)
+            )
+        else:
+            self._runner_client.run(
+                'file.managed',
+                fun_kwargs=dict(
+                    source=str(source),
+                    name=str(dest),
+                    makedirs=True
+                )
+            )
+
+        if self.refresh_on_update:
+            self.refresh()
+
+        return dest

--- a/api/python/provisioner/fileroot.py
+++ b/api/python/provisioner/fileroot.py
@@ -34,6 +34,7 @@ class FileRoot:
     _runner_client: SaltRunnerClient = attr.ib(init=False, default=None)
 
     def __attrs_post_init__(self):
+        """Do post init."""
         self._runner_client = SaltRunnerClient()
 
     def refresh(self):

--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -84,6 +84,13 @@ class AttrParserArgs:
     def __attrs_post_init__(self):  # noqa: C901 FIXME
         self.name = self._attr.name
 
+        if self.name.startswith('__'):
+            raise ValueError(
+                f"{self.name}: multiple leading underscores are not expected"
+            )
+
+        self.name = self.name.lstrip('_')
+
         if self.prefix:
             self.name = self.prefix + self.name
 
@@ -123,7 +130,10 @@ class AttrParserArgs:
         if self._attr.default is not attr.NOTHING:
             # optional argument
             self.name = '--' + self.name.replace('_', '-')
-            self.default = self._attr.default
+            default_v = self._attr.default
+            if isinstance(default_v, attr.Factory):
+                default_v = default_v.factory()
+            self.default = default_v
             self.metavar = (
                 parser_args.get('metavar')
                 or (self._attr.type.__name__ if self._attr.type else None)

--- a/api/python/provisioner/paths.py
+++ b/api/python/provisioner/paths.py
@@ -22,24 +22,42 @@ from .vendor import attr
 
 
 @attr.s(auto_attribs=True)
-class PillarPath:
-    _base_dir: Path = attr.ib(
+class RootPath:
+    _root: Path = attr.ib(
         converter=utils.converter_path,
         validator=utils.validator_path
     )
+
+    @property
+    def root(self):
+        return self._root
+
+
+@attr.s(auto_attribs=True)
+class FileRootPath(RootPath):
+
+    def path(self, path):
+        return self._root / path
+
+
+@attr.s(auto_attribs=True)
+class PillarPath(RootPath):
     _prefix: str = ''
 
     _host_dir_tmpl: str = attr.ib(init=False, default=None)
     _all_hosts_dir: Path = attr.ib(init=False, default=None)
 
+    @staticmethod
+    def add_merge_prefix(pillar_path: 'PillarPath', path: Path) -> Path:
+        if path.name.startswith(pillar_path.prefix):
+            return path
+        else:
+            return path.with_name(f"{pillar_path.prefix}{path.name}")
+
     def __attrs_post_init__(self):
         """Post init logic."""
-        self._host_dir_tmpl = str(self.base_dir / 'minions/{minion_id}')
-        self._all_hosts_dir = self.base_dir / 'groups/all'
-
-    @property
-    def base_dir(self):
-        return self._base_dir
+        self._host_dir_tmpl = str(self.root / 'minions/{minion_id}')
+        self._all_hosts_dir = self.root / 'groups/all'
 
     @property
     def prefix(self):
@@ -53,6 +71,23 @@ class PillarPath:
     def all_hosts_dir(self):
         return self._all_hosts_dir
 
+    def host_path(self, path, target: str):
+        return self.add_merge_prefix(
+            self, (
+                Path(self.all_hosts_dir.format(minion_id=target))
+                / path
+            )
+        )
+
+    def all_hosts_path(self, path):
+        return self.add_merge_prefix(self, self.all_hosts_dir / path)
+
+
+DEFAULT_FILEROOT = PillarPath(config.PRVSNR_FILEROOT_DIR)
+USER_SHARED_FILEROOT = PillarPath(config.PRVSNR_USER_FILEROOT_DIR)
+USER_LOCAL_FILEROOT = PillarPath(config.PRVSNR_USER_LOCAL_FILEROOT_DIR)
+GLUSTERFS_VOLUME_FILEROOT = PillarPath(config.GLUSTERFS_VOLUME_FILEROOT_DIR)
+
 
 DEFAULT_PILLAR = PillarPath(config.PRVSNR_PILLAR_DIR)
 
@@ -64,4 +99,9 @@ USER_SHARED_PILLAR = PillarPath(
 USER_LOCAL_PILLAR = PillarPath(
     config.PRVSNR_USER_LOCAL_PILLAR_DIR,
     config.PRVSNR_USER_LOCAL_PILLAR_PREFIX
+)
+
+GLUSTERFS_VOLUME_PILLAR = PillarPath(
+    config.GLUSTERFS_VOLUME_PILLAR_DIR,
+    config.PRVSNR_USER_PILLAR_PREFIX
 )

--- a/api/python/provisioner/pillar.py
+++ b/api/python/provisioner/pillar.py
@@ -29,9 +29,12 @@ from .config import (
     PRVSNR_PILLAR_DIR
 )
 from .paths import (
+    PillarPath,
     USER_SHARED_PILLAR,
     USER_LOCAL_PILLAR
 )
+
+# from .salt_api import SaltClientBase
 # from .inputs import ParamGroupInputBase, ParamDictItemInputBase
 from .values import UNCHANGED, DEFAULT, MISSED, UNDEFINED
 
@@ -200,6 +203,28 @@ class PillarResolver:
                 pk: PillarEntry(pk.keypath, pillar).get() for pk in pi_keys
             }
         return res
+
+
+# FIXME EOS-15022 rename once tested enough
+@attr.s(auto_attribs=True)
+class PillarResolverNew(PillarResolver):
+    # FIXME EOS-15022 cross import issue
+    # client: SaltClientBase = None
+    client: Any = None
+
+    @property
+    def pillar(self):
+        if self._pillar is None:
+            if self.client is None:
+                self._pillar = pillar_get(
+                    targets=self.targets, local=self.local
+                )
+            else:
+                # TODO IMPROVE optional targetting should
+                #      be taken care only inside client parameters
+                #      for now
+                self._pillar = self.client.pillar_get(targets=self.targets)
+        return self._pillar
 
 
 # TODO verify that targets are resoloved to real minions
@@ -408,3 +433,34 @@ class PillarUpdater:
         elif pillar:
             cls.ensure_exists(path)
             dump_yaml(path, pillar)
+
+
+# FIXME EOS-15022 rename once tested enough
+@attr.s(auto_attribs=True)
+class PillarUpdaterNew(PillarUpdater):
+    pillar_path: PillarPath = USER_SHARED_PILLAR
+
+    def __attrs_post_init__(self):
+        if self.local:
+            self.pillar_path = USER_LOCAL_PILLAR
+
+    @classmethod
+    def add_merge_prefix(cls, path: Path, local=False):
+        pillar_path = (
+            USER_LOCAL_PILLAR if local else USER_SHARED_PILLAR
+        )
+
+        if path.name.startswith(pillar_path.prefix):
+            return path
+        else:
+            return path.with_name(f"{pillar_path.prefix}{path.name}")
+
+    def pillar(self, path: Path):
+        if self.targets == ALL_MINIONS:
+            _path = self.pillar_path.all_hosts_path(path)
+        else:
+            _path = self.pillar_path.host_path(path, self.targets)
+
+        if _path not in self._pillars:
+            self._pillars[_path] = load_yaml(_path) if _path.exists() else {}
+        return self._pillars[_path]

--- a/api/python/provisioner/runner.py
+++ b/api/python/provisioner/runner.py
@@ -16,25 +16,19 @@
 #
 
 import os
-from typing import Union, Any
+from typing import Union, Any, List
 
 from .vendor import attr
 from . import inputs
 from .salt import provisioner_cmd
-from .commands import commands
 from .errors import ProvisionerError
 
 
 # TODO TESTS
 @attr.s(auto_attribs=True)
 class SimpleRunner:
-    nowait: bool = attr.ib(
-        metadata={
-            inputs.METADATA_ARGPARSER: {
-                'help': "run the command as a salt job in async mode"
-            }
-        }, default=False
-    )
+    commands: List
+    nowait: bool = False
 
     @classmethod
     def fill_parser(cls, parser):
@@ -69,5 +63,5 @@ class SimpleRunner:
             except Exception as exc:
                 raise ProvisionerError(repr(exc)) from exc
         else:
-            cmd = commands[command]
+            cmd = self.commands[command]
             return cmd.run(*args, **kwargs)

--- a/api/python/provisioner/salt.py
+++ b/api/python/provisioner/salt.py
@@ -1029,10 +1029,7 @@ def _salt_client_cmd(
         if local:
             _cmd_f = client.cmd
         else:
-            _cmd_f = (
-                client.cmd_async if nowait
-                else salt_local_client().cmd
-            )
+            _cmd_f = (client.cmd_async if nowait else client.cmd)
 
         salt_res = _cmd_f(*cmd_args.args, **cmd_args.kwargs)
     except Exception as exc:

--- a/api/python/provisioner/salt_api/__init__.py
+++ b/api/python/provisioner/salt_api/__init__.py
@@ -15,28 +15,17 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-__title__ = 'cortx-prvsnr'
-__version__ = '0.42.0'
-__author__ = "Seagate"
-__author_email__ = 'support@seagate.com'  # TODO
-__maintainer__ = 'Seagate'
-__maintainer_email__ = __author_email__
-__url__ = 'https://github.com/Seagate/cortx-prvsnr'
-__description__ = 'Provisioner API for CORTX components'
-__long_description__ = __description__
-__download_url__ = f"{__url__}"
-__license__ = "GNU Affero General Public License"  # TODO
+from .base import SaltClientBase
+from .client import SaltLocalClient
+from .runner import SaltRunnerClient
+from .caller import SaltCallerClient, SaltLocalCallerClient
+from .ssh import SaltSSHClient
 
-__all__ = [
-    '__title__',
-    '__version__',
-    '__author__',
-    '__author_email__',
-    '__maintainer__',
-    '__maintainer_email__',
-    '__url__',
-    '__description__',
-    '__long_description__',
-    '__download_url__',
-    '__license__',
+client_types = [
+    SaltClientBase,
+    SaltLocalClient,
+    SaltRunnerClient,
+    SaltCallerClient,
+    SaltLocalCallerClient,
+    SaltSSHClient
 ]

--- a/api/python/provisioner/salt_api/auth.py
+++ b/api/python/provisioner/salt_api/auth.py
@@ -15,28 +15,49 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-__title__ = 'cortx-prvsnr'
-__version__ = '0.42.0'
-__author__ = "Seagate"
-__author_email__ = 'support@seagate.com'  # TODO
-__maintainer__ = 'Seagate'
-__maintainer_email__ = __author_email__
-__url__ = 'https://github.com/Seagate/cortx-prvsnr'
-__description__ = 'Provisioner API for CORTX components'
-__long_description__ = __description__
-__download_url__ = f"{__url__}"
-__license__ = "GNU Affero General Public License"  # TODO
+import logging
 
-__all__ = [
-    '__title__',
-    '__version__',
-    '__author__',
-    '__author_email__',
-    '__maintainer__',
-    '__maintainer_email__',
-    '__url__',
-    '__description__',
-    '__long_description__',
-    '__download_url__',
-    '__license__',
-]
+
+logger = logging.getLogger(__name__)
+
+
+_eauth = 'pam'
+_username = None
+_password = None
+
+
+def username():
+    return _username
+
+
+def password():
+    return _password
+
+
+def eauth():
+    return _eauth
+
+
+# TODO
+#   - think about static salt client (one for the module)
+def auth_init(username, password, eauth='pam'):
+    global _eauth
+    global _username
+    global _password
+    _eauth = eauth
+    _username = username
+    _password = password
+
+
+# TODO TEST
+def _set_auth(kwargs):
+    eauth = kwargs.pop('eauth', _eauth)
+    username = kwargs.pop('username', _username)
+    password = kwargs.pop('password', _password)
+
+    if username:
+        kwargs['eauth'] = eauth
+        kwargs['username'] = username
+        kwargs['password'] = password
+
+    return

--- a/api/python/provisioner/salt_api/base.py
+++ b/api/python/provisioner/salt_api/base.py
@@ -59,6 +59,7 @@ class SaltArgsBase:
         return dict(arg=self.fun_args, kwarg=self.fun_kwargs, **self.kw)
 
     def __str__(self):
+        """Return str presentation."""
         _dct = self._as_dict()
         _self_safe = type(self)(**_dct)
         return str(attr.asdict(_self_safe))
@@ -95,16 +96,17 @@ class SaltClientResultBase:
 class SaltClientJIDResult(SaltClientResultBase):
 
     def __attrs_post_init__(self):
+        """Do post init."""
         if not isinstance(self.raw, str):
             self.fails = (
-                'not a valid salt job ID value type: {type(self.raw)}'
+                f'not a valid salt job ID value type: {type(self.raw)}'
             )
 
         try:
             self.results = int(self.raw)
         except ValueError:
             self.fails = (
-                'not a valid salt job ID value: {self.raw}'
+                f'not a valid salt job ID value: {self.raw}'
             )
 
 
@@ -112,8 +114,9 @@ class SaltClientJIDResult(SaltClientResultBase):
 class SaltClientJobResult(SaltClientResultBase):
 
     def __attrs_post_init__(self):
+        """Do post init."""
         # TODO is it a valid case actually ?
-        if type(self.raw) is not dict:
+        if not isinstance(self.raw, dict):
             self.results = self.raw
         else:
             try:
@@ -126,7 +129,7 @@ class SaltClientJobResult(SaltClientResultBase):
         # TODO HARDEN check format of result
         for target, job_result in self.raw.items():
             ret = None
-            if type(job_result) is dict:
+            if isinstance(job_result, dict):
                 # result format as a part of job differs (async result) from
                 # sync case:
                 #   - 'ret' for sync
@@ -147,7 +150,7 @@ class SaltClientJobResult(SaltClientResultBase):
             if job_result.get('retcode') != 0:
                 if (
                     self.cmd_args_view['fun'].startswith('state.')
-                    and (type(ret) is dict)
+                    and isinstance(ret, dict)
                 ):
                     _fails = self._get_state_fails(ret)
                 else:
@@ -157,7 +160,8 @@ class SaltClientJobResult(SaltClientResultBase):
                 self.fails[target] = _fails
 
         # TODO TESTS
-    def _get_state_fails(self, ret: Dict):
+    @staticmethod
+    def _get_state_fails(ret: Dict):
         fails = {}
         for task, tresult in ret.items():
             if not tresult['result']:
@@ -176,11 +180,11 @@ class SaltClientBase(ABC):
     @property
     @abstractmethod
     def _cmd_args_t(self) -> Type[SaltArgsBase]:
-        ...
+        """Return type of arguments."""
 
     @property
     def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
-        ...
+        """Return client result type."""
 
     def _build_cmd_args(
         self,
@@ -203,7 +207,7 @@ class SaltClientBase(ABC):
 
     @abstractmethod
     def _run(self, cmd_args: SaltArgsBase):
-        ...
+        """Do salt call with provided arguments."""
 
     def _parse_res(
         self, salt_res, cmd_args_view: Dict

--- a/api/python/provisioner/salt_api/base.py
+++ b/api/python/provisioner/salt_api/base.py
@@ -1,0 +1,292 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from abc import ABC, abstractmethod
+from typing import (
+    List, Union, Dict, Tuple, Any, Type
+)
+import logging
+
+from ..vendor import attr
+from ..config import (
+   SECRET_MASK
+)
+from ..errors import (
+    SaltNoReturnError,
+    SaltCmdRunError, SaltCmdResultError
+)
+
+logger = logging.getLogger(__name__)
+
+
+# TODO TEST
+@attr.s(auto_attribs=True)
+class SaltArgsBase:
+    _prvsnr_type_ = True
+
+    fun: str = attr.ib(converter=str)
+    fun_args: Tuple = attr.ib(
+        converter=lambda v: () if v is None else v, default=None
+    )
+    fun_kwargs: Dict = attr.ib(
+        converter=lambda v: {} if v is None else v, default=None
+    )
+    kw: Dict = attr.Factory(dict)
+    secure: bool = False
+
+    @property
+    def args(self):
+        return (self.fun,)
+
+    @property
+    def kwargs(self):
+        # FIXME check why 'arg' key is used here
+        #       (looks like some client specific)
+        return dict(arg=self.fun_args, kwarg=self.fun_kwargs, **self.kw)
+
+    def __str__(self):
+        _dct = self._as_dict()
+        _self_safe = type(self)(**_dct)
+        return str(attr.asdict(_self_safe))
+
+    def _as_dict(self):
+        _dct = attr.asdict(self)
+        if 'password' in _dct['kw']:
+            _dct['kw']['password'] = SECRET_MASK
+
+        if 'password' in _dct['fun_kwargs']:
+            _dct['fun_kwargs']['password'] = SECRET_MASK
+
+        # we do not mask the 'kw' more since
+        # it should include only salt related parameters
+        # that are safe to show
+        if self.secure:
+            _dct['fun_args'] = SECRET_MASK
+            _dct['fun_kwargs'] = SECRET_MASK
+
+        return _dct
+
+
+@attr.s(auto_attribs=True)
+class SaltClientResultBase:
+    _prvsnr_type_ = True
+
+    raw: Any
+    cmd_args_view: Dict
+    results: Any = attr.ib(init=False, default=attr.Factory(dict))
+    fails: Any = attr.ib(init=False, default=attr.Factory(dict))
+
+
+@attr.s(auto_attribs=True)
+class SaltClientJIDResult(SaltClientResultBase):
+
+    def __attrs_post_init__(self):
+        if not isinstance(self.raw, str):
+            self.fails = (
+                'not a valid salt job ID value type: {type(self.raw)}'
+            )
+
+        try:
+            self.results = int(self.raw)
+        except ValueError:
+            self.fails = (
+                'not a valid salt job ID value: {self.raw}'
+            )
+
+
+@attr.s(auto_attribs=True)
+class SaltClientJobResult(SaltClientResultBase):
+
+    def __attrs_post_init__(self):
+        # TODO is it a valid case actually ?
+        if type(self.raw) is not dict:
+            self.results = self.raw
+        else:
+            try:
+                self._parse_raw_dict()
+            except Exception as exc:
+                self.results = self.raw
+                self.fails = str(exc)
+
+    def _parse_raw_dict(self):
+        # TODO HARDEN check format of result
+        for target, job_result in self.raw.items():
+            ret = None
+            if type(job_result) is dict:
+                # result format as a part of job differs (async result) from
+                # sync case:
+                #   - 'ret' for sync
+                #   - 'return' for async
+                ret = job_result.get('ret', job_result.get('return'))
+            elif job_result is False:
+                # TODO IMPROVE explore salt docs/code for that,
+                #      currently it's only an observation
+                self.fails[target] = 'no connection to minion'
+
+            if ret is None:
+                self.results[target] = job_result
+                continue
+            else:
+                self.results[target] = ret
+
+            _fails = {}
+            if job_result.get('retcode') != 0:
+                if (
+                    self.cmd_args_view['fun'].startswith('state.')
+                    and (type(ret) is dict)
+                ):
+                    _fails = self._get_state_fails(ret)
+                else:
+                    _fails = ret
+
+            if _fails:
+                self.fails[target] = _fails
+
+        # TODO TESTS
+    def _get_state_fails(self, ret: Dict):
+        fails = {}
+        for task, tresult in ret.items():
+            if not tresult['result']:
+                fails[task] = {
+                    'comment': tresult.get('comment'),
+                    'changes': tresult.get('changes')
+                }
+        return fails
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltClientBase(ABC):
+    c_path: str = None
+
+    @property
+    @abstractmethod
+    def _cmd_args_t(self) -> Type[SaltArgsBase]:
+        ...
+
+    @property
+    def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
+        ...
+
+    def _build_cmd_args(
+        self,
+        fun: str,
+        fun_args: Union[Tuple, None] = None,
+        fun_kwargs: Union[Dict, None] = None,
+        secure=False,
+        **kwargs
+    ) -> SaltArgsBase:
+
+        _kwargs = {
+            k: kwargs.pop(k) for k in list(kwargs)
+            if k in attr.fields_dict(self._cmd_args_t)
+        }
+
+        return self._cmd_args_t(
+            fun, fun_args=fun_args, fun_kwargs=fun_kwargs,
+            kw=kwargs, secure=secure, **_kwargs
+        )
+
+    @abstractmethod
+    def _run(self, cmd_args: SaltArgsBase):
+        ...
+
+    def _parse_res(
+        self, salt_res, cmd_args_view: Dict
+    ) -> SaltClientResultBase:
+        return self._salt_client_res_t(salt_res, cmd_args_view)
+
+    # TODO LOGGING ??? better logging coverage
+    def run(
+        self,
+        fun: str,
+        fun_args: Union[Tuple, None] = None,
+        fun_kwargs: Union[Dict, None] = None,
+        secure=False,
+        **kwargs
+    ):
+        # XXX Caller for local minion commands works not smoothly,
+        #     issues with ioloop, possibly related one
+        #     https://github.com/saltstack/salt/issues/46905
+        # return _salt_caller_cmd(fun, *args, **kwargs)
+
+        # TODO log username / password ??? / eauth
+        cmd_args = self._build_cmd_args(
+            fun, fun_args, fun_kwargs, secure, **kwargs
+        )
+
+        # TODO IMPROVE EOS-14361 make a View class instead
+        cmd_args_view = cmd_args._as_dict()
+
+        logger.debug(
+            f"'{type(self)}' client: Running function '{fun}' "
+            f"with args: {cmd_args}"
+        )
+
+        try:
+            salt_res = self._run(cmd_args)
+        except Exception as exc:
+            # TODO too generic
+            raise SaltCmdRunError(cmd_args_view, repr(exc)) from exc
+
+        if not salt_res:
+            raise SaltNoReturnError(
+                cmd_args_view, 'Empty salt result: {}'.format(salt_res)
+            )
+
+        res = self._parse_res(salt_res, cmd_args_view)
+
+        if res.fails:
+            raise SaltCmdResultError(cmd_args_view, res.fails)
+
+        try:
+            logger.debug(
+                f"'{type(self)}' client: Function '{fun}' resulted in "
+                f"{res.results}"
+            )
+        except Exception as exc:
+            if (type(exc).__name__ == 'OSError' and exc.strerror == 'Message too long'):  # noqa: E501
+                logger.exception("Exception Skipped: {}".format(str(exc.strerror)))  # noqa: E501
+            else:
+                raise exc
+
+        return res.results
+
+    def _fun_fun(
+        self,
+        fun,
+        fun_fun: str,
+        fun_args: Union[List, Tuple, None] = None,
+        **kwargs
+    ):
+        return self.run(
+            fun,
+            fun_args=[fun_fun] + list(fun_args or []),
+            **kwargs
+        )
+
+    def state_apply(self, state: str, **kwargs):
+        return self.fun_fun('state.apply', state, **kwargs)
+
+    def cmd_run(self, cmd: str, **kwargs):
+        return self.fun_fun('cmd.run', cmd, **kwargs)
+
+    def state_single(self, state_fun: str, **kwargs):
+        return self.fun_fun('state.single', state_fun, **kwargs)
+
+    def pillar_get(self, **kwargs):
+        return self.run('pillar.items', **kwargs)

--- a/api/python/provisioner/salt_api/caller.py
+++ b/api/python/provisioner/salt_api/caller.py
@@ -1,0 +1,175 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import salt.config
+from salt.client import Caller
+from typing import (
+    Dict, Type
+)
+import logging
+
+from .. import inputs
+from ..vendor import attr
+
+from .base import (
+    SaltArgsBase,
+    SaltClientResultBase
+)
+from .base import (
+    SaltClientJobResult,
+    SaltClientBase
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+_salt_caller = None
+_salt_caller_local = None
+_local_minion_id = None
+
+
+# XXX Caller for local minion commands works not smoothly,
+#     issues with ioloop, possibly related one
+#     https://github.com/saltstack/salt/issues/46905
+def salt_caller():
+    global _salt_caller
+    if not _salt_caller:
+        __opts__ = salt.config.minion_config('/etc/salt/minion')
+        _salt_caller = Caller(mopts=__opts__)
+    return _salt_caller
+
+
+def salt_caller_local():
+    global _salt_caller_local
+    # FIXME EOS-14233 by some reason pillar.item result are not updated
+    #       for old handlers even if refresh step is called
+    if not _salt_caller_local or True:
+        __opts__ = salt.config.minion_config('/etc/salt/minion')
+        __opts__['file_client'] = 'local'
+        _salt_caller_local = Caller(mopts=__opts__)
+    return _salt_caller_local
+
+
+@attr.s(auto_attribs=True)
+class SaltCallerArgs(SaltArgsBase):
+    @property
+    def args(self):
+        return (self.fun, *self.fun_args)
+
+    @property
+    def kwargs(self):
+        return self.fun_kwargs
+
+
+@attr.s(auto_attribs=True)
+class SaltCallerClientResult(SaltClientJobResult):
+    client: Caller
+
+    def __attrs_post_init__(self):
+        self.raw = {
+            'local': {
+                'ret': self.raw,
+                # XXX not declared salt internals, no other way to
+                #     detect a failure
+                'retcode': self.client.sminion.functions.pack[
+                    '__context__'].get('retcode', 0)
+            }
+        }
+        super().__attrs_post_init__()
+
+    def _parse_raw_dict(self):
+        ret = self.raw['local']['ret']
+
+        if (
+            self.cmd_args_view['fun'].startswith('state.')
+            and (type(ret) is dict)
+        ):
+            self.results['local'] = ret
+
+            _fails = self._get_state_fails(ret)
+            if _fails:
+                self.fails['local'] = _fails
+        else:
+            super()._parse_raw_dict()
+
+
+@attr.s(auto_attribs=True)
+class SaltCallerClientBase(SaltClientBase):
+    c_path: str = attr.ib(
+        default='/etc/salt/minion',
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "config path"
+            }
+        }
+    )
+
+    shared: bool = False
+    _local: bool = True
+
+    _client: Caller = attr.ib(init=False, default=None)
+
+    def __attrs_post_init__(self):
+        if self.shared:
+            if self._local:
+                self._client = salt_caller_local()
+            else:
+                self._client = salt_caller()
+        else:
+            __opts__ = salt.config.minion_config(str(self.c_path))
+            if self._local:
+                __opts__['file_client'] = 'local'
+            self._client = Caller(mopts=__opts__)
+
+    @property
+    def _cmd_args_t(self) -> Type[SaltArgsBase]:
+        return SaltCallerArgs
+
+    @property
+    def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
+        return SaltCallerClientResult
+
+    def _run(self, cmd_args: SaltArgsBase):
+        # FIXME
+        return self._client.cmd(*cmd_args.args, **cmd_args.kwargs)
+
+    def _parse_res(
+        self, salt_res, cmd_args_view: Dict
+    ) -> SaltClientResultBase:
+        return self._salt_client_res_t(
+            salt_res, cmd_args_view, self._client
+        )
+
+
+@attr.s(auto_attribs=True)
+class SaltLocalCallerClient(SaltCallerClientBase):
+    _local: bool = attr.ib(init=False, default=True)
+
+
+@attr.s(auto_attribs=True)
+class SaltCallerClient(SaltCallerClientBase):
+    _local: bool = attr.ib(init=False, default=False)
+
+
+def local_minion_id():
+    global _local_minion_id
+    if not _local_minion_id:
+        _local_minion_id = SaltLocalCallerClient.run(
+            'grains.get', fun_args=['id']
+        )['local']
+    return _local_minion_id

--- a/api/python/provisioner/salt_api/caller.py
+++ b/api/python/provisioner/salt_api/caller.py
@@ -81,6 +81,7 @@ class SaltCallerClientResult(SaltClientJobResult):
     client: Caller
 
     def __attrs_post_init__(self):
+        """Do post init."""
         self.raw = {
             'local': {
                 'ret': self.raw,
@@ -97,7 +98,7 @@ class SaltCallerClientResult(SaltClientJobResult):
 
         if (
             self.cmd_args_view['fun'].startswith('state.')
-            and (type(ret) is dict)
+            and isinstance(ret, dict)
         ):
             self.results['local'] = ret
 
@@ -125,6 +126,7 @@ class SaltCallerClientBase(SaltClientBase):
     _client: Caller = attr.ib(init=False, default=None)
 
     def __attrs_post_init__(self):
+        """Do post init."""
         if self.shared:
             if self._local:
                 self._client = salt_caller_local()
@@ -169,7 +171,7 @@ class SaltCallerClient(SaltCallerClientBase):
 def local_minion_id():
     global _local_minion_id
     if not _local_minion_id:
-        _local_minion_id = SaltLocalCallerClient.run(
+        _local_minion_id = SaltLocalCallerClient().run(
             'grains.get', fun_args=['id']
         )['local']
     return _local_minion_id

--- a/api/python/provisioner/salt_api/client.py
+++ b/api/python/provisioner/salt_api/client.py
@@ -1,0 +1,158 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from salt.client import LocalClient
+from typing import (
+    Dict, Type, Union, Tuple
+)
+import logging
+
+from .. import inputs
+from ..vendor import attr
+from ..config import (
+   ALL_MINIONS, LOCAL_MINION
+)
+# from ..commands._basic import RunArgs
+
+from .caller import local_minion_id
+from .base import (
+    SaltArgsBase,
+    SaltClientBase,
+    SaltClientResultBase,
+    SaltClientJobResult,
+    SaltClientJIDResult
+)
+from .auth import _set_auth
+
+logger = logging.getLogger(__name__)
+
+_salt_local_client = None
+
+
+def salt_local_client():
+    global _salt_local_client
+    # TODO IMPROVE in case of minion retsart old handler will
+    #      lead to Authentication error, so always recreate it
+    #      as a workaround for now
+    if not _salt_local_client or True:
+        _salt_local_client = LocalClient()
+    return _salt_local_client
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltLocalClientArgs(SaltArgsBase):
+    targets: str = attr.ib(
+        converter=(
+            lambda v: local_minion_id() if v == LOCAL_MINION else str(v)
+        ),
+        default=ALL_MINIONS
+    )
+
+    @property
+    def args(self):
+        return (self.targets, self.fun)
+
+
+@attr.s(auto_attribs=True)
+class SaltLocalClientResult(SaltClientJobResult):
+    pass
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltLocalClient(SaltClientBase):
+    c_path: str = attr.ib(
+        default='/etc/salt/master',
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "config path"
+            }
+        }
+    )
+    # targets: str = RunArgs.targets
+    targets: str = attr.ib(
+        default=ALL_MINIONS,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "command's host targets"
+            }
+        }
+    )
+
+    shared: bool = False
+
+    _client: LocalClient = attr.ib(init=False, default=None)
+
+    def __attrs_post_init__(self):
+        if self.shared:
+            self._client = salt_local_client()
+        else:
+            self._client = LocalClient(c_path=str(self.c_path))
+
+    @property
+    def _cmd_args_t(self) -> Type[SaltArgsBase]:
+        return SaltLocalClientArgs
+
+    @property
+    def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
+        return SaltLocalClientResult
+
+    def _build_cmd_args(
+        self,
+        fun: str,
+        fun_args: Union[Tuple, None] = None,
+        fun_kwargs: Union[Dict, None] = None,
+        secure=False,
+        **kwargs
+    ) -> SaltArgsBase:
+
+        cmd_args = super()._build_cmd_args(
+            fun, fun_args, fun_kwargs, secure, **kwargs
+        )
+
+        _set_auth(cmd_args.kw)
+        cmd_args.kw['full_return'] = True
+
+        return cmd_args
+
+    def _run(self, cmd_args: SaltArgsBase):
+        return self._client.cmd(*cmd_args.args, **cmd_args.kwargs)
+
+    def run(
+        self,
+        fun: str,
+        fun_args: Union[Tuple, None] = None,
+        fun_kwargs: Union[Dict, None] = None,
+        secure=False,
+        **kwargs
+    ):
+        targets = kwargs.pop('targets', self.targets)
+        if targets:
+            kwargs['targets'] = targets
+
+        return super().run(fun, fun_args, fun_kwargs, secure, **kwargs)
+
+
+@attr.s(auto_attribs=True)
+class SaltLocalAsyncClient(SaltLocalClient):
+    @property
+    def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
+        return SaltClientJIDResult
+
+    def _run(self, cmd_args: SaltArgsBase):
+        return self._client.cmd_async(*cmd_args.args, **cmd_args.kwargs)

--- a/api/python/provisioner/salt_api/client.py
+++ b/api/python/provisioner/salt_api/client.py
@@ -99,6 +99,7 @@ class SaltLocalClient(SaltClientBase):
     _client: LocalClient = attr.ib(init=False, default=None)
 
     def __attrs_post_init__(self):
+        """Do post init."""
         if self.shared:
             self._client = salt_local_client()
         else:

--- a/api/python/provisioner/salt_api/runner.py
+++ b/api/python/provisioner/salt_api/runner.py
@@ -1,0 +1,215 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import salt.config
+from salt.runner import RunnerClient
+from typing import (
+    List, Dict, Any, Type, Union, Tuple
+)
+import logging
+
+from .. import inputs
+from ..vendor import attr
+
+from .base import (
+    SaltArgsBase,
+    SaltClientBase,
+    SaltClientResultBase,
+    SaltClientJIDResult
+)
+from .auth import _set_auth
+
+logger = logging.getLogger(__name__)
+
+
+_salt_runner_client = None
+
+
+def salt_runner_client():
+    global _salt_runner_client
+    if not _salt_runner_client:
+        __opts__ = salt.config.client_config('/etc/salt/master')
+        _salt_runner_client = RunnerClient(opts=__opts__)
+    return _salt_runner_client
+
+
+# TODO TEST
+@attr.s(auto_attribs=True)
+class SaltRunnerClientArgs(SaltArgsBase):
+    pass
+
+
+# TODO TEST
+# TODO IMPROVE EOS-14361 optionally mask fun_args
+@attr.s(auto_attribs=True)
+class SaltRunnerSchemaResult:
+    _prvsnr_type_ = True
+
+    jid: str
+    fun: str
+    success: bool
+    result: Any
+    stamp: str = ''
+    user: str = ''
+    fun_args: List = attr.Factory(list)
+
+    @classmethod
+    def from_salt_res(cls, data: Dict):
+        _data = {
+            k.lower().replace('-', '_').lstrip('_'): v for k, v in data.items()
+            if k != 'return'
+        }
+        if 'return' in data:
+            _data['result'] = data['return']
+        return cls(**_data)
+
+
+# TODO TYPE
+# TODO TEST
+@attr.s(auto_attribs=True)
+class SaltRunnerClientResult(SaltClientResultBase):
+
+    def __attrs_post_init__(self):
+        if type(self.raw) is not dict:
+            self.fails = (
+                "RunnerClient result type is not a dictionary: "
+                f"{type(self.raw)}"
+            )
+        else:
+            res = self.raw
+
+            if 'username' in self.cmd_args_view['kw']:
+                try:
+                    res = self.raw['data']
+                except KeyError:
+                    # TODO IMPROVE EOS-14361 raw result might disclosure
+                    #      the secrets from cmd args
+                    self.fails = (
+                        "no data key in RunnerClient result dictionary: "
+                        f"{self.raw}"
+                    )
+                    return
+
+            try:
+                res = SaltRunnerSchemaResult.from_salt_res(res)
+            except TypeError:
+                # TODO IMPROVE EOS-14361 raw result might disclosure
+                #      the secrets from cmd args
+                res.fails = (
+                    "Failed to parse salt runner result: "
+                    f"{self.raw}"
+                )
+            else:
+                self.results = res.result
+                if not res.success:
+                    self.fails = self.results
+
+
+@attr.s(auto_attribs=True)
+class SaltRunnerClient(SaltClientBase):
+    c_path: str = attr.ib(
+        default='/etc/salt/master',
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "config path"
+            }
+        }
+    )
+    shared: bool = False
+
+    _client: RunnerClient = attr.ib(init=False, default=None)
+
+    def __attrs_post_init__(self):
+        if self.shared:
+            self._client = salt_runner_client()
+        else:
+            __opts__ = salt.config.client_config(str(self.c_path))
+            self._client = RunnerClient(opts=__opts__)
+
+    @property
+    def _cmd_args_t(self) -> Type[SaltArgsBase]:
+        return SaltRunnerClientArgs
+
+    @property
+    def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
+        return SaltRunnerClientResult
+
+    def _build_cmd_args(
+        self,
+        fun: str,
+        fun_args: Union[Tuple, None] = None,
+        fun_kwargs: Union[Dict, None] = None,
+        secure=False,
+        **kwargs
+    ) -> SaltArgsBase:
+
+        cmd_args = super()._build_cmd_args(
+            fun, fun_args, fun_kwargs, secure, **kwargs
+        )
+
+        _set_auth(cmd_args.kw)
+
+        if 'username' not in cmd_args.kw:
+            cmd_args.kw['print_event'] = False
+            cmd_args.kw['full_return'] = True
+
+        return cmd_args
+
+    def _run(self, cmd_args: SaltArgsBase):
+        if 'username' in cmd_args.kw:
+            low = dict(fun=cmd_args.fun, **cmd_args.kwargs)
+            return self._client.cmd_sync(low, full_return=True)
+        else:
+            return self._client.cmd(*cmd_args.args, **cmd_args.kwargs)
+
+
+@attr.s(auto_attribs=True)
+class SaltRunnerAsyncClient(SaltRunnerClient):
+
+    def __attrs_post_init__(self):
+        raise NotImplementedError(
+            'async calls for RunnerClient are not supported yet'
+        )
+
+    @property
+    def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
+        return SaltClientJIDResult
+
+    def _build_cmd_args(
+        self,
+        fun: str,
+        fun_args: Union[Tuple, None] = None,
+        fun_kwargs: Union[Dict, None] = None,
+        secure=False,
+        **kwargs
+    ) -> SaltArgsBase:
+
+        cmd_args = super()._build_cmd_args(
+            fun, fun_args, fun_kwargs, secure, **kwargs
+        )
+
+        if 'username' not in cmd_args.kw:
+            raise NotImplementedError(
+                'async calls without external auth for RunnerClient'
+                ' are not supported yet'
+            )
+
+        return cmd_args
+
+    def _run(self, cmd_args: SaltArgsBase):
+        low = dict(fun=cmd_args.fun, **cmd_args.kwargs)
+        return salt_runner_client().cmd_async(low, full_return=True)

--- a/api/python/provisioner/salt_api/runner.py
+++ b/api/python/provisioner/salt_api/runner.py
@@ -84,7 +84,8 @@ class SaltRunnerSchemaResult:
 class SaltRunnerClientResult(SaltClientResultBase):
 
     def __attrs_post_init__(self):
-        if type(self.raw) is not dict:
+        """Do post init."""
+        if not isinstance(self.raw, dict):
             self.fails = (
                 "RunnerClient result type is not a dictionary: "
                 f"{type(self.raw)}"
@@ -134,6 +135,7 @@ class SaltRunnerClient(SaltClientBase):
     _client: RunnerClient = attr.ib(init=False, default=None)
 
     def __attrs_post_init__(self):
+        """Do post init."""
         if self.shared:
             self._client = salt_runner_client()
         else:
@@ -181,6 +183,7 @@ class SaltRunnerClient(SaltClientBase):
 class SaltRunnerAsyncClient(SaltRunnerClient):
 
     def __attrs_post_init__(self):
+        """Do post init."""
         raise NotImplementedError(
             'async calls for RunnerClient are not supported yet'
         )

--- a/api/python/provisioner/salt_api/ssh.py
+++ b/api/python/provisioner/salt_api/ssh.py
@@ -83,6 +83,7 @@ class SaltSSHRawResultSchema(SaltSSHResultSchemaBase):
     other: Dict = attr.ib(init=False, default=attr.Factory(dict))
 
     def __attrs_post_init__(self):
+        """Do post init."""
         self._result = self.raw
 
 
@@ -94,6 +95,7 @@ class SaltSSHSimpleResultSchema(SaltSSHResultSchemaBase):
     stdout: str
 
     def __attrs_post_init__(self):
+        """Do post init."""
         self._result = self.stdout
         if self.retcode:
             self._fail = f'STDERR: {self.stderr}, STDOUT: {self.stdout}'
@@ -109,11 +111,12 @@ class SaltSSHJobResultSchema(SaltSSHResultSchemaBase):
     jresult: Any
 
     def __attrs_post_init__(self):
+        """Do post init."""
         self._result = self.jresult
 
         # TODO IMPROVE better error presentation
         if self.retcode or (
-            type(self._result) is dict and
+            isinstance(self._result, dict) and
             self._result.get('retcode')
         ):
             self._fail = self._result
@@ -124,12 +127,14 @@ class SaltSSHJobResultSchema(SaltSSHResultSchemaBase):
 class SaltSSHStateJobResultSchema(SaltSSHJobResultSchema):
 
     def __attrs_post_init__(self):
+        """Do post init."""
         self._result, _fail = self._get_state_results(self.jresult)
         if _fail:
             self._fail = _fail
 
     # TODO IMPROVE EOS-8473
-    def _get_state_results(self, ret: Dict):
+    @staticmethod
+    def _get_state_results(ret: Dict):
         results = {}
         fails = {}
         for task, tresult in ret.items():
@@ -165,7 +170,7 @@ class SaltSSHResultParser:
 
     @classmethod
     def from_salt_res(cls, data: Any, cmd_args_view: Dict):
-        if type(data) is dict:
+        if isinstance(data, dict):
             _data = {cls._sanitize_key(k): v for k, v in data.items()}
             _types = [
                 SaltSSHSimpleResultSchema,
@@ -252,20 +257,20 @@ class SaltSSHClient(SaltClientBase):
     _def_roster_data: Dict = attr.ib(init=False, default=attr.Factory(dict))
 
     def __attrs_post_init__(self):
+        """Do post init."""
         self._client = SSHClient(c_path=str(self.c_path))
-        '''
-        if self.roster_file is None:
-            path = USER_SHARED_PILLAR.all_hosts_path(
-                'roster.sls'
-            )
-            if not path.exists():
-                path = GLUSTERFS_VOLUME_PILLAR_DIR.all_hosts_path(
-                    'roster.sls'
-                )
 
-            if path.exists():
-                self.roster_file = path
-        '''
+        # if self.roster_file is None:
+        #     path = USER_SHARED_PILLAR.all_hosts_path(
+        #         'roster.sls'
+        #     )
+        #     if not path.exists():
+        #        path = GLUSTERFS_VOLUME_PILLAR_DIR.all_hosts_path(
+        #            'roster.sls'
+        #        )
+
+        #    if path.exists():
+        #        self.roster_file = path
 
         if self.roster_file:
             logger.debug(f'default roster is set to {self.roster_file}')

--- a/api/python/provisioner/salt_api/ssh.py
+++ b/api/python/provisioner/salt_api/ssh.py
@@ -1,0 +1,449 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from abc import ABC
+from typing import (
+    List, Dict, Any, Type, Optional, Union, Tuple
+)
+from salt.client.ssh.client import SSHClient
+from pathlib import Path
+import logging
+
+from .. import inputs, config
+from ..vendor import attr
+from ..ssh import copy_id
+from ..utils import load_yaml
+from ..errors import (
+    SaltCmdResultError
+)
+# from ..paths import (
+#     USER_SHARED_PILLAR,
+#    GLUSTERFS_VOLUME_PILLAR_DIR
+# )
+from ..cli_parser import KeyValueListAction
+# from ..commands._basic import RunArgs
+
+from .base import (
+    SaltArgsBase,
+    SaltClientBase,
+    SaltClientResultBase,
+    SaltClientJobResult
+)
+from .client import (
+    SaltLocalClientArgs
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHArgs(SaltLocalClientArgs):
+    pass
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHResultSchemaBase(ABC):
+    _prvsnr_type_ = True
+    raw: Any
+    # some not tracked fields
+    other: Dict
+
+    _result: Any = attr.ib(init=False, default=None)
+    _fail: Any = attr.ib(init=False, default=None)
+
+    @property
+    def result(self):
+        return self._result
+
+    @property
+    def fail(self):
+        return self._fail
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHRawResultSchema(SaltSSHResultSchemaBase):
+    other: Dict = attr.ib(init=False, default=attr.Factory(dict))
+
+    def __attrs_post_init__(self):
+        self._result = self.raw
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHSimpleResultSchema(SaltSSHResultSchemaBase):
+    retcode: int
+    stderr: str
+    stdout: str
+
+    def __attrs_post_init__(self):
+        self._result = self.stdout
+        if self.retcode:
+            self._fail = f'STDERR: {self.stderr}, STDOUT: {self.stdout}'
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHJobResultSchema(SaltSSHResultSchemaBase):
+    retcode: int
+    jid: str
+    fun: str
+    fun_args: List
+    jresult: Any
+
+    def __attrs_post_init__(self):
+        self._result = self.jresult
+
+        # TODO IMPROVE better error presentation
+        if self.retcode or (
+            type(self._result) is dict and
+            self._result.get('retcode')
+        ):
+            self._fail = self._result
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHStateJobResultSchema(SaltSSHJobResultSchema):
+
+    def __attrs_post_init__(self):
+        self._result, _fail = self._get_state_results(self.jresult)
+        if _fail:
+            self._fail = _fail
+
+    # TODO IMPROVE EOS-8473
+    def _get_state_results(self, ret: Dict):
+        results = {}
+        fails = {}
+        for task, tresult in ret.items():
+            _dict = results if tresult['result'] else fails
+            _dict[task] = {
+                'comment': tresult.get('comment'),
+                'changes': tresult.get('changes')
+            }
+        return results, fails
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHResultParser:
+
+    @classmethod
+    def _sanitize_key(cls, key):
+        return (
+            'jresult' if key == 'return' else
+            key.lower().replace('-', '_').lstrip('_')
+        )
+
+    @classmethod
+    def _verify(cls, res_t: Type[SaltSSHResultSchemaBase], data: Dict) -> bool:
+        required = [
+            k for k, v in attr.fields_dict(res_t).items()
+            if (
+                v.default is attr.NOTHING and
+                k not in attr.fields_dict(SaltSSHResultSchemaBase)
+            )
+        ]
+        return not (set(required) - set(data))
+
+    @classmethod
+    def from_salt_res(cls, data: Any, cmd_args_view: Dict):
+        if type(data) is dict:
+            _data = {cls._sanitize_key(k): v for k, v in data.items()}
+            _types = [
+                SaltSSHSimpleResultSchema,
+                (
+                    SaltSSHStateJobResultSchema
+                    if cmd_args_view['fun'].startswith('state.')
+                    else SaltSSHJobResultSchema
+                )
+            ]
+            for res_t in _types:
+                if cls._verify(res_t, _data):
+                    # TODO IMPROVE EOS-8473 makes sense
+                    #      to place non-sanitized fields into other
+                    other = {
+                        k: _data.pop(k) for k in list(_data)
+                        if (
+                            k not in attr.fields_dict(res_t) or
+                            k in attr.fields_dict(SaltSSHResultSchemaBase)
+                        )
+                    }
+                    return res_t(data, other=other, **_data)
+
+        return SaltSSHRawResultSchema(data)
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHClientResult(SaltClientJobResult):
+    def _parse_raw_dict(self):
+        for target, job_result in self.raw.items():
+            ssh_res = SaltSSHResultParser.from_salt_res(
+                job_result, self.cmd_args_view
+            )
+            self.results[target] = ssh_res.result
+            if ssh_res.fail is not None:
+                self.fails[target] = ssh_res.fail
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class SaltSSHClient(SaltClientBase):
+    c_path: str = attr.ib(
+        default='/etc/salt/master',
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "config path"
+            }
+        }
+    )
+    roster_file: str = attr.ib(
+        default=config.SALT_ROSTER_DEFAULT,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "path to roster file"
+            }
+        }
+    )
+    ssh_options: Optional[Dict] = attr.ib(
+        default=attr.Factory(
+            lambda: [
+                'UserKnownHostsFile=/dev/null',
+                'StrictHostKeyChecking=no'
+            ]
+        ),
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "ssh connection options",
+                'metavar': 'KEY=VALUE',
+                'nargs': '+',
+                'action': KeyValueListAction
+            }
+        }
+    )
+    # targets: str = RunArgs.targets
+    targets: str = attr.ib(
+        default=config.ALL_MINIONS,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "command's host targets"
+            }
+        }
+    )
+
+    _client: SSHClient = attr.ib(init=False, default=None)
+    _def_roster_data: Dict = attr.ib(init=False, default=attr.Factory(dict))
+
+    def __attrs_post_init__(self):
+        self._client = SSHClient(c_path=str(self.c_path))
+        '''
+        if self.roster_file is None:
+            path = USER_SHARED_PILLAR.all_hosts_path(
+                'roster.sls'
+            )
+            if not path.exists():
+                path = GLUSTERFS_VOLUME_PILLAR_DIR.all_hosts_path(
+                    'roster.sls'
+                )
+
+            if path.exists():
+                self.roster_file = path
+        '''
+
+        if self.roster_file:
+            logger.debug(f'default roster is set to {self.roster_file}')
+            self._def_roster_data = load_yaml(self.roster_file)
+
+    @property
+    def _cmd_args_t(self) -> Type[SaltArgsBase]:
+        return SaltSSHArgs
+
+    @property
+    def _salt_client_res_t(self) -> Type[SaltClientResultBase]:
+        return SaltSSHClientResult
+
+    def roster_data(self, roster_file=None):
+        if roster_file:
+            return load_yaml(roster_file)
+        else:
+            return self._def_roster_data
+
+    def roster_targets(self, roster_file=None):
+        return list(self.roster_data(roster_file))
+
+    def _run(self, cmd_args: SaltSSHArgs):
+        salt_logger = logging.getLogger('salt.client.ssh')
+        salt_log_level = None
+
+        if cmd_args.secure and salt_logger.isEnabledFor(logging.DEBUG):
+            salt_log_level = salt_logger.getEffectiveLevel()
+            salt_logger.setLevel(logging.INFO)
+
+        try:
+            return self._client.cmd(*cmd_args.args, **cmd_args.kwargs)
+        finally:
+            if salt_log_level is not None:
+                salt_logger.setLevel(salt_log_level)
+
+    def run(
+        self,
+        fun: str,
+        fun_args: Union[Tuple, None] = None,
+        fun_kwargs: Union[Dict, None] = None,
+        secure=False,
+        **kwargs
+    ):
+        for arg in ('roster_file', 'ssh_options', 'targets'):
+            arg_v = kwargs.pop(arg, getattr(self, arg))
+            if arg_v:
+                kwargs[arg] = (
+                    str(arg_v) if arg == 'roster_file' else arg_v
+                )
+
+        return super().run(fun, fun_args, fun_kwargs, secure, **kwargs)
+
+    # TODO TEST EOS-8473
+    def ensure_access(
+        self, targets: List, bootstrap_roster_file=None
+    ):
+        for target in targets:
+            try:
+                # try to reach using default (class-level) settings
+                self.run(
+                    'uname',
+                    targets=target,
+                    raw_shell=True
+                )
+            except SaltCmdResultError as exc:
+                reason = exc.reason.get(target)
+                roster_file = exc.cmd_args.get('kw').get('roster_file')
+
+                if roster_file and ('Permission denied' in reason):
+                    roster = load_yaml(roster_file)
+
+                    if bootstrap_roster_file:
+                        # NOTE assumptions:
+                        #   - python3 is already there since it can be
+                        #     installed using the bootstrap key
+                        #     (so salt modules might be used now)
+                        #   - bootstrap key is availble in salt-ssh file roots
+
+                        self.run(
+                            'state.single',
+                            fun_args=['file.directory'],
+                            fun_kwargs=dict(name='~/.ssh', mode=700),
+                            targets=target,
+                            roster_file=bootstrap_roster_file
+                        )
+
+                        # inject production access public key
+                        # FIXME hardcoded 'root'
+                        self.run(
+                            'state.single',
+                            fun_args=['ssh_auth.present'],
+                            fun_kwargs=dict(
+                                name=None,
+                                user=roster.get(target, {}).get(
+                                    'user', 'root'
+                                ),
+                                # FIXME hardcoded path to production pub key
+                                source="salt://provisioner/files/minions/all/id_rsa_prvsnr.pub"  # noqa: E501
+                            ),
+                            targets=target,
+                            roster_file=bootstrap_roster_file
+                        )
+                    else:
+                        copy_id(
+                            host=roster.get(target, {}).get('host'),
+                            user=roster.get(target, {}).get('user'),
+                            port=roster.get(target, {}).get('port'),
+                            priv_key_path=roster.get(target, {}).get('priv'),
+                            ssh_options=exc.cmd_args.get('kw').get(
+                                'ssh_options'
+                            ),
+                            force=True
+                        )
+                else:
+                    raise
+
+    # TODO TEST EOS-8473
+    def ensure_python3(
+        self,
+        targets: List,
+        roster_file=None
+    ):
+        for target in targets:
+            try:
+                self.run(
+                    'python3 --version',
+                    targets=target,
+                    roster_file=roster_file,
+                    raw_shell=True
+                )
+            except SaltCmdResultError as exc:
+                reason = exc.reason.get(target)
+                # TODO IMPROVE EOS-8473 better search string / regex
+                roster_file = exc.cmd_args.get('kw').get('roster_file')
+                if roster_file and ("not found" in reason):
+                    self.run(
+                        'yum install -y python3',
+                        targets=target,
+                        roster_file=roster_file,
+                        ssh_options=exc.cmd_args.get('kw').get('ssh_options'),
+                        raw_shell=True
+                    )
+                else:
+                    raise
+
+    # TODO TEST EOS-8473
+    def ensure_ready(
+            self, targets: List, bootstrap_roster_file: Optional[Path] = None,
+    ):
+        if bootstrap_roster_file:
+            self.ensure_python3(targets, roster_file=bootstrap_roster_file)
+
+        self.ensure_access(
+            targets,
+            bootstrap_roster_file=bootstrap_roster_file
+        )
+
+        if not bootstrap_roster_file:
+            self.ensure_python3(targets)
+
+    # FIXME issues:
+    #   1. not properly processed error, e.g.:
+    #
+    #        self.run(
+    #            'state.single',
+    #            fun_args=['ssh_auth.present'],
+    #            fun_kwargs=dict(
+    #                user=roster.get(target, {}).get(
+    #                    'user', 'root'
+    #                ),
+    #                source=f"{priv_file}.pub"
+    #            ),
+    #            targets=target,
+    #            roster_file=bootstrap_roster_file
+    #        )
+    #
+    #        will return with success but salt actually error takes place:
+    #
+    #        TypeError encountered executing state.single: single() missing 1
+    #        required positional argument: 'name'


### PR DESCRIPTION
New provisioenr API command-wrapper over different salt client. Available as both python API and CLI.                                                                                                                                        
                                                                                                                                                                                                                                             
General goals:                                                                                                                                                                                                                               
- provide generic API over salt's ones
- make salt-ssh based operation as simple as others

### Usage

**As CLI**

`provisioner salt CLIENT FUN [--fun-args ARG ...] [--fun-kwargs ARG=VALUE ...]`

where 
- `CLIENT` is one of {salt|runner|caller|local|ssh}
- `FUN` is a Salt's fun (e.g. `test.ping`, `state.apply`, `jobs.list_jobs` ...) and depends on client type

please check `provisioner salt CLIENT --help` for more detiails

**As API**

each client is presented as a separate class that provides generic API, please refer the code for more details

**Note 1.**
Provisioner API wraps Salt's python API not CLI one.

**Note 2.**
salt-ssh by default uses `/etc/salt/master` and `/etc/salt/roster` for configuration and roster data accordingly.
So on a setup roster file should be prepared as yaml. Custom roster location might be passed as well

Example (usually it is very close to ~/.ssh/config):

   ```
    srvnode-1:
        host: <IP/domain>
        port: 22
        priv: /root/.ssh/id_rsa_prvsnr
        user: root
    srvnode-2:
        host: <IP/domain>
        port: 22
        priv: /root/.ssh/id_rsa_prvsnr
        user: root
   ```


Examples:

1. `cmd.run` command using different salt clients:
-   like salt:
    - `provisioner salt salt cmd.run --fun-args hostname --out json`
-   like salt-run:
    - `provisioner runner salt.cmd --fun-args cmd.run hostname --out json`
-   like salt-call:
    - `provisioner caller cmd.run --fun-args hostname --out json`
-   like salt-call --local:
    - `provisioner local cmd.run --fun-args hostname --out json`
-   like salt-ssh:
    - `provisioner ssh cmd.run --fun-args hostname --out json`

2. others
-  `provisioner salt runner jobs.list_jobs --out json`
-   `provisioner salt salt state.single --fun-args file.directory --fun-kwargs 'name=~/testdir' 'mode=700' --targets srvnode-1 --out json`