### PR TITLE
EOS-18337: Make bootstrap API salt states for cortx repositories available in deployed environment

### DIFF
--- a/devops/rpms/buildrpm.sh
+++ b/devops/rpms/buildrpm.sh
@@ -69,11 +69,12 @@ pushd ~/rpmbuild/SOURCES/
 
     # Setup the source tar for rpm build
     DEST_DIR=cortx-prvsnr-${CORTX_PRVSNR_VERSION}-git${GIT_VER}
-    mkdir -p ${DEST_DIR}/{cli,files/etc,files/conf,pillar,srv}
+    mkdir -p ${DEST_DIR}/{cli,files/etc,files/conf,pillar,srv,srv_ext}
     cp -R ${BASEDIR}/../../cli/src/* ${DEST_DIR}/cli
     # cp -R ${BASEDIR}/../../srv/components/provisioner/files/setup.yaml ${DEST_DIR}/files/conf
     cp -R ${BASEDIR}/../../pillar ${DEST_DIR}
     cp -R ${BASEDIR}/../../srv ${DEST_DIR}
+    cp -R ${BASEDIR}/../../api/python/provisioner/srv/salt/repos ${DEST_DIR}/srv_ext
 
 
     tar -zcvf ${DEST_DIR}.tar.gz ${DEST_DIR}

--- a/devops/rpms/buildrpm.sh
+++ b/devops/rpms/buildrpm.sh
@@ -68,13 +68,13 @@ pushd ~/rpmbuild/SOURCES/
     rm -rf cortx-prvsnr*
 
     # Setup the source tar for rpm build
-    DEST_DIR=cortx-prvsnr-${CORTX_PRVSNR_VERSION}-git${GIT_VER}
-    mkdir -p ${DEST_DIR}/{cli,files/etc,files/conf,pillar,srv,srv_ext}
-    cp -R ${BASEDIR}/../../cli/src/* ${DEST_DIR}/cli
+    DEST_DIR="cortx-prvsnr-${CORTX_PRVSNR_VERSION}-git${GIT_VER}"
+    mkdir -p "${DEST_DIR}/{cli,files/etc,files/conf,pillar,srv,srv_ext}"
+    cp -R "${BASEDIR}/../../cli/src/*" "${DEST_DIR}/cli"
     # cp -R ${BASEDIR}/../../srv/components/provisioner/files/setup.yaml ${DEST_DIR}/files/conf
-    cp -R ${BASEDIR}/../../pillar ${DEST_DIR}
-    cp -R ${BASEDIR}/../../srv ${DEST_DIR}
-    cp -R ${BASEDIR}/../../api/python/provisioner/srv/salt/repos ${DEST_DIR}/srv_ext
+    cp -R "${BASEDIR}/../../pillar" "${DEST_DIR}"
+    cp -R "${BASEDIR}/../../srv" "${DEST_DIR}"
+    cp -R "${BASEDIR}/../../api/python/provisioner/srv/salt/repos" "${DEST_DIR}/srv_ext"
 
 
     tar -zcvf ${DEST_DIR}.tar.gz ${DEST_DIR}

--- a/devops/rpms/buildrpm.sh
+++ b/devops/rpms/buildrpm.sh
@@ -69,8 +69,8 @@ pushd ~/rpmbuild/SOURCES/
 
     # Setup the source tar for rpm build
     DEST_DIR="cortx-prvsnr-${CORTX_PRVSNR_VERSION}-git${GIT_VER}"
-    mkdir -p "${DEST_DIR}/{cli,files/etc,files/conf,pillar,srv,srv_ext}"
-    cp -R "${BASEDIR}/../../cli/src/*" "${DEST_DIR}/cli"
+    mkdir -p "${DEST_DIR}"/{cli,files/etc,files/conf,pillar,srv,srv_ext}
+    cp -R "${BASEDIR}"/../../cli/src/* "${DEST_DIR}/cli"
     # cp -R ${BASEDIR}/../../srv/components/provisioner/files/setup.yaml ${DEST_DIR}/files/conf
     cp -R "${BASEDIR}/../../pillar" "${DEST_DIR}"
     cp -R "${BASEDIR}/../../srv" "${DEST_DIR}"

--- a/devops/rpms/cortx-prvsnr.spec
+++ b/devops/rpms/cortx-prvsnr.spec
@@ -46,6 +46,7 @@ cp -R cli %{buildroot}/opt/seagate/cortx/provisioner
 cp -R pillar %{buildroot}/opt/seagate/cortx/provisioner
 cp -R srv %{buildroot}/opt/seagate/cortx/provisioner
 cp -R srv/components/provisioner/files/setup.yaml %{buildroot}/opt/seagate/cortx/provisioner/conf/
+cp -R srv_ext %{buildroot}/opt/seagate/cortx/provisioner/srv_ext/
 
 
 %post
@@ -63,3 +64,4 @@ rm -rf %{buildroot}
 /opt/seagate/cortx/provisioner/files
 /opt/seagate/cortx/provisioner/pillar
 /opt/seagate/cortx/provisioner/srv
+/opt/seagate/cortx/provisioner/srv_ext

--- a/srv/components/provisioner/salt_master/files/master
+++ b/srv/components/provisioner/salt_master/files/master
@@ -672,6 +672,7 @@ file_roots:
     - /var/lib/seagate/cortx/provisioner/shared/srv/salt     # new style
     - /opt/seagate/cortx/provisioner/srv_user   # old style
     - /opt/seagate/cortx/provisioner/srv
+    - /opt/seagate/cortx/provisioner/srv_ext
 
 # The master_roots setting configures a master-only copy of the file_roots dictionary,
 # used by the state compiler.

--- a/srv/components/provisioner/salt_master/files/master
+++ b/srv/components/provisioner/salt_master/files/master
@@ -672,7 +672,7 @@ file_roots:
     - /var/lib/seagate/cortx/provisioner/shared/srv/salt     # new style
     - /opt/seagate/cortx/provisioner/srv_user   # old style
     - /opt/seagate/cortx/provisioner/srv
-    - /opt/seagate/cortx/provisioner/srv_ext
+    - /opt/seagate/cortx/provisioner/srv_ext  # file root for salt extensions
 
 # The master_roots setting configures a master-only copy of the file_roots dictionary,
 # used by the state compiler.

--- a/srv/components/provisioner/salt_minion/files/minion
+++ b/srv/components/provisioner/salt_minion/files/minion
@@ -578,6 +578,7 @@ file_roots:
     - /var/lib/seagate/cortx/provisioner/shared/srv/salt     # new style
     - /opt/seagate/cortx/provisioner/srv_user
     - /opt/seagate/cortx/provisioner/srv
+    - /opt/seagate/cortx/provisioner/srv_ext
 
 # Uncomment the line below if you do not want the file_server to follow
 # symlinks when walking the filesystem tree. This is set to True

--- a/srv/components/provisioner/salt_minion/files/minion
+++ b/srv/components/provisioner/salt_minion/files/minion
@@ -578,7 +578,7 @@ file_roots:
     - /var/lib/seagate/cortx/provisioner/shared/srv/salt     # new style
     - /opt/seagate/cortx/provisioner/srv_user
     - /opt/seagate/cortx/provisioner/srv
-    - /opt/seagate/cortx/provisioner/srv_ext
+    - /opt/seagate/cortx/provisioner/srv_ext  # file root for salt extensions
 
 # Uncomment the line below if you do not want the file_server to follow
 # symlinks when walking the filesystem tree. This is set to True


### PR DESCRIPTION
I added `api/python/provisioner/srv/salt/repos` to core provisioner rpm package to use for sw upgrade