### PR TITLE
EOS-18457: Filename encoding error in PIP environment

### DIFF
--- a/api/python/provisioner/srv/salt/provisioner/api/install.sls
+++ b/api/python/provisioner/srv/salt/provisioner/api/install.sls
@@ -15,6 +15,12 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+set_env_vars:
+  environ.setenv:
+    - name: LC_ALL
+    - value: en_US.UTF-8
+    - update_minion: True
+
 api_installed:
 {% if salt['pillar.get']('api_distr') == 'pip' %}
   pip.installed:
@@ -22,6 +28,8 @@ api_installed:
     - bin_env: /usr/bin/pip3
     - upgrade: False  # to reuse already installed dependencies
                       # that may come from rpm repositories
+    - require:
+      - set_env_vars
 {% else %}
   pkg.installed:
     - pkgs:

--- a/api/python/provisioner/srv/salt/provisioner/api/install.sls
+++ b/api/python/provisioner/srv/salt/provisioner/api/install.sls
@@ -15,11 +15,14 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+{% if salt['pillar.get']('api_distr') == 'pip' %}
 set_env_vars:
   environ.setenv:
     - name: LC_ALL
     - value: en_US.UTF-8
     - update_minion: True
+{% endif %}
+
 
 api_installed:
 {% if salt['pillar.get']('api_distr') == 'pip' %}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,7 +23,12 @@ sudo groupadd docker
 sudo usermod -aG docker $USER
 ```
 
-After that command, re-login/re-connect to your terminal or VM console. 
+After that command, re-login/re-connect to your terminal or VM console.
+
+:warning: NOTE: for more information about post-installation steps, please,
+visit the official page:
+
+https://docs.docker.com/engine/install/linux-postinstall/
 
 #### Docker on Fedora 33
 
@@ -159,7 +164,7 @@ sudo docker run hello-world
     Possible options (you may check them using `pytest test/build_helpers --help`, `custom options` part)
     - `--docker-mount-dev` to mount `/dev` into containers (necessary if you need to mount ISO inside a container)
     - `--root-passwd <STR>` to set a root password for initial ssh access
-    - `--nodes-num <INT>` number of nodes, currently it can be from 1 to 3
+    - `--nodes-num <INT>` number of nodes, currently it can be from 1 to 6
 
 
 - You may set up a provisioner inside the container using the local source mode

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,6 +16,13 @@
 The base Docker installation methods for popular Linux distributions are listed here:
 	https://docs.docker.com/engine/install/
 
+To run Docker commands without **sudo**, add your user to **docker** group
+
+```bash
+sudo groupadd docker
+sudo usermod -aG docker $USER
+```
+
 #### Docker on Fedora 33
 
 Docker is not supported by **Fedora 33** officially. You can use the following method (Moby based approach):
@@ -61,7 +68,7 @@ sudo firewall-cmd --permanent --zone=FedoraWorkstation --add-masquerade
 
 
 <details>
-<summary>5. Add your user to **docker** group to run docker without **sudo**</summary>
+<summary>5. Add your user to <strong>docker</strong> group to run docker without <strong>sudo</strong></summary>
 
 ```bash
 sudo groupadd docker
@@ -102,6 +109,12 @@ sudo docker run hello-world
 
   :warning: NOTE: For more details about Python virtual environment see
   https://docs.python.org/3.6/library/venv.html
+
+- Activate created Python environment
+
+  ```bash
+  source venv/bin/activate
+  ```
 
 - Install provisioner API to `venv`: 
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,8 @@ sudo groupadd docker
 sudo usermod -aG docker $USER
 ```
 
+After that command, re-login/re-connect to your terminal or VM console. 
+
 #### Docker on Fedora 33
 
 Docker is not supported by **Fedora 33** officially. You can use the following method (Moby based approach):


### PR DESCRIPTION
I added the setup of the `LC_ALL` variable during the pip installation of provisioner dependencies.

-----
[View rendered docs/testing.md](https://github.com/Seagate/cortx-prvsnr/blob/EOS-18457/docs/testing.md)