### PR TITLE
Test helpers for setup routine

### DIFF
--- a/api/python/provisioner/salt.py
+++ b/api/python/provisioner/salt.py
@@ -586,9 +586,6 @@ class SaltClientBase(ABC):
         res = self.parse_res(salt_res, cmd_args_view)
 
         if res.fails:
-            logger.error(
-                "salt command failed, reason {}, args {}"
-                .format(res.fails, cmd_args_view))
             raise SaltCmdResultError(cmd_args_view, res.fails)
         else:
             try:
@@ -966,9 +963,6 @@ def _salt_runner_cmd(  # noqa: C901 FIXME
     if res.success:
         return res.result
     else:
-        logger.error(
-                "salt command failed, reason {}, args {}"
-                .format(res.result, cmd_args_view))
         raise SaltCmdResultError(cmd_args_view, res.result)
 
 
@@ -1072,9 +1066,6 @@ def _salt_client_cmd(
     res = salt_res_t(salt_res, cmd_args_view, client)
 
     if res.fails:
-        logger.error(
-                "salt command failed, reason {}, args {}"
-                .format(res.fails, cmd_args_view))
         raise SaltCmdResultError(cmd_args_view, res.fails)
     else:
         return res.results

--- a/api/python/provisioner/srv/salt/cortx_repos/install.sls
+++ b/api/python/provisioner/srv/salt/cortx_repos/install.sls
@@ -17,7 +17,9 @@
 
 # TODO TEST
 
-{% if "RedHat" in grains['os'] %}
+# Note. we use True here since currently we do not consider
+#       any usage of an alternative option
+{% if "RedHat" in grains['os'] or True %}
 
 setup_yum_salt_repo:
   file.managed:
@@ -33,6 +35,16 @@ setup_yum_salt_repo:
 clean_yum_salt_repo_metadata:
   cmd.run:
     - name: yum --disablerepo="*" --enablerepo="saltstack" clean metadata
+
+epel_release_installed:
+  pkg.installed:
+    - name: epel-release
+
+# TODO IMPROVE look for specific salt module instead of cmd.run
+# (https://repo.saltstack.com/#rhel, instructions for minor releases centos7 py3)
+import_yum_salt_repo_key:
+  cmd.run:
+    - name: rpm --import https://repo.saltstack.com/py3/redhat/7/x86_64/archive/3002.2/SALTSTACK-GPG-KEY.pub
 
 {% else %}
 
@@ -54,14 +66,3 @@ clean_yum_cache:
     - name: yum clean expire-cache && rm -rf /var/cache/yum
 
 {% endif %}
-
-#epel_release_installed:
-#  pkg.installed:
-#    - name: epel-release
-
-# TODO IMPROVE look for specific salt module instead of cmd.run
-# TODO IMPROVE a temporary fix since later version (2019.2.1) is buggy
-# (https://repo.saltstack.com/#rhel, instructions for minor releases centos7 py3)
-import_yum_salt_repo_key:
-  cmd.run:
-    - name: rpm --import https://archive.repo.saltstack.com/py3/redhat/7/x86_64/archive/2019.2.0/SALTSTACK-GPG-KEY.pub

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -86,7 +86,7 @@ setup(
     },
     install_requires=[
         'PyYAML',
-        'salt >= 3002.2'
+        'salt == 3002.2'
     ],  # TODO
     setup_requires=([] + pytest_runner),
     extras_require={

--- a/files/etc/yum.repos.d/saltstack.repo
+++ b/files/etc/yum.repos.d/saltstack.repo
@@ -1,9 +1,9 @@
 [saltstack]
 name=SaltStack repo for RHEL/CentOS $releasever
 #baseurl=https://archive.repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/2019.2.0
-baseurl=https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002
+baseurl=https://repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/3002.2
 enabled=1
 gpgcheck=1
 #gpgkey=https://archive.repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/2019.2.0/SALTSTACK-GPG-KEY.pub
-gpgkey=https://repo.saltstack.com/py3/redhat/$releasever/$basearch/3002/SALTSTACK-GPG-KEY.pub
+gpgkey=https://repo.saltstack.com/py3/redhat/$releasever/$basearch/archive/3002.2/SALTSTACK-GPG-KEY.pub
 priority=1

--- a/srv/components/provisioner/config/init.sls
+++ b/srv/components/provisioner/config/init.sls
@@ -20,4 +20,6 @@
 include:
   - components.provisioner.config.generate_cluster_pillar
   - components.provisioner.config.rsyslog_config
+{% if not salt['pillar.get']('inline:no_encrypt', False) %}
   - components.system.config.pillar_encrypt
+{% endif %}

--- a/test/build_helpers/__init__.py
+++ b/test/build_helpers/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#

--- a/test/build_helpers/conftest.py
+++ b/test/build_helpers/conftest.py
@@ -1,0 +1,74 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import pytest
+
+from test import helper as h
+
+
+prvsnr_pytest_options = {
+    "docker-mount-dev": dict(
+        action='store_true',
+        help="Mount /dev into docker containers, default: False"
+    ),
+    "no-docker-mount-glusterfs": dict(
+        action='store_false',
+        help=(
+            "Mount /dev into docker containers, "
+            "default: False (means do mount)"
+        )
+    ),
+    "root-passwd": dict(
+        action='store',
+        help="Mount /dev into docker containers",
+        default='root'
+    ),
+    # TODO validation
+    "nodes-num": dict(
+        action='store', type=int,
+        help="Number of nodes",
+        default=1
+    )
+}
+
+
+def pytest_addoption(parser):
+    h.add_options(parser, prvsnr_pytest_options)
+
+
+@pytest.fixture(scope="session")
+def options_list(options_list):
+    return options_list + list(prvsnr_pytest_options)
+
+
+@pytest.fixture(scope='session')
+def nodes_num(request):
+    return request.config.getoption("nodes_num")
+
+
+@pytest.fixture(scope='session')
+def root_passwd(request):
+    return request.config.getoption("root_passwd")
+
+
+@pytest.fixture(scope='session')
+def ask_proceed():
+
+    def _f():
+        input('Press any key to continue...')
+
+    return _f

--- a/test/build_helpers/test_build_env.py
+++ b/test/build_helpers/test_build_env.py
@@ -79,5 +79,6 @@ def test_build_setup_env(
             )
 
     print(ssh_config.read_text())
+    print(f'Path to config: {ssh_config}')
 
     ask_proceed()

--- a/test/build_helpers/test_build_env.py
+++ b/test/build_helpers/test_build_env.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import pytest
+import logging
+from collections import defaultdict
+from copy import deepcopy
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def env_provider():
+    return 'docker'
+
+
+@pytest.fixture
+def hosts_spec(hosts_spec, hosts, tmpdir_function, request):
+    res = deepcopy(hosts_spec)
+    for host in hosts:
+        docker_settings = res[host]['remote']['specific']
+        docker_settings['docker'] = defaultdict(
+            dict, docker_settings.get('docker', {})
+        )
+        docker_settings = docker_settings['docker']
+        docker_settings['privileged'] = True
+
+        if not request.config.getoption("no_docker_mount_glusterfs"):
+            host_glusterfs = tmpdir_function / host / 'srv/glusterfs'
+            host_glusterfs.mkdir(parents=True)
+
+            docker_settings['volumes'][str(host_glusterfs)] = {
+                'bind': '/srv/glusterfs', 'mode': 'rw'
+            }
+
+        if request.config.getoption("docker_mount_dev"):
+            docker_settings['volumes']['/dev'] = {
+                'bind': '/dev', 'mode': 'ro'
+            }
+    return res
+
+
+@pytest.mark.isolated
+@pytest.mark.env_level('utils')
+def test_build_setup_env(
+    request, root_passwd, nodes_num, ssh_config, env_provider,
+    ask_proceed
+):
+    request.applymarker(
+        pytest.mark.hosts([f'srvnode{i}' for i in range(1, nodes_num + 1)])
+    )
+
+    mhosts = [
+        request.getfixturevalue(f'mhostsrvnode{i}')
+        for i in range(1, nodes_num + 1)
+    ]
+
+    for mhost in mhosts:
+        mhost.check_output(f'echo {root_passwd} | passwd --stdin root')
+
+        if env_provider == 'vbox':
+            mhost.remote.cmd(
+               'snapshot', 'save', mhost.remote.name, 'initial --force'
+            )
+
+    print(ssh_config.read_text())
+
+    ask_proceed()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,7 +42,7 @@ DOCKER_IMAGES_REPO = "seagate/cortx-prvsnr"
 VAGRANT_VMS_PREFIX = DOCKER_IMAGES_REPO.replace('/', '.')
 
 SSH_KEY_FILE_NAME = "id_rsa.test"
-MAX_NODES_NUMBER = 3
+MAX_NODES_NUMBER = 6
 
 # TODO 'base' level format is too different
 ENV_LEVELS_HIERARCHY = {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,6 +42,7 @@ DOCKER_IMAGES_REPO = "seagate/cortx-prvsnr"
 VAGRANT_VMS_PREFIX = DOCKER_IMAGES_REPO.replace('/', '.')
 
 SSH_KEY_FILE_NAME = "id_rsa.test"
+MAX_NODES_NUMBER = 3
 
 # TODO 'base' level format is too different
 ENV_LEVELS_HIERARCHY = {
@@ -105,15 +106,11 @@ BASE_OS_NAMES = list(ENV_LEVELS_HIERARCHY['base'])
 DEFAULT_BASE_OS_NAME = 'centos7.7.1908'
 
 DEFAULT_CLUSTER_SPEC = {
-    'srvnode1': {
-        'hostname': 'srvnode-1',
-        'minion_id': 'srvnode-1',
-        'roles': ['primary'],
-    }, 'srvnode2': {
-        'hostname': 'srvnode-2',
-        'minion_id': 'srvnode-2',
-        'roles': ['secondary'],
-    }
+    f'srvnode{node_id}': {
+        'hostname': f'srvnode-{node_id}',
+        'minion_id': f'srvnode-{node_id}',
+        'roles': ['primary' if node_id == 1 else 'secondary'],
+    } for node_id in range(1, MAX_NODES_NUMBER + 1)
 }
 
 
@@ -394,8 +391,7 @@ prvsnr_pytest_options = {
 
 
 def pytest_addoption(parser):
-    for name, params in prvsnr_pytest_options.items():
-        parser.addoption("--" + name, **params)
+    h.add_options(parser, prvsnr_pytest_options)
 
 
 # TODO DOC how to modify tests collections
@@ -499,9 +495,9 @@ def patch_logging(request, monkeypatch):
 @pytest.fixture(scope='session')
 def hosts_spec(request):
     return {
-        'srvnode1': {
+        f'srvnode{node_id}': {
             'remote': {
-                'hostname': 'srvnode-1',
+                'hostname': f'srvnode-{node_id}',
                 'specific': {
                     'vbox': {
                         'memory': 4096,
@@ -511,23 +507,9 @@ def hosts_spec(request):
                     }
                 }
             },
-            'minion_id': 'srvnode-1',
-            'roles': ['primary'],
-        }, 'srvnode2': {
-            'remote': {
-                'hostname': 'srvnode-2',
-                'specific': {
-                    'vbox': {
-                        'memory': 4096,
-                        'cpus': 2,
-                        'mgmt_disk_size': 2048,
-                        'data_disk_size': 2048
-                    }
-                }
-            },
-            'minion_id': 'srvnode-2',
-            'roles': ['secondary'],
-        }
+            'minion_id': f'srvnode-{node_id}',
+            'roles': ['primary' if node_id == 1 else 'secondary'],
+        } for node_id in range(1, MAX_NODES_NUMBER + 1)
     }
 
 
@@ -1590,6 +1572,5 @@ def build_mhost_fixture(label=None, module_name=__name__):
 # default 'host' fixture is always present
 build_mhost_fixture()
 # also host fixtures for CORTX stack makes sense
-build_mhost_fixture('srvnode1')
-build_mhost_fixture('srvnode2')
-build_mhost_fixture('srvnode3')
+for node_id in range(1, MAX_NODES_NUMBER + 1):
+    build_mhost_fixture(f'srvnode{node_id}')

--- a/test/helper.py
+++ b/test/helper.py
@@ -817,3 +817,8 @@ def dump_options(request, options_list):
         for opt in options_list
     ])
     logger.info('Passed options:\n{}'.format(opts_str))
+
+
+def add_options(parser, options):
+    for name, params in options.items():
+        parser.addoption("--" + name, **params)


### PR DESCRIPTION
Summary:

- adds ability to setup testing env of multiple nodes using pytest testing scenario
- makes setup provisioner logic more flexible for `local` source

Example of usage:

- install docker
- run `pytest test/build_helpers -k test_build_setup_env -s --root-passwd root1 --nodes-num 3`
  - that will start (almost) clean docker containers and configure root passwords as specified
  - print ssh configuration for the prepared env into the output
  - then it would prompt for a key (once any key is pressed it would teardown the env)
  - possible options (you may check them using `pytest test/build_helpers --help`, `custom options` part)
    - `--docker-mount-dev` to mount `/dev` into containers (necessary if you need to mount ISO inside a container)
    - `--root-passwd <STR>` to set a root password for initial ssh access
    - `--nodes-num <INT>` number of nodes, currently it can be from 1 to 3
- in other terminal run `provisioner setup_provisioner --source local --logfile --logfile-filename ./setup.log ... srvnode-1:<IP1> srvnode-2:<IP2> srvnode-3:<IP3>`