### PR TITLE
[EOS-17836] Bootstrap cluster should not be part of provisioner

### DIFF
--- a/api/python/provisioner/commands/deploy_vm.py
+++ b/api/python/provisioner/commands/deploy_vm.py
@@ -190,13 +190,6 @@ class DeployVM(Deploy):
                 else:
                     self._apply_state(f"components.{state}", targets, stages)
 
-            if state == "hare":
-                logger.info("Bootstraping cluster")
-                self._cmd_run(
-                    "hctl bootstrap --mkfs /var/lib/hare/cluster.yaml",
-                    targets=self._primary_id()
-                )
-
     def run(self, **kwargs):  # noqa: C901
         run_args = self._run_args_type(**kwargs)
 


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

starting cortx-cluster:

`cortx cluster start`

will run by either from GUI or admin will run it.