### PR TITLE
[EOS-17445] destroy ha components on single node vm

### DIFF
--- a/cli/src/destroy
+++ b/cli/src/destroy
@@ -45,20 +45,17 @@ remove_system=false
 remove_prvsnr=false
 tgt_node=srvnode-2
 
-controlpath_states=(
-# states to be applied in desired sequence
-    "ha.ctrlstack-ha.teardown"
-    "csm.teardown"
-    "uds.teardown"
-    "sspl.teardown"
-)
-
 ha_states=(
-    "ha.iostack-ha.teardown"
-    "ha.cortx-ha.ha_cleanup"
     "ha.cortx-ha.teardown"
     "ha.corosync-pacemaker.teardown"
     "hare.teardown"
+)
+
+controlpath_states=(
+# states to be applied in desired sequence
+    "csm.teardown"
+    "uds.teardown"
+    "sspl.teardown"
 )
 
 iopath_states=(
@@ -163,31 +160,14 @@ function teardown_states {
         # TODO use salt orchestration
         for state in ${states[@]}; do
             l_info "Removing $state from node: "$tgt_node""
-            $cmd salt "$tgt_node" state.apply components.$state $salt_opts
+            $cmd salt "$tgt_node" state.apply components.$state $salt_opts || true
             sleep 2     # Mindfulness break
         done
     else
         for state in ${states[@]}; do
-            if [[ "$state" == "ha.iostack-ha" ]]; then
-                
-                l_info "Installing cortx-ha on both nodes"
-                $cmd salt "*" state.apply components.ha.cortx-ha.prepare  $salt_opts || true
-                $cmd salt "*" state.apply components.ha.cortx-ha.install  $salt_opts || true
-                sleep 2     # Mindfulness break
-
-                l_info "Removing $state from srvnode-1"
-                $cmd salt srvnode-1 state.apply components.$state  $salt_opts || true
-                sleep 2     # Mindfulness break
-                l_info "Removing $state from srvnode-2"
-                $cmd salt srvnode-2 state.apply components.$state  $salt_opts || true
-                sleep 2     # Mindfulness break
-
-                l_info "Removing cortx-ha on both nodes"
-                $cmd salt "*" state.apply components.ha.cortx-ha.teardown  $salt_opts || true
-                sleep 2     # Mindfulness break
-
-            elif [[ "$state" == "ha.corosync-pacemaker"
-                || "$state" == "sspl" ]]; then
+            if [[ "$state" == "ha.corosync-pacemaker.teardown"
+                || "$state" == "ha.cortx-ha.teardown"
+                || "$state" == "sspl.teardown" ]]; then
 
                 l_info "Removing $state from srvnode-1"
                 $cmd salt srvnode-1 state.apply components.$state  $salt_opts || true
@@ -196,9 +176,9 @@ function teardown_states {
                 $cmd salt srvnode-2 state.apply components.$state  $salt_opts || true
                 sleep 2     # Mindfulness break
             
-            elif [[ "$state" == "misc_pkgs.openldap"
-                || "$state" == "misc_pkgs.rabbitmq"
-                || "$state" == "system.storage.multipath" ]]; then
+            elif [[ "$state" == "misc_pkgs.openldap.teardown"
+                || "$state" == "misc_pkgs.rabbitmq.teardown"
+                || "$state" == "system.storage.multipath.teardown" ]]; then
                 
                 l_info "Removing $state from srvnode-2"
                 $cmd salt srvnode-2 state.apply components.$state  $salt_opts || true
@@ -246,9 +226,8 @@ salt_opts="--no-color --out-file=$LOG_FILE --out-file-append $salt_opts_dry_run"
 
 if [[ "$run_all" == true ]]; then
     ensure_cluster_in_maintenance
-
-    teardown_states "${controlpath_states[@]}"
     teardown_states "${ha_states[@]}"
+    teardown_states "${controlpath_states[@]}"
     teardown_states "${iopath_states[@]}"
     teardown_states "${prereq_states[@]}"
     teardown_states "${system_states[@]}"

--- a/cli/src/destroy-vm
+++ b/cli/src/destroy-vm
@@ -35,12 +35,17 @@ function trap_handler {
 } 
 
 run_all=true
+run_ha_states=false
 io_states=false
 ctrlpath_states=false
 remove_prereqs=false
 remove_system=false
 remove_prvsnr=false
 
+ha_states=(
+    "ha.cortx-ha"
+    "ha.corosync-pacemaker"
+)
 
 controlpath_states=(
 # states to be applied in desired sequence
@@ -92,6 +97,7 @@ General options:
 $base_options_usage
 Options:
        -S,  --singlenode     switch to single node mode setup
+       --ha-states           remove only ha states(cortx-ha, corosync-pacemaker)
        --iopath-states       remove only iopath (hare,s3server,motr,lustre) components
        --ctrlpath-states     remove only ctrlpath (uds,csm,sspl) components
        --remove-prvsnr       removes provisioner and system cleanup
@@ -106,6 +112,10 @@ function options_parser {
     case "$1" in
         -S|--singlenode)
             singlenode=true
+            ;;
+        --ha-states)
+            run_ha_states=true
+            run_all=false
             ;;
         --iopath-states)
             io_states=true
@@ -149,7 +159,7 @@ function teardown_states {
             $cmd salt srvnode-1 state.apply components.$state.teardown $salt_opts || true
             sleep 2     # Mindfulness break
         else
-            if [[ "$state" == "sspl" ]]; then
+            if [[ "$state" == "sspl" || "$state" == "ha.cortx-ha" ]]; then
                 l_info "Applying state $state from srvnode-1"
                 $cmd salt srvnode-1 state.apply components.$state.teardown  $salt_opts || true
                 sleep 2     # Mindfulness break
@@ -172,7 +182,7 @@ function teardown_states {
     done
 }
 
-parse_args 'S' 'singlenode,iopath-states,ctrlpath-states,remove-prvsnr,prereq-states,system-states' options_parser '' "$@"
+parse_args 'S' 'singlenode,ha-states,iopath-states,ctrlpath-states,remove-prvsnr,prereq-states,system-states' options_parser '' "$@"
 
 if [[ "$verbosity" -ge 2 ]]; then
     set -x
@@ -192,10 +202,16 @@ l_info "Updating salt pillar data"
 $cmd salt "*" saltutil.refresh_pillar
 
 if [[ "$run_all" == true ]]; then
+    teardown_states "${ha_states[@]}"
     teardown_states "${controlpath_states[@]}"
     teardown_states "${iopath_states[@]}"
     teardown_states "${prereq_states[@]}"
     teardown_states "${system_states[@]}"
+fi
+
+if [[ "$run_ha_states" == true ]]; then
+    l_info "Removing the ha sates group packages"
+    teardown_states "${ha_states[@]}"
 fi
 
 if [[ "$ctrlpath_states" == true ]]; then

--- a/srv/components/ha/corosync-pacemaker/teardown.sls
+++ b/srv/components/ha/corosync-pacemaker/teardown.sls
@@ -15,30 +15,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-{% set server_nodes = [ ] -%}
-{% for node in pillar['cluster'].keys() -%}
-{% if "srvnode-" in node -%}
-{% do server_nodes.append(node)-%}
-{% endif -%}
-{% endfor -%}
-{%- if "primary" in server_nodes %}
-Destroy resource ClusterIP:
-  cmd.run:
-    - name: pcs resource delete ClusterIP
-    - onlyif: pcs resource show ClusterIP
-
-Remove authorized nodes:
-  cmd.run:
-    - names:
-      {%- for node_id in server_nodes %}
-      - pcs cluster node remove {{ node_id }} --force || true
-      {%- endfor %}
-
-Destroy Cluster:
-  cmd.run:
-    - name: pcs cluster destroy --all --force || true
-{% endif %}
-
 Remove user and group:
   user.absent:
     - name: hacluster

--- a/srv/components/ha/cortx-ha/ha_cleanup.sls
+++ b/srv/components/ha/cortx-ha/ha_cleanup.sls
@@ -18,7 +18,7 @@
 {% if "primary" in pillar["cluster"][grains["id"]]["roles"] %}
 Run cortx-ha ha setup:
   cmd.run:
-    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup.yaml', 'ha:ha-cleanup')
+    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/ha/conf/setup.yaml', 'ha:cleanup')
 {% else %}
 No HA cleanup on secondary node:
   test.show_notification:


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

1.  In R1 we had ctrlstack-ha , iostack-ha and cortx-ha but in R2 we have only cortx-ha which will take care of complete pcs cluster.
2.  In R2 we have mini provisioner available at cortx-ha component to cleanup pcs cluster. provisioner need to call mini provisioner to cleanup.