### PR TITLE
EOS-15665: Generate passwd for csm user

### DIFF
--- a/pillar/components/csm.sls
+++ b/pillar/components/csm.sls
@@ -1,0 +1,3 @@
+csm:
+  user: csm
+  secret:

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -24,6 +24,7 @@ base:
     - components.cluster                    # default all minions vars (here and below) TODO create task: move to groups.all.components...
     - components.commons
     - components.corosync-pacemaker
+    - components.csm
     - components.elasticsearch
     - components.motr
     - components.haproxy


### PR DESCRIPTION
Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>

Autogenerate password for csm user at the time of deployment.
A blank pillar entry with key secret/password is assigned a dynamically generated password string during deployment as its value.