### PR TITLE
[EOS-17823] Updated logic for getting nodes from pillar and need passwordless ssh…

### DIFF
--- a/api/python/provisioner/commands/auto_deploy.py
+++ b/api/python/provisioner/commands/auto_deploy.py
@@ -106,7 +106,13 @@ class AutoDeploy(SetupCmdBase, CommandParserFillerMixin):
             setup_ctx.ssh_client.cmd_run(
                 (
                     'salt-call state.apply '
-                    'components.system.config'
+                    'components.system.config.pillar_encrypt'
+                ), targets=setup_ctx.run_args.primary.minion_id
+            )
+            setup_ctx.ssh_client.cmd_run(
+                (
+                    'salt-call state.apply '
+                    'components.system.config.hosts'
                 )
             )
 

--- a/api/python/provisioner/commands/auto_deploy.py
+++ b/api/python/provisioner/commands/auto_deploy.py
@@ -106,8 +106,8 @@ class AutoDeploy(SetupCmdBase, CommandParserFillerMixin):
             setup_ctx.ssh_client.cmd_run(
                 (
                     'salt-call state.apply '
-                    'components.system.config.pillar_encrypt'
-                ), targets=setup_ctx.run_args.primary.minion_id
+                    'components.system.config'
+                )
             )
 
             # The ConfStore JSON is required to be generated on all nodes

--- a/api/python/provisioner/commands/check.py
+++ b/api/python/provisioner/commands/check.py
@@ -790,12 +790,7 @@ class Check(CommandParserFillerMixin):
             return check_value
 
         try:
-            # nodes = Check._get_pillar_data("cluster/node_list")
-            cluster_dict = Check._get_pillar_data("cluster")
-            nodes = [
-                node for node in cluster_dict.keys()
-                if 'srvnode-' in node
-            ]
+            nodes = Check._get_nodes_list()
         except Exception as exc:
             check_value.set_fail(checked_target=cfg.ALL_MINIONS,
                                  comment=str(exc))
@@ -838,7 +833,7 @@ class Check(CommandParserFillerMixin):
             return check_value
 
         try:
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
         except Exception as exc:
             check_value.set_fail(checked_target=cfg.ALL_MINIONS,
                                  comment=str(exc))
@@ -881,7 +876,7 @@ class Check(CommandParserFillerMixin):
             return res
 
         try:
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
 
             lun_args = [cfg.LUNS_MAPPED_CHECK] + nodes
             StorageV().validate('luns', lun_args)
@@ -913,7 +908,7 @@ class Check(CommandParserFillerMixin):
             return check_value
 
         try:
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
         except Exception as exc:
             check_value.set_fail(checked_target=cfg.ALL_MINIONS,
                                  comment=str(exc))
@@ -950,7 +945,7 @@ class Check(CommandParserFillerMixin):
             return res
 
         try:
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
             StorageV().validate('lvms', nodes)
         except Exception as exc:
             res.set_fail(checked_target=cfg.ALL_MINIONS,
@@ -1004,7 +999,7 @@ class Check(CommandParserFillerMixin):
 
         try:
             # Get node list
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
         except Exception as exc:
             check_entry.set_fail(checked_target=cfg.ALL_MINIONS,
                                  comment=str(exc))
@@ -1046,7 +1041,7 @@ class Check(CommandParserFillerMixin):
 
         try:
             # Get node list
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
         except Exception as exc:
             check_entry.set_fail(checked_target=cfg.ALL_MINIONS,
                                  comment=str(exc))
@@ -1108,7 +1103,7 @@ class Check(CommandParserFillerMixin):
 
         try:
             # Get node list
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
         except Exception as exc:
             check_entry.set_fail(checked_target=cfg.ALL_MINIONS,
                                  comment=str(exc))
@@ -1181,7 +1176,7 @@ class Check(CommandParserFillerMixin):
 
         try:
             # Get node list
-            nodes = Check._get_pillar_data("cluster/node_list")
+            nodes = Check._get_nodes_list()
         except Exception as exc:
             check_entry.set_fail(checked_target=cfg.ALL_MINIONS,
                                  comment=str(exc))
@@ -1228,6 +1223,15 @@ class Check(CommandParserFillerMixin):
             raise ValueError(f"value is not specified for {key}")
         else:
             return pillar[pillar_key]
+
+    @staticmethod
+    def _get_nodes_list():
+        """Retrieve node  list from pillar"""
+        nodes = []
+        for key in Check._get_pillar_data("cluster"):
+            if 'srvnode' in key:
+                nodes.append(key)
+        return nodes
 
     def run(self, check_name: str = "",
             check_args: str = "") -> CheckResult:

--- a/api/python/provisioner/srv/salt/ssh/check.sls
+++ b/api/python/provisioner/srv/salt/ssh/check.sls
@@ -18,11 +18,9 @@
 # TODO TEST EOS-8473
 
 {% for node_id, node in pillar['node_specs'].items() %}
-    {% if node_id != grains['id'] %}
 
 check_{{ node_id }}_reachable:
   cmd.run:
     - name: ssh -q -o "ConnectTimeout=5" {{ node_id }} exit
 
-    {% endif %}
 {% endfor %}

--- a/srv/components/system/storage/multipath/config.sls
+++ b/srv/components/system/storage/multipath/config.sls
@@ -34,7 +34,7 @@ Copy multipath config:
 #     - name: multipath -F
 
 
-{% set enclosure_id = "enclosure-" + ((grains['id']).split('_'))[1] %}
+{% set enclosure_id = "enclosure-" + ((grains['id']).split('-'))[1] %}
 {% if not 'JBOD' in pillar['storage'][enclosure_id]['controller']['type'] %}
 {% if (not "primary" in pillar["cluster"][grains["id"]]["roles"])
     or (pillar['cluster']['replace_node']['minion_id']


### PR DESCRIPTION
… for single node

Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

1. Need passwordless ssh for single node for validation API
2. Hosts entries should be present before Validation API 
3. fixed get nodes logic in validation API