### PR TITLE
EOS-14767-sms2: System maintenance page throws error "service status can't be checked as services are restarting"

### DIFF
--- a/cli/src/replace_node/deploy-replacement
+++ b/cli/src/replace_node/deploy-replacement
@@ -482,14 +482,14 @@ elif [[ -e ${flag_file_dir}/${tgt_node}.multipath
 
         prereq_states
 
-        iopath_states
-
-        controlpath_states
-
         sync_states
+
+        iopath_states
 
         ha_states
 
+        controlpath_states
+        
         restore_states
 
         add_node_states


### PR DESCRIPTION
Signed-off-by: Anjali Somwanshi anjali.somwanshi@seagate.com