### PR TITLE
update mine data after machine_id refresh

### DIFF
--- a/srv/components/provisioner/config/machine_id/refresh_grains.sls
+++ b/srv/components/provisioner/config/machine_id/refresh_grains.sls
@@ -25,4 +25,4 @@ Replace machine id in grains:
 Sync data:
   module.run:
     - saltutil.refresh_grains: []
-
+    - mine.update: []


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

Even if we refresh grains data mine data is not getting refreshed so added mine.update after that mine is getting updated