### PR TITLE
EOS-17569, EOS-17821: Network Config update for existing cluster (FQDN support)

### DIFF
--- a/srv/components/provisioner/files/cluster_sls.template
+++ b/srv/components/provisioner/files/cluster_sls.template
@@ -67,6 +67,7 @@ cluster:
         interfaces:
           - eth0
         public_ip:                    # DHCP is assumed if left blank
+        public_fqdn: {{ srvnode-{{ (num + 1) }} }}.mgmt.public
         netmask:
         gateway:                      # Gateway IP of Management Network. Not required for DHCP.
         mtu: 1500
@@ -78,7 +79,9 @@ cluster:
         interface_type: tcp           # tcp/o2ib
         transport_type: lnet          # lnet/libfabric
         public_ip:                    # DHCP is assumed if left blank
+        public_fqdn: {{ srvnode-{{ (num + 1) }} }}.data.public
         private_ip:                   # Fixed IP of Private Data Network
+        private_fqdn: {{ srvnode-{{ (num + 1) }} }}.data.private
         netmask:
         gateway:                      # Gateway IP of Public Data Network. Not required for DHCP.
         mtu: {% if "physical" in grains["virtual"] %} 9000 {% else %} 1500 {% endif %}

--- a/srv/components/system/config/hosts.sls
+++ b/srv/components/system/config/hosts.sls
@@ -33,9 +33,9 @@ Hostsfile update for manangement interfaces:
         {%- for node in server_nodes %}
         {%- for srvnode, ip_data in salt['mine.get'](node, 'node_ip_addrs') | dictsort() %}
         {% if ('mgmt0' in grains['ip4_interfaces']) and (grains['ip4_interfaces']['mgmt0'][0]) -%}
-        {{ grains['ip4_interfaces']['mgmt0'][0] }}   {{ srvnode }}
+        {{ grains['ip4_interfaces']['mgmt0'][0] }}   {{ srvnode }}.mgmt.public
         {% else -%}
-        {{ ip_data[pillar['cluster'][srvnode]['network']['mgmt']['interfaces'][0]][0] }}   {{ srvnode }}
+        {{ ip_data[pillar['cluster'][srvnode]['network']['mgmt']['interfaces'][0]][0] }}   {{ srvnode }}.mgmt.public
         {%- endif %}
         {% endfor -%}
         {%- endfor %}
@@ -52,10 +52,10 @@ Hostsfile update for data interfaces:
         {%- for node in server_nodes %}
         {%- for srvnode, ip_data in salt['mine.get'](node, 'node_ip_addrs') | dictsort() %}
         {% if ('data0' in grains['ip4_interfaces']) and (grains['ip4_interfaces']['data0'][0]) -%}
-        {{ grains['ip4_interfaces']['data0'][0] }}   {{ srvnode }}
+        {{ grains['ip4_interfaces']['data0'][0] }}   {{ srvnode }}.data.public
         {% else -%}
-        {{ ip_data[pillar['cluster'][srvnode]['network']['data']['public_interfaces'][0]][0] }}   {{ srvnode }}-data-public
-        {{ ip_data[pillar['cluster'][srvnode]['network']['data']['private_interfaces'][0]][0] }}   {{ srvnode }}-data-private
+        {{ ip_data[pillar['cluster'][srvnode]['network']['data']['public_interfaces'][0]][0] }}   {{ srvnode }}.data.public
+        {{ ip_data[pillar['cluster'][srvnode]['network']['data']['private_interfaces'][0]][0] }}   {{ srvnode }}.data.private
         {% endif -%}
         {% endfor -%}
         {% endfor -%}


### PR DESCRIPTION
Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>

Addresses:
- Define internal custom domains for data/mgmt interfaces
- Network Config update for existing cluster (FQDN support)