### PR TITLE
[EOS-17600] adds basis of the new modular logic and repos support

### DIFF
--- a/api/python/provisioner/api_spec.yaml
+++ b/api/python/provisioner/api_spec.yaml
@@ -121,6 +121,10 @@ generate_roster:
   type: GenerateRoster
 reset_machine_id:
   type: ResetMachineId
+resource:
+  type: Resource
+destroy:
+  type: DestroyNode
 
 # setup commands
 setup_provisioner:
@@ -148,5 +152,6 @@ deploy_jbod:
 deploy_dual:
   type: DeployDual
 
-destroy:
-  type: DestroyNode
+# others
+helper:
+  type: Helper

--- a/api/python/provisioner/cli_parser.py
+++ b/api/python/provisioner/cli_parser.py
@@ -141,7 +141,6 @@ def parse_args(args=None, commands: Optional[List] = None):
 
         # TODO description and help strings
         for cmd_name, cmd in commands.items():
-
             desc = getattr(cmd, 'description', f'{cmd_name} configuration')
 
             subparser = subparsers.add_parser(

--- a/api/python/provisioner/commands/_basic.py
+++ b/api/python/provisioner/commands/_basic.py
@@ -15,13 +15,26 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+from typing import Optional, Union, Type
+
 from ..vendor import attr
-from .. import inputs, ALL_MINIONS
+from .. import inputs, config
+from ..utils import validator__subclass_of
+from ..paths import PillarPath, FileRootPath
+
+from ..salt_api import (
+    SaltLocalClient,
+    SaltRunnerClient,
+    SaltCallerClient,
+    SaltLocalCallerClient,
+    SaltSSHClient
+)
+from ..salt_api.base import SaltClientBaseParams
 
 
 class RunArgs:
     targets: str = attr.ib(
-        default=ALL_MINIONS,
+        default=config.ALL_MINIONS,
         metadata={
             inputs.METADATA_ARGPARSER: {
                 'help': "command's host targets"
@@ -42,20 +55,147 @@ class RunArgs:
             }
         }, default=False
     )
+    runner_minion_id: Optional[str] = attr.ib(
+        default=None,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "remote target to run a command on"
+            }
+        }
+    )
+
+
+def converter__str_to_salt_client_t(client: str):
+    clients = {
+        'salt': SaltLocalClient,
+        'runner': SaltRunnerClient,
+        'caller': SaltCallerClient,
+        'local': SaltLocalCallerClient,
+        'ssh': SaltSSHClient
+    }
+    return clients[client]
+
+
+# XXX duplicates salt clients args definitions
+# XXX duplicates SSHProfile from helper.py
+class RunArgsSaltClientParams:
+    salt_client_type: Optional[
+        Union[str, Type[SaltLocalClient], Type[SaltSSHClient]]
+    ] = attr.ib(
+        default='salt',
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "salt client type"
+            },
+            'choices': ['salt', 'ssh'],
+            'metavar': 'STR'
+        },
+        converter=converter__str_to_salt_client_t,
+        validator=validator__subclass_of((SaltLocalClient, SaltSSHClient))
+    )
+    salt_c_path: str = attr.ib(
+        default=config.SALT_MASTER_CONFIG_DEFAULT,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "config path"
+            }
+        }
+    )
+    salt_ssh_roster: str = attr.ib(
+        default=config.SALT_ROSTER_DEFAULT,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "path to roster file"
+            }
+        }
+    )
+    salt_ssh_profile: str = attr.ib(
+        default=None,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "path to ssh profile, if specified"
+                    " paths to roster, roots and configuration files"
+                    " would be set automatically"
+                )
+            }
+        }
+    )
+    salt_ssh_profile_name: str = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "A name of the setup profile "
+                    f"considered inside {config.profile_base_dir().parent} "
+                    "(ignored if '--salt-ssh-profile' option is specified)."
+                ),
+            }
+        },
+        default=None
+    )
 
 
 @attr.s(auto_attribs=True)
 class RunArgsBase:
     targets: str = RunArgs.targets
+    runner_minion_id: str = RunArgs.runner_minion_id
 
 
+@attr.s(auto_attribs=True)
+class RunArgsSaltClient:
+    salt_client_type: Optional[
+        Union[str, Type[SaltLocalClient], Type[SaltSSHClient]]
+    ] = RunArgsSaltClientParams.salt_client_type
+    salt_c_path: str = RunArgsSaltClientParams.salt_c_path
+    salt_ssh_roster: str = RunArgsSaltClientParams.salt_ssh_roster
+    salt_ssh_profile: str = RunArgsSaltClientParams.salt_ssh_profile
+    salt_ssh_profile_name: str = (
+        RunArgsSaltClientParams.salt_ssh_profile_name
+    )
+    fileroot_path: Union[FileRootPath, str] = (
+        SaltClientBaseParams.fileroot_path
+    )
+    pillar_path: Union[PillarPath, str] = SaltClientBaseParams.pillar_path
+
+    client: str = attr.ib(init=False, default=None)
+
+    def __attrs_post_init__(self):
+        kwargs = dict(
+            c_path=self.salt_c_path,
+            fileroot_path=self.fileroot_path,
+            pillar_path=self.pillar_path
+        )
+
+        if issubclass(self.salt_client_type, SaltSSHClient):
+            if self.salt_ssh_profile_name and not self.salt_ssh_profile:
+                self.salt_ssh_profile = (
+                    config.profile_base_dir().parent
+                    / self.salt_ssh_profile_name
+                )
+
+            # XXX EOS-17600 re_config always True here
+            kwargs.update(dict(
+                profile=self.salt_ssh_profile,
+                roster_file=self.salt_ssh_roster,
+                re_config=True
+            ))
+
+        self.client = self.salt_client_type(**kwargs)  # pylint: disable=not-callable
+
+
+@attr.s(auto_attribs=True)
+class ProvisionerCommand:
+    """Base class for provisioner commands."""
+
+
+# XXX rethink class hirarchy, it's no more mixin actually
 class CommandParserFillerMixin:
     _run_args_type = RunArgsBase
 
     @classmethod
     def _run_args_types(cls):
         ret = cls._run_args_type
-        return ret if type(ret) is list else [ret]
+        return ret if isinstance(ret, list) else [ret] if ret else []
 
     @classmethod
     def fill_parser(cls, parser, parents=None):
@@ -68,7 +208,10 @@ class CommandParserFillerMixin:
 
     @classmethod
     def extract_positional_args(cls, kwargs):
+        res = []
         for arg_type in cls._run_args_types():
-            return inputs.ParserFiller.extract_positional_args(
+            _args, kwargs = inputs.ParserFiller.extract_positional_args(
                 arg_type, kwargs
             )
+            res.extend(_args)
+        return res, kwargs

--- a/api/python/provisioner/commands/helper.py
+++ b/api/python/provisioner/commands/helper.py
@@ -1,0 +1,325 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import Type, Optional, List
+from pathlib import Path
+import logging
+import argparse
+
+from ..vendor import attr
+from .. import (
+    inputs,
+    config,
+    profile
+)
+from ..node import Node
+from .. import utils
+from ..ssh import keygen
+
+from ._basic import (
+    CommandParserFillerMixin
+)
+from ..salt_api import SaltSSHClient
+
+
+logger = logging.getLogger(__name__)
+
+default_profile = config.profile_base_dir()
+
+
+class RunArgsHelpersParams:
+    # XXX DRY copy-paste from setup_provisioner.py
+    nodes: str = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "cluster node specification, "
+                    "format: id:[user@]hostname[:port]"
+                ),
+                'nargs': '+'
+            }
+        },
+        converter=(
+            lambda specs: [
+                (s if isinstance(s, Node) else Node.from_spec(s))
+                for s in specs
+            ]
+        )
+    )
+    profile_name: str = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "A name to assign to the setup profile "
+                    f"generated inside {default_profile.parent} "
+                    "(ignored if '--profile' option is specified)."
+                ),
+            }
+        },
+        default=None
+    )
+    profile: str = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "the path to the setup profile directory, "
+                    "by default auto-generated inside current directory,  "
+                    "if specified '--name' option is ignored"
+                )
+            }
+        },
+        default=None,
+        converter=(lambda v: Path(str(v)) if v else v)
+    )
+    ssh_key: str = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "ssh key",
+                'metavar': 'PATH'
+            }
+        },
+        default=None,
+        converter=utils.converter_path_resolved,
+        validator=utils.validator_path_exists
+    )
+    bootstrap_key: str = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "bootstrap key for initial access only",
+                'metavar': 'PATH'
+            }
+        },
+        default=None,
+        converter=utils.converter_path_resolved,
+        validator=utils.validator_path_exists
+    )
+
+
+@attr.s(auto_attribs=True)
+class SSHProfile:
+
+    profile_name: str = RunArgsHelpersParams.profile_name
+    profile: str = RunArgsHelpersParams.profile
+
+    def __attrs_post_init__(self):
+        if not self.profile:
+            if self.profile_name:
+                self.profile = default_profile.parent / self.profile_name
+            else:
+                self.profile = default_profile
+
+
+@attr.s(auto_attribs=True)
+class SSHProfileGenerator(SSHProfile, CommandParserFillerMixin):
+    description = (
+        "A helper profile generator for salt-ssh."
+        "  If '--profile' is specified it would be a profile location."
+        " Otherwise if '--name' is specified profile with the name would be"
+        f" located inside '{default_profile.parent}' directory."
+        " Finally if neither of these options is specified"
+        f" default profile would be generated at '{default_profile}'"
+    )
+
+    # XXX validation
+    add_file_roots: Optional[List] = attr.ib(
+        default=attr.Factory(list),
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "additional file roots",
+                'metavar': 'PATH',
+                'nargs': '*'
+            }
+        }
+    )
+    add_pillar_roots: Optional[List] = attr.ib(
+        default=attr.Factory(list),
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "additional pillar roots",
+                'metavar': 'PATH',
+                'nargs': '*'
+            }
+        }
+    )
+    cleanup: bool = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "cleanup existing profile"
+                )
+            }
+        },
+        default=False,
+    )
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        self.add_file_roots = [Path(p) for p in self.add_file_roots]
+        self.add_pillar_roots = [Path(p) for p in self.add_pillar_roots]
+
+    def run(self):
+        paths = config.profile_paths(
+            config.profile_base_dir(profile=self.profile)
+        )
+
+        logger.debug(f"Generating profile at '{self.profile}'")
+        profile.setup(
+            paths,
+            clean=self.cleanup,
+            add_file_roots=self.add_file_roots,
+            add_pillar_roots=self.add_pillar_roots
+        )
+
+        logger.info(
+            f"Generated profile location is '{self.profile}'."
+        )
+
+
+@attr.s(auto_attribs=True)
+class EnsureNodesReady(SSHProfile, CommandParserFillerMixin):
+    description = (
+        "Ensures the nodes are accessible and ready to accept "
+        " provisioner commands."
+        " If '--profile' is specified it would be used as a profile location."
+        " Otherwise if '--name' is specified profile with that name"
+        f" will be considered inside '{default_profile.parent}' directory."
+        " Finally if neither of these options is specified"
+        f" default profile at '{default_profile}' would be used."
+        "If '--ssh-key' is specified then a public key at the same location"
+        " is considered."
+    )
+
+    nodes: str = RunArgsHelpersParams.nodes
+    profile_name: str = RunArgsHelpersParams.profile_name
+    profile: str = RunArgsHelpersParams.profile
+    ssh_key: str = RunArgsHelpersParams.ssh_key
+    bootstrap_key: str = RunArgsHelpersParams.bootstrap_key
+
+    regenerate_key: bool = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "Re-generate an access key if exists"
+            }
+        },
+        default=False
+    )
+
+    def run(self):
+        paths = config.profile_paths(
+            config.profile_base_dir(profile=self.profile)
+        )
+        bootstrap_roster = paths['salt_bootstrap_roster_file']
+
+        ssh_key = self.ssh_key
+        if not ssh_key:
+            ssh_key = paths['setup_key_file']
+
+            if self.regenerate_key or not ssh_key.exists():
+                logger.debug(f"Generating access key as '{ssh_key}'")
+                keygen(ssh_key)
+
+        logger.debug(f"Generating roster as '{paths['salt_roster_file']}'")
+        SaltSSHClient.build_roster(
+            self.nodes, ssh_key, paths['salt_roster_file']
+        )
+
+        ssh_client = SaltSSHClient(profile=self.profile)
+
+        if self.bootstrap_key:
+            logger.debug(
+                f"Generating bootstrap roster as '{bootstrap_roster}'"
+            )
+            ssh_client.build_roster(
+                self.nodes, self.bootstrap_key, bootstrap_roster
+            )
+        elif bootstrap_roster.exists():
+            logger.warning(
+                f"Existent bootstrap roster '{bootstrap_roster}' will be used"
+            )
+
+        # if self.bootstrap_key:
+        #     ssh_client.add_file_roots([self.bootstrap_key.parent])
+
+        for node in ssh_client.roster_targets():
+            logger.info(
+                f"Ensuring '{node}' is ready to accept commands"
+            )
+            ssh_client.ensure_ready(
+                [node],
+                bootstrap_roster_file=(
+                    bootstrap_roster if bootstrap_roster.exists() else None
+                )
+            )
+
+
+@attr.s(auto_attribs=True)
+class Helper(CommandParserFillerMixin):
+    input_type: Type[inputs.NoParams] = inputs.NoParams
+    _run_args_type = None
+
+    helpers = {
+        'generate-profile': SSHProfileGenerator,
+        'ensure-nodes-ready': EnsureNodesReady
+    }
+
+    @classmethod
+    def fill_parser(cls, parser, parents=None):
+        if parents is None:
+            parents = []
+
+        subparsers = parser.add_subparsers(
+            dest='helper',
+            title='Various helpers',
+            description='valid helpers',
+            # requried=True # ( sad, but python 3.6 doesn't have that
+        )
+
+        for helper_name, helper_t in cls.helpers.items():
+            subparser = subparsers.add_parser(
+                helper_name, description=helper_t.description,
+                help=f"{helper_name} helper help", parents=parents,
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            )
+            inputs.ParserFiller.fill_parser(helper_t, subparser)
+
+    # XXX DRY copy-paste from SaltClient command
+    @classmethod
+    def extract_positional_args(cls, kwargs):
+        helper_t = cls.helpers[kwargs.pop('helper')]
+        _args = [helper_t]
+
+        args, kwargs = super().extract_positional_args(kwargs)
+        _args.extend(args)
+
+        args, kwargs = inputs.ParserFiller.extract_positional_args(
+            helper_t, kwargs
+        )
+        _args.extend(args)
+
+        return _args, kwargs
+
+    @staticmethod
+    def run(helper_t, *args, **kwargs):
+        helper_kwargs = {
+            k: kwargs.pop(k) for k in list(kwargs)
+            if k in attr.fields_dict(helper_t)
+        }
+
+        helper = helper_t(*args, **helper_kwargs)
+
+        return helper.run(**kwargs)

--- a/api/python/provisioner/commands/resource.py
+++ b/api/python/provisioner/commands/resource.py
@@ -1,0 +1,140 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import Type
+import logging
+import argparse
+from collections import defaultdict
+from copy import deepcopy
+
+from ..vendor import attr
+from .. import inputs
+
+from ._basic import (
+    RunArgsBase,
+    RunArgsSaltClient,
+    CommandParserFillerMixin
+)
+
+from provisioner.scm.saltstack.rc_sls.base import SLSResourceManager
+
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True)
+class Resource(CommandParserFillerMixin):
+    input_type: Type[inputs.NoParams] = inputs.NoParams
+    _run_args_type = [RunArgsBase, RunArgsSaltClient]
+
+    @classmethod
+    def fill_parser(cls, parser, parents=None):
+        if parents is None:
+            parents = []
+
+        # add common args block for all resources
+        resource_parser_common = argparse.ArgumentParser(add_help=False)
+        super().fill_parser(resource_parser_common)
+        parents.append(resource_parser_common)
+
+        subparsers = parser.add_subparsers(
+            dest='resource_name',
+            title='resources',
+            description='valid resources'
+        )
+
+        rc_manager = SLSResourceManager()
+        rc_states = defaultdict(list)
+
+        for state_t in rc_manager.transitions:
+            rc_states[state_t.resource_t].append(state_t)
+
+        for rc_t, state_ts in rc_states.items():
+            rc_name = rc_t.resource_t_id.value
+            rc_subparser = subparsers.add_parser(
+                rc_name, description=f"{rc_name} configuration",
+                help=f"{rc_name} resource help", parents=parents,
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            )
+
+            state_subparsers = rc_subparser.add_subparsers(
+                dest="resource_state_name",
+                title=f"resource {rc_name} states",
+                description=f"valid states for resource {rc_name}"
+            )
+
+            for state_t in state_ts:
+                state_name = state_t.name
+                state_subparser = state_subparsers.add_parser(
+                    state_name, description=f"{state_name} configuration",
+                    help=f"{state_name} configuration help", parents=parents,
+                    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+                )
+                inputs.ParserFiller.fill_parser(state_t, state_subparser)
+
+    @classmethod
+    def extract_positional_args(cls, kwargs):
+        # FIXME
+        rc_manager = SLSResourceManager()
+        state_ts = {st_t.name: st_t for st_t in rc_manager.transitions}
+
+        # XXX ??? FIXME
+        kwargs.pop('resource_name')
+
+        state_name = kwargs.pop('resource_state_name')
+        state_t = state_ts[state_name]
+        _args = [state_t]
+
+        args, kwargs = super().extract_positional_args(kwargs)
+        _args.extend(args)
+
+        args, kwargs = inputs.ParserFiller.extract_positional_args(
+            state_t, kwargs
+        )
+        _args.extend(args)
+
+        return _args, kwargs
+
+    @staticmethod
+    def run( state_t, *args, **kwargs):
+        _kwargs = deepcopy(kwargs)
+
+        salt_args = RunArgsSaltClient(**{
+            k: kwargs.pop(k) for k in list(kwargs)
+            if k in attr.fields_dict(RunArgsSaltClient)
+        })
+
+        run_args = RunArgsBase(**{
+            k: kwargs.pop(k) for k in list(kwargs)
+            if k in attr.fields_dict(RunArgsBase)
+        })
+
+        if run_args.runner_minion_id:
+            return salt_args.salt_client.provisioner_cmd(
+                'resource',
+                fun_args=([state_t.name] + list(args)),
+                fun_kwargs=_kwargs,
+                runner_minion_id=run_args.runner_minion_id
+            )
+        else:
+            rc_manager = SLSResourceManager()
+            state = state_t(*args, **kwargs)
+            return rc_manager.run(
+                state,
+                trans_kwargs=dict(client=salt_args.client),
+                targets=run_args.targets
+            )

--- a/api/python/provisioner/commands/salt.py
+++ b/api/python/provisioner/commands/salt.py
@@ -105,6 +105,7 @@ class RunArgsSaltFun:
     )
 
 
+# TODO DOC example how to organize subcommands
 @attr.s(auto_attribs=True)
 class SaltClient(CommandParserFillerMixin):
     input_type: Type[inputs.NoParams] = inputs.NoParams

--- a/api/python/provisioner/commands/set_swupgrade_repo.py
+++ b/api/python/provisioner/commands/set_swupgrade_repo.py
@@ -102,6 +102,7 @@ class SetSWUpgradeRepo(SetSWUpdateRepo):
             # TODO IMPROVE later raise and error
             if False:
                 raise SWUpdateRepoSourceError(
+                    # FIXME repo is undefined here
                     str(repo.source),
                     (
                         f"SW upgrade repository for the release "

--- a/api/python/provisioner/commands/setup_provisioner.py
+++ b/api/python/provisioner/commands/setup_provisioner.py
@@ -1284,6 +1284,7 @@ class SetupProvisioner(SetupCmdBase, CommandParserFillerMixin):
 
         setup_ctx = SetupCtx(run_args, paths, ssh_client)
 
+        # we iterate explicitly here to make the progress clearer in console
         for node in run_args.nodes:
             logger.info(
                 f"Ensuring '{node.minion_id}' is ready to accept commands"

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -33,6 +33,11 @@ else:
             PROJECT_PATH = None
             break
 
+API_SPEC_PATH = CONFIG_MODULE_DIR / 'api_spec.yaml'
+PARAMS_SPEC_PATH = CONFIG_MODULE_DIR / 'params_spec.yaml'
+CLI_SPEC_PATH = CONFIG_MODULE_DIR / 'cli_spec.yaml'
+ATTRS_SPEC_PATH = CONFIG_MODULE_DIR / 'attrs_spec.yaml'
+
 # TODO
 #  - rename to defaults.py or constants.py or ...
 #  - then rename base.py to config.py
@@ -40,7 +45,7 @@ else:
 
 CORTX_CONFIG_DIR = Path('/opt/seagate/cortx_configs')
 CORTX_ROOT_DIR = Path('/opt/seagate/cortx')
-PRVSNR_TMP_DIR = Path(  Path.home() / '.tmp/seagate/prvsnr/')
+PRVSNR_TMP_DIR = Path(Path.home() / '.tmp/seagate/prvsnr/')
 CONFSTORE_CLUSTER_CONFIG = CORTX_CONFIG_DIR / 'provisioner_cluster.json'
 
 PRVSNR_ROOT_DIR = Path('/opt/seagate/cortx/provisioner')
@@ -63,6 +68,9 @@ PRVSNR_USER_LOCAL_FILEROOT_DIR = PRVSNR_USER_LOCAL_SALT_DIR / 'salt'
 PRVSNR_USER_PILLAR_DIR = PRVSNR_USER_SALT_DIR / 'pillar'
 PRVSNR_USER_LOCAL_PILLAR_DIR = PRVSNR_USER_LOCAL_SALT_DIR / 'pillar'
 
+
+SALT_JOBS_CACHE_DIR = Path('/var/cache/salt/master/jobs')
+
 # Notes:
 # 1. how salt's pillar roots organized:
 #   - salt searches for files in each root
@@ -77,6 +85,7 @@ PRVSNR_USER_LOCAL_PILLAR_DIR = PRVSNR_USER_LOCAL_SALT_DIR / 'pillar'
 #     salt master/minion config files
 #     (e.g. default ones have less priority than user ones,
 #           shared user pillar has less priority than local one)
+PRVSNR_FACTORY_PILLAR_PREFIX = "u_factory_"
 PRVSNR_USER_PILLAR_PREFIX = 'uu_'
 PRVSNR_USER_LOCAL_PILLAR_PREFIX = 'zzz_'
 
@@ -88,6 +97,8 @@ PRVSNR_PILLAR_CONFIG_INI = str(
 REPO_CANDIDATE_NAME = 'candidate'
 RELEASE_INFO_FILE = 'RELEASE.INFO'
 
+SALT_MASTER_CONFIG_DEFAULT = '/etc/salt/master'
+SALT_MINION_CONFIG_DEFAULT = '/etc/salt/minion'
 SALT_ROSTER_DEFAULT = '/etc/salt/roster'
 
 # TODO EOS-12076 EOS-12334
@@ -97,6 +108,7 @@ OS_ISO_DIR = 'os'
 CORTX_ISO_DIR = 'cortx_iso'
 CORTX_3RD_PARTY_ISO_DIR = '3rd_party'
 CORTX_PYTHON_ISO_DIR = 'python_deps'
+
 
 PRVSNR_CORTX_REPOS_BASE_DIR = (
     PRVSNR_DATA_LOCAL_DIR / 'cortx_repos'
@@ -125,7 +137,9 @@ PRVSNR_USER_FILES_SSL_CERTS_FILE = Path(
 SSL_CERTS_FILE = Path('/etc/ssl/stx/stx.pem')
 
 GLUSTERFS_VOLUME_SALT_JOBS = Path('/srv/glusterfs/volume_salt_cache_jobs')
+GLUSTERFS_VOLUME_NAME_SALT_JOBS = 'volume_salt_cache_jobs'
 GLUSTERFS_VOLUME_PRVSNR_DATA = Path('/srv/glusterfs/volume_prvsnr_data')
+GLUSTERFS_VOLUME_NAME_PRVSNR_DATA = 'volume_prvsnr_data'
 
 GLUSTERFS_VOLUME_FILEROOT_DIR = GLUSTERFS_VOLUME_PRVSNR_DATA / 'srv/salt'
 GLUSTERFS_VOLUME_PILLAR_DIR = GLUSTERFS_VOLUME_PRVSNR_DATA / 'srv/pillar'
@@ -135,7 +149,11 @@ SEAGATE_USER_FILEROOT_DIR_TMPL = str(
     'components/provisioner/files/users/{uname}'
 )
 
+SSH_PRIV_KEY = Path('/root/.ssh/id_rsa_prvsnr')
+SSH_PUB_KEY = Path('/root/.ssh/id_rsa_prvsnr.pub')
+
 ALL_MINIONS = '*'
+ALL_TARGETS = ALL_MINIONS  # XXX rethink later
 LOCAL_MINION = '__local__'
 
 PRVSNR_VALUES_PREFIX = 'PRVSNR_'
@@ -261,16 +279,21 @@ PRVSNR_USER_FACTORY_PROFILE_DIR = (
 
 def profile_base_dir(
     location: Union[str, Path] = None,
-    setup_name: Optional[str] = 'default'
+    setup_name: Optional[str] = 'default',
+    profile: Optional[Union[str, Path]] = None
 ):
+    if profile:
+        return Path(profile).resolve()
     if location is None:
         location = Path.home() / PROFILE_DIR_NAME
     else:
+        location = Path(location)
         location = location.resolve()
 
     return (location / setup_name)
 
 
+# TODO make a class
 def profile_paths(base_dir: Optional[Path] = None) -> Dict:
     if base_dir is None:
         base_dir = profile_base_dir()
@@ -344,10 +367,15 @@ LOCALHOST_IP = '127.0.0.1'
 LOCALHOST_DOMAIN = 'localhost'
 
 
+# TODO rename to DistType
 class DistrType(Enum):
     """Distribution types"""
-    CORTX = "cortx"       # only release packages
-    BUNDLE = "bundle"     # release packages along with all dependencies
+    # only release packages, optional separate os and deps
+    CORTX = "cortx"
+    # release packages along with all dependencies,
+    # optional python index inside,
+    # optional separate os
+    BUNDLE = "bundle"
 
 
 # Defines a "frozen" list for allowed commands and supported by provisioner
@@ -375,6 +403,8 @@ SETUP_INFO_FIELDS = (NODES, SERVERS_PER_NODE, STORAGE_TYPE, SERVER_TYPE)
 
 # TODO: EOS-12418-improvement: maybe, it makes sense to move it to values.py
 NOT_AVAILABLE = "N/A"
+
+CLI_NEW_SERVICE_USER_PWD_VALUE = '__GENERATE__'  # nosec
 
 
 class Checks(Enum):
@@ -504,3 +534,35 @@ CRITICALLY_FAILED = {"critical": True, "failed": False}
 NON_CRITICALLY_FAILED = {"critical": False, "failed": True}
 
 IS_REPO_KEY = "is_repo"
+
+class SWUpgradeRepos(Enum):
+    """List of supported SW Upgrade Repositories."""
+
+    OS = "os"  # yum repo
+    third_party = "3rd_party"  # yum repo
+    cortx = "cortx_iso"  # yum repo
+    python = "python_deps"  # python index
+
+
+YUM_REPO_TYPE = "yum"
+
+SW_UPGRADE_REPOS = {
+    SWUpgradeRepos.OS.value: {
+        YUM_REPO_TYPE: True
+    },
+    SWUpgradeRepos.third_party.value: {
+        YUM_REPO_TYPE: True
+    },
+    SWUpgradeRepos.cortx.value: {
+        YUM_REPO_TYPE: True
+    },
+    SWUpgradeRepos.python.value: {
+        YUM_REPO_TYPE: False
+    }
+}
+
+
+class CortxResourceT(Enum):
+    """Resource types in CORTX provisioner"""
+
+    REPOS = "cortx_repos"

--- a/api/python/provisioner/discovery.py
+++ b/api/python/provisioner/discovery.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import List
+import logging
+
+from . import (
+    config,
+)
+from .errors import (
+    ProvisionerError,
+    SaltCmdResultError,
+)
+from .node import Node, NodeGrains
+
+logger = logging.getLogger(__name__)
+
+
+class Discoverer:
+
+    @staticmethod
+    def resolve_connections(nodes: List[Node], salt_client):
+        addrs = {}
+
+        # TODO EOS-11511 improve later
+        # the problem: local hostname might appear in grains
+        # (probably for VMs only)
+
+        # local_hostname = socket.gethostname()
+
+        for node in nodes:
+            addrs[node.minion_id] = set(
+                [
+                    v for v in node.addrs
+                    if v not in (
+                        config.LOCALHOST_IP,
+                        config.LOCALHOST_DOMAIN,
+                        # local_hostname
+                    )
+                ]
+            )
+
+        for node in nodes:
+            pings = set()
+            candidates = set(addrs[node.minion_id])
+            for _node in nodes:
+                if _node is not node:
+                    candidates -= addrs[_node.minion_id]
+
+            targets = '|'.join(
+                [_node.minion_id for _node in nodes if _node is not node]
+            )
+
+            for addr in candidates:
+                try:
+                    salt_client.cmd_run(
+                        f"ping -c 1 -W 1 {addr}", targets=targets,
+                        tgt_type='pcre'
+                    )
+                except SaltCmdResultError as exc:
+                    logger.debug(
+                        f"Possible address '{addr}' "
+                        f"of {node.minion_id} is not reachable "
+                        f"from some nodes: {exc}"
+                    )
+                else:
+                    pings.add(addr)
+
+            if pings:
+                logger.info(
+                    f"{node.minion_id} is reachable "
+                    f"from other nodes by: {pings}"
+                )
+            else:
+                raise ProvisionerError(
+                    f"{node.minion_id} is not reachable"
+                    f"from other nodes by any of {candidates}"
+                )
+
+            node.ping_addrs = list(pings)
+
+    @staticmethod
+    def resolve_grains(nodes: List[Node], salt_client):
+        salt_ret = salt_client.run('grains.items')
+        for node in nodes:
+            # assume that list of nodes matches the result
+            # TODO IMPROVE EOS-8473 better parser for grains return
+            node.grains = NodeGrains.from_grains(
+                **salt_ret[node.minion_id]['return']
+            )

--- a/api/python/provisioner/log.py
+++ b/api/python/provisioner/log.py
@@ -32,11 +32,11 @@ from . import inputs
 from .errors import LogMsgTooLong
 from .base import prvsnr_config
 from .config import (
-    LOG_NULL_HANDLER as null_handler,
-    LOG_CONSOLE_HANDLER as console_handler,
-    LOG_FILE_HANDLER as logfile_handler,
-    LOG_FILE_SALT_HANDLER as saltlogfile_handler,
-    LOG_CMD_FILTER as cmd_filter,
+    LOG_NULL_HANDLER as NULL_HANDLER,
+    LOG_CONSOLE_HANDLER as CONSOLE_HANDLER,
+    LOG_FILE_HANDLER as LOGFILE_HANDLER,
+    LOG_FILE_SALT_HANDLER as SALTLOGFILE_HANDLER,
+    LOG_CMD_FILTER as CMD_FILTER,
     LOG_HUMAN_FORMATTER,
     LOG_TRUNC_MSG_TMPL,
     LOG_TRUNC_MSG_SIZE_MAX
@@ -156,15 +156,15 @@ def build_log_args_cls(log_config=None):  # noqa: C901 FIXME
                     }, default=hattrs['formatter']
                 )
 
-        if hname == null_handler:
+        if hname == NULL_HANDLER:
             return _NullLogHandler
-        elif hname == console_handler:
+        elif hname == CONSOLE_HANDLER:
             @attr.s(auto_attribs=True)
             class _ConsoleStreamLogHandler(_LogHandler):
                 stream: str = attr.ib(
                     metadata={
                         inputs.METADATA_ARGPARSER: {
-                            'help': f"{console_handler} log stream",
+                            'help': f"{CONSOLE_HANDLER} log stream",
                             'choices': ['stderr', 'stdout']
                         }
                     },
@@ -172,7 +172,7 @@ def build_log_args_cls(log_config=None):  # noqa: C901 FIXME
                     converter=(lambda stream: 'ext://sys.{}'.format(stream))
                 )
             return _ConsoleStreamLogHandler
-        elif hname in (logfile_handler, saltlogfile_handler):
+        elif hname in (LOGFILE_HANDLER, SALTLOGFILE_HANDLER):
             @attr.s(auto_attribs=True)
             class _FileLogHandler(_LogHandler):
                 filename: str = attr.ib(
@@ -220,11 +220,11 @@ def build_log_args_cls(log_config=None):  # noqa: C901 FIXME
         'hcls': {}
     }
 
-    if type(log_config.get('filters', {}).get(cmd_filter)) is dict:
+    if isinstance(log_config.get('filters', {}).get(CMD_FILTER), dict):
         log_attrs.update({
             'cmd': attr.ib(
                 type=str,
-                default=log_config['filters'][cmd_filter].get(
+                default=log_config['filters'][CMD_FILTER].get(
                     'cmd', 'unknown'
                 ),
                 converter=(lambda cmd: cmd if cmd else 'unknown')
@@ -236,10 +236,10 @@ def build_log_args_cls(log_config=None):  # noqa: C901 FIXME
         # Note. null handler is not dynamically configurable
         log_attrs.update({
             hname: attr.ib(
-                init=(hname != null_handler),
+                init=(hname != NULL_HANDLER),
                 type=bool,
                 default=(hname in log_config['root']['handlers']),
-                metadata=(None if hname == null_handler else {
+                metadata=(None if hname == NULL_HANDLER else {
                     inputs.METADATA_ARGPARSER: {
                         'help': "{} logging handler".format(hname),
                         'action': 'store_bool'
@@ -312,7 +312,7 @@ def build_log_args_cls(log_config=None):  # noqa: C901 FIXME
             res['root']['handlers'][:] = root_handlers + human_handlers
 
             if hasattr(self, 'cmd'):
-                res['filters'][cmd_filter]['cmd'] = self.cmd
+                res['filters'][CMD_FILTER]['cmd'] = self.cmd
 
             return res
 

--- a/api/python/provisioner/node.py
+++ b/api/python/provisioner/node.py
@@ -1,0 +1,131 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import List, Dict, Optional, Iterable
+import logging
+
+from .vendor import attr
+
+
+logger = logging.getLogger(__name__)
+
+
+# TODO TEST EOS-8473
+# TODO IMPROVE EOS-8473 converters and validators
+@attr.s(auto_attribs=True)
+class NodeGrains:
+    fqdn: str = None
+    host: str = None
+    ipv4: List = attr.Factory(list)
+    fqdns: List = attr.Factory(list)
+    not_used: Dict = attr.Factory(dict)
+
+    @classmethod
+    def from_grains(cls, **kwargs):
+        # Note. assumtion that 'not_used' doesn't appear in grains
+        not_used = {
+            k: kwargs.pop(k) for k in list(kwargs)
+            if k not in attr.fields_dict(cls)
+        }
+        return cls(**kwargs, not_used=not_used)
+
+    @property
+    def addrs(self):
+        res = []
+        for _attr in ('host', 'fqdn', 'fqdns', 'ipv4'):
+            v = getattr(self, _attr)
+            if v:
+                if isinstance(v, list):
+                    res.extend(v)
+                else:  # str is expected
+                    res.append(v)
+        return list(set(res))
+
+
+# TODO TEST EOS-8473
+@attr.s(auto_attribs=True)
+class Node:
+    minion_id: str
+    host: str
+    user: str = 'root'
+    port: int = 22
+
+    grains: Optional[NodeGrains] = None
+    # ordered by priority
+    _ping_addrs: List = attr.Factory(list)
+
+    @classmethod
+    def from_spec(cls, spec: str) -> 'Node':
+        kwargs = {}
+
+        parts = spec.split(':')
+        kwargs['minion_id'] = parts[0]
+        hostspec = parts[1]
+
+        try:
+            kwargs['port'] = parts[2]
+        except IndexError:
+            pass
+
+        parts = hostspec.split('@')
+        try:
+            kwargs['user'] = parts[0]
+            kwargs['host'] = parts[1]
+        except IndexError:
+            del kwargs['user']
+            kwargs['host'] = parts[0]
+
+        return cls(**kwargs)
+
+    def __str__(self):
+        return (
+            '{}:{}@{}:{}'
+            .format(
+                self.minion_id,
+                self.user,
+                self.host,
+                self.port
+            )
+        )
+
+    @property
+    def addrs(self):
+        return list(set([self.host] + self.grains.addrs))
+
+    @property
+    def ping_addrs(self):
+        return self._ping_addrs
+
+    @ping_addrs.setter
+    def ping_addrs(self, addrs: Iterable):
+        # TODO IMPROVE EOS-8473 more effective way to order
+        #      w.g. use dict (it remembers the order) and set intersection
+        priorities = [
+            self.grains.fqdn
+        ] + self.grains.fqdns + [
+            self.host,
+            self.grains.host
+        ] + self.grains.ipv4
+
+        self._ping_addrs[:] = []
+        for addr in priorities:
+            if addr in addrs and (addr not in self._ping_addrs):
+                self._ping_addrs.append(addr)
+
+        for addr in addrs:
+            if addr not in self._ping_addrs:
+                self._ping_addrs.append(addr)

--- a/api/python/provisioner/profile.py
+++ b/api/python/provisioner/profile.py
@@ -16,9 +16,12 @@
 #
 
 from typing import Optional, List
+import logging
 
 from . import config
 from .utils import dump_yaml, run_subprocess_cmd
+
+logger = logging.getLogger(__name__)
 
 
 # TODO TEST EOS-8473
@@ -31,7 +34,10 @@ def setup(
     if profile_paths is None:
         profile_paths = config.profile_paths()
 
-    if clean:
+    if clean and profile_paths['base_dir'].exists():
+        logger.warning(
+            f"Cleaning up existing profile {profile_paths['base_dir']}"
+        )
         run_subprocess_cmd(['rm', '-rf', str(profile_paths['base_dir'])])
 
     if add_file_roots is None:

--- a/api/python/provisioner/resources/__init__.py
+++ b/api/python/provisioner/resources/__init__.py
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+from pathlib import Path
+import importlib
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+MODULE_PATH = Path(__file__)
+MODULE_DIR = MODULE_PATH.resolve().parent
+
+
+def list_components():
+    from .base import ComponentBase
+
+    py_files = [
+        i for i in MODULE_DIR.glob('*.py')
+        if i.name != MODULE_PATH.name and i.name == 'test.py'
+    ]
+
+    modules = [
+        importlib.import_module(f'{__package__}.{f.stem}')
+        for f in py_files
+    ]
+
+    res = []
+
+    for mod in modules:
+        for _attr_name in dir(mod):
+            _attr = getattr(mod, _attr_name)
+            try:
+                if not issubclass(_attr, ComponentBase):
+                    raise TypeError
+            except TypeError:
+                pass  # not a class or not a subclass of ComponentBase
+            else:
+                if _attr is not ComponentBase:
+                    if _attr.name:
+                        res.append(_attr)
+                    else:
+                        logger.debug(
+                            f"Ignoring component class {_attr}: "
+                            "undefined 'name'"
+                        )

--- a/api/python/provisioner/resources/base.py
+++ b/api/python/provisioner/resources/base.py
@@ -1,0 +1,379 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Optional, Type, Dict
+from pathlib import Path
+from enum import Enum
+import logging
+# import importlib
+
+# import itertools
+
+from ..vendor import attr
+from ..config import ALL_TARGETS, CortxResourceT
+# from ..values import _Singletone
+
+logger = logging.getLogger(__name__)
+
+MODULE_PATH = Path(__file__)
+MODULE_DIR = MODULE_PATH.resolve().parent
+
+
+class ResourceManagerT(Enum):
+    """SCM types"""
+    SALTSTACK = 'saltstack'
+
+
+# class SetupOST(Enum):
+#     """Target platform types"""
+#     CENTOS_7 = 'centos7'
+#     CENTOS_8 = 'centos8'
+
+
+# @attr.s(auto_attribs=True)
+# class SetupManager:
+#     engine: SetupEngineType = SetupEngineType.SALTSTACK
+#     os: SetupEngineType = SetupOSType.CENTOS_8
+#
+#     def __attrs_post_init__(self):
+#         self.name = self._attr.name
+#         self._register = COMPONENTS_REGISTER
+
+
+class ResourceParams:
+    """Base class for resource parameters."""
+
+
+@attr.s(auto_attribs=True)
+class ResourceBase:
+    """Base class for resources.
+
+    ...
+
+    Attributes
+    ----------
+    name : string
+        Name of the resource.
+
+    """
+    resource_t_id: ClassVar[Optional[CortxResourceT]] = None
+    params_t: ClassVar[Optional[Type[ResourceParams]]] = None
+
+
+@attr.s(auto_attribs=True)
+class ResourceState:
+    """Base class for resource state."""
+    name: ClassVar[Optional[str]] = None
+    resource_t: ClassVar[Optional[Type[ResourceBase]]] = None
+
+
+@attr.s(auto_attribs=True)
+class ResourceTransition(ABC):
+    """Base class for resource state transitions."""
+    state_t: ClassVar[Optional[Type[ResourceState]]] = None
+
+    state: ResourceState = attr.ib(
+        validator=attr.validators.instance_of(ResourceState)
+    )
+
+    # XXX need abstraction for targets:
+    #     - different SCM might use different aliases for all targets,
+    #       different bulk targeting (lists, globs, regex ...)
+    @abstractmethod
+    def run(self, targets: Any = ALL_TARGETS):
+        """Move a resource to a state on specified targets."""
+
+
+@attr.s(auto_attribs=True)
+class ResourceManager:
+    """Base class for resource state transitions."""
+    engine_t: ClassVar[Optional[Type[ResourceManagerT]]] = None
+
+    transitions: Dict[
+        Type[ResourceState], Type[ResourceTransition]
+    ] = attr.Factory(dict)
+
+    def __attrs_post_init__(self):
+        pass
+
+    def run(
+        self,
+        state: ResourceState,
+        targets: Any = ALL_TARGETS,
+        trans_args=None, trans_kwargs=None,
+        *args, **kwargs
+    ):
+        """Apply state on specified targets."""
+
+        try:
+            transition_t = self.transitions[type(state)]
+        except KeyError:
+            raise TypeError(f'unsupported state type {type(state)}')
+
+        if trans_args is None:
+            trans_args = []
+
+        if trans_kwargs is None:
+            trans_kwargs = {}
+
+        trans = transition_t(state, *trans_args, **trans_kwargs)
+        return trans.run(*args, targets=targets, **kwargs)
+
+
+# class ResourceManagerBase(ABC):
+#     """Base class for resource managers.
+#     """
+#     name = None
+#     os_types = None
+#     engine_types = None
+#
+#     @abstractmethod
+#     def apply(self, resource: ResourceBase, new_state: Resource):
+#         ...
+#
+#
+# _MngrResp = attr.make_class(
+#     "_MngrResp", ('engine', 'os_name'), frozen=True
+# )
+#
+#
+# class _ResourcesRegister(_Singletone):
+#
+#     def __init__(self):
+#         self._resources = None
+#         self._managers = None
+#
+#     def _load(self):
+#         py_files = [
+#             i for i in MODULE_DIR.glob('*.py')
+#             if i.name not in (MODULE_PATH.name, '__init__.py')
+#         ]
+#
+#         modules = [
+#             importlib.import_module(f'{__package__}.{f.stem}')
+#             for f in py_files
+#         ]
+#
+#         resources = []
+#         managers = []
+#
+#         for mod in modules:
+#             for _attr_name in dir(mod):
+#                 _attr = getattr(mod, _attr_name)
+#
+#                 for (base_cls, res) in [
+#                     (ResourceBase, self.resources),
+#                     (ResourceManagerBase, self.managers)
+#                 ]:
+#                     try:
+#                         if not issubclass(_attr, base_cls):
+#                             raise TypeError
+#                     except TypeError:
+#                         pass  # not a class or not a subclass of ResourceBase
+#                     else:
+#                         if _attr.name:
+#                             res.append(_attr)
+#                         else:
+#                             logger.debug(
+#                                 f"Ignoring resource class {_attr}: "
+#                                 "undefined 'name'"
+#                             )
+#
+#         self.resources = {comp.name: comp for comp in resources}
+#         # TODO optimize: ranges
+#         for mngr in managers:
+#             self.managers = {
+#                 _MngrResp(*resp): mngr
+#                 for resp in itertools.product(
+#                     mngr.eng_types,
+#                     mngr.os_types
+#                 )
+#             }
+#
+#     @property
+#     def resources(self):
+#         if self._resources is None:
+#             self._load()
+#         return self._resources
+#
+#     def mananger(self, comp_t, engine, os_name):
+#         if self._managers is None:
+#             self._load()
+#         return self.managers.get(_MngrResp(engine, os_name))
+#
+#     def reload(self):
+#         self._load()
+#
+#
+# COMPONENTS_REGISTER = _ResourcesRegister()
+#
+#
+# @attr.s(auto_attribs=True)
+# class SaltState:
+#     """Base class for SaltStack resource state.
+#
+#     Attributes define set of pillar keys to parametrize salt state.
+#
+#     ...
+#
+#     Attributes
+#     ----------
+#
+#     Methods
+#     -------
+#
+#     Examples
+#     --------
+#
+#     GlusterFS ''replaced'' state logic may require:
+#
+#     - old node role
+#     - old node location (host)
+#     - new node location
+#     """
+#     targets: str = ALL_MINIONS
+#
+#
+# class SaltStackResourceManager(ABC):
+#     """Base class for resource managers based on SaltStack. """
+#     name = 'saltstack'
+#     os_types = list(SetupOSType)
+#     engine_types = [SetupEngineType.SALTSTACK]
+#
+#     def apply(self, resource: ResourceBase, new_state: ResourceState):
+#         for pillar in new_state_attr_list:
+#             pillar_set pillar
+#         salt.state_apply(new_state.name, targets=new_state.targets)
+#
+
+# class DeployStage(ResourceState):
+#     resource = None
+#     stage = None
+#     prefix = 'components'
+#
+#     @property
+#     def state():
+#         return f"{self.prefix}.{self.resource}.{self.stage}"
+#
+#
+#
+# @attr.s(auto_attribs=True)
+# class ClusterResourceState(ResourceState):
+#     resource_id: ClusterResourceID
+#
+#
+# class SWManagerBase(ResourceManagerBase):
+#
+#     def setup(self, comp: Any, targets=ALL_MINIONS):
+#         self.prepare(comp, targets)
+#         self.install(comp, targets)
+#         self.config(comp, targets)
+#
+#     @abstractmethod
+#     def prepare(self, comp: Any, targets=ALL_MINIONS):
+#         ...
+#
+#     @abstractmethod
+#     def install(self, comp: Any, targets=ALL_MINIONS):
+#         ...
+#
+#     @abstractmethod
+#     def config(self, comp: Any, targets=ALL_MINIONS):
+#         ...
+#
+#
+# class ServiceManagerBase(SWManagerBase):
+#
+#     def setup(self, comp: Any, targets=ALL_MINIONS):
+#         super().setup(comp, targets)
+#         self.start(comp, targets)
+#
+#     @abstractmethod
+#     def start(self, comp: Any, targets=ALL_MINIONS):
+#         ...
+#
+#     @abstractmethod
+#     def stop(self, comp: Any, targets=ALL_MINIONS):
+#         ...
+#
+#
+# class ClusteredServiceManagerBase(SWManagerBase):
+#
+#     def setup(self, comp: Any, targets=ALL_MINIONS):
+#         super().setup(comp, targets)
+#         self.join(comp, targets)
+#
+#     @abstractmethod
+#     def join(self, comp: Any, targets=ALL_MINIONS):
+#         self.start(comp, targets)
+#         self.attach(comp, targets)
+#
+#     def attach(self, comp: Any, targets=ALL_MINIONS):
+#         pass
+#
+#     @abstractmethod
+#     def disconnect(self, comp: Any, targets=ALL_MINIONS):
+#         self.detach(comp, targets)
+#         self.stop(comp, targets)
+#
+#     def detach(self, comp: Any, targets=ALL_MINIONS):
+#         pass
+#
+#
+# # Note.
+# #   - attach/detach makes sense only for active services (masters),
+# #     clients might be just stopped
+# class ClusterManagerBase(SWManagerBase):
+#
+#     def setup(self, comp: Any, targets=ALL_MINIONS):
+#         super().setup(comp, targets)
+#         self.join(comp, targets)
+#
+#     @abstractmethod
+#     def join(self, comp: Any, targets=ALL_MINIONS):
+#         self.start(comp, targets)
+#         self.attach(comp, targets)
+#
+#     def attach(self, comp: Any, targets=ALL_MINIONS):
+#         pass
+#
+#     @abstractmethod
+#     def disconnect(self, comp: Any, targets=ALL_MINIONS):
+#         self.detach(comp, targets)
+#         self.stop(comp, targets)
+#
+#     def detach(self, comp: Any, targets=ALL_MINIONS):
+#         pass
+#
+#
+#
+# entity manager (set): implies R
+#     - no state
+#     - api:            implies S
+#         - install T
+#         - config T
+#         - start T
+#         - stop T
+#         - disconnect T
+#
+# cluster manager:
+#     - structure:
+#         - entity: T, R, S
+#     - api:
+#         - apply
+#         - adjust(target:role)

--- a/api/python/provisioner/resources/cortx_repos.py
+++ b/api/python/provisioner/resources/cortx_repos.py
@@ -1,0 +1,147 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import Union
+from pathlib import Path
+import logging
+
+from .base import (
+    ResourceParams, ResourceBase, ResourceState
+)
+from provisioner import config, inputs, utils
+from provisioner.vendor import attr
+
+
+logger = logging.getLogger(__name__)
+
+
+# XXX - default values depends on context (business logic),
+#       e.g. might be UNCHANGED or a real current value
+class CortxReposParams(ResourceParams):
+    # TODO EOS-12076 validate it is a file or dir or url
+    cortx: Union[str, Path] = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "path/url to a CORTX distribution"
+                ),
+            }
+        },
+        # FIXME allow url as well
+        # XXX copy validation routine from SetSWUpdateRepo
+        converter=utils.converter_path_resolved,
+        validator=utils.validator_path_exists
+    )
+    dist_type: config.DistrType = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "the type of the distribution"
+                ),
+                'choices': [dt.value for dt in config.DistrType]
+            },
+        },
+        default=config.DistrType.BUNDLE.value,
+        # TODO EOS-12076 better validation
+        converter=(lambda v: config.DistrType(v))  # pylint: disable=unnecessary-lambda
+    )
+    deps: Union[str, Path] = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "path/url to a CORTX 3rd parties distribution"
+                ),
+            }
+        },
+        default=None,
+        # FIXME allow url as well
+        # XXX copy validation routine from SetSWUpdateRepo
+        converter=utils.converter_path_resolved,
+        validator=utils.validator_path_exists
+    )
+    os: Union[str, Path] = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "path/url to a CORTX OS distribution"
+                ),
+            }
+        },
+        default=None,
+        # FIXME allow url as well
+        # XXX copy validation routine from SetSWUpdateRepo
+        converter=utils.converter_path_resolved,
+        validator=utils.validator_path_exists
+    )
+    py_index: bool = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "consider a custom python index inside CORTX distribution "
+                    "(for bundle distribution only)"
+                )
+            }
+        },
+        default=False
+    )
+
+
+@attr.s(auto_attribs=True)
+class CortxRepos(ResourceBase):
+    resource_t_id = config.CortxResourceT.REPOS
+    params_t = CortxReposParams
+
+
+@attr.s(auto_attribs=True)
+class CortxReposState(ResourceState):
+    resource_t = CortxRepos
+
+
+@attr.s
+class CortxReposSetup(CortxReposState):
+    name = 'setup'
+
+    dist_type = CortxReposParams.dist_type
+    cortx = CortxReposParams.cortx
+    deps = CortxReposParams.deps
+    os = CortxReposParams.os
+    py_index = CortxReposParams.py_index
+
+    target_build: Path = attr.ib(
+        init=False, default=None
+    )
+
+    # XXX - for UNCHANCGED values we may resolve real values here
+    #       and validate only after that
+    def __attrs_post_init__(self):  # noqa: C901
+        # TODO check that ISOs are not the same
+
+        if self.dist_type == config.DistrType.BUNDLE:
+            self.target_build = (
+                'file://{}'.format(
+                    config.PRVSNR_CORTX_REPOS_BASE_DIR /
+                    config.CORTX_SINGLE_ISO_DIR
+                )
+            )
+        else:
+            if self.cortx is ('ISO' or 'dir'):  # FIXME
+                self.target_build = 'file://{}'.format(
+                    config.PRVSNR_CORTX_REPOS_BASE_DIR /
+                    config.CORTX_ISO_DIR
+                )
+            else:  # url
+                self.target_build = self.cortx

--- a/api/python/provisioner/salt_api/base.py
+++ b/api/python/provisioner/salt_api/base.py
@@ -17,19 +17,26 @@
 
 from abc import ABC, abstractmethod
 from typing import (
-    List, Union, Dict, Tuple, Any, Type
+    List, Union, Dict, Tuple, Any, Type, Optional, Iterable
 )
 import logging
-from pprint import pformat
+from pathlib import Path
 
 from ..vendor import attr
-from ..config import (
-   SECRET_MASK
-)
+from .. import config, inputs
 from ..errors import (
     SaltNoReturnError,
-    SaltCmdRunError, SaltCmdResultError
+    SaltCmdRunError,
+    SaltCmdResultError,
+    ProvisionerError
 )
+from ..paths import (
+    PillarPath, FileRootPath, USER_SHARED_PILLAR, USER_SHARED_FILEROOT
+)
+from ..pillar import PillarUpdaterNew
+from .._api_cli import process_cli_result
+from ..values import is_special
+from ..pillar import PillarIterable
 
 logger = logging.getLogger(__name__)
 
@@ -68,17 +75,17 @@ class SaltArgsBase:
     def _as_dict(self):
         _dct = attr.asdict(self)
         if 'password' in _dct['kw']:
-            _dct['kw']['password'] = SECRET_MASK
+            _dct['kw']['password'] = config.SECRET_MASK
 
         if 'password' in _dct['fun_kwargs']:
-            _dct['fun_kwargs']['password'] = SECRET_MASK
+            _dct['fun_kwargs']['password'] = config.SECRET_MASK
 
         # we do not mask the 'kw' more since
         # it should include only salt related parameters
         # that are safe to show
         if self.secure:
-            _dct['fun_args'] = SECRET_MASK
-            _dct['fun_kwargs'] = SECRET_MASK
+            _dct['fun_args'] = config.SECRET_MASK
+            _dct['fun_kwargs'] = config.SECRET_MASK
 
         return _dct
 
@@ -173,10 +180,55 @@ class SaltClientJobResult(SaltClientResultBase):
         return fails
 
 
+def converter__pillar_path(path):
+    if not isinstance(path, PillarPath):
+        # XXX prefix ???
+        path = PillarPath(path, config.PRVSNR_USER_PILLAR_PREFIX)
+    return path
+
+
+def converter__fileroot_path(path):
+    return (
+        path if isinstance(path, FileRootPath) else FileRootPath(path)
+    )
+
+
+class SaltClientBaseParams:
+    pillar_path: Union[PillarPath, str] = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "path to writeable (user) pillar path",
+                'default': str(USER_SHARED_PILLAR.root),
+                'metavar': 'PATH'
+            }
+        },
+        default=USER_SHARED_PILLAR,
+        converter=converter__pillar_path,
+        validator=attr.validators.instance_of(PillarPath)
+    )
+    fileroot_path: Union[FileRootPath, str] = attr.ib(
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "path to writeable (user) pillar path",
+                'default': str(USER_SHARED_FILEROOT.root),
+                'metavar': 'PATH'
+            }
+        },
+        default=USER_SHARED_FILEROOT,
+        converter=converter__fileroot_path,
+        validator=attr.validators.instance_of(FileRootPath)
+    )
+
+
 # TODO TEST EOS-8473
 @attr.s(auto_attribs=True)
 class SaltClientBase(ABC):
     c_path: str = None
+
+    fileroot_path: Union[FileRootPath, str] = (
+        SaltClientBaseParams.fileroot_path
+    )
+    pillar_path: Union[PillarPath, str] = SaltClientBaseParams.pillar_path
 
     @property
     @abstractmethod
@@ -219,8 +271,8 @@ class SaltClientBase(ABC):
     def run(
         self,
         fun: str,
-        fun_args: Union[Tuple, None] = None,
-        fun_kwargs: Union[Dict, None] = None,
+        fun_args: Optional[Tuple] = None,
+        fun_kwargs: Optional[Dict] = None,
         secure=False,
         **kwargs
     ):
@@ -260,10 +312,9 @@ class SaltClientBase(ABC):
 
         try:
             logger.debug(
-                f"Function '{fun}' on '{targets}' "
-                f"resulted in {pformat(res.results)}"
+                f"'{type(self)}' client: Function '{fun}' resulted in "
+                f"{res.results}"
             )
-
         except Exception as exc:
             if (type(exc).__name__ == 'OSError' and exc.strerror == 'Message too long'):  # noqa: E501
                 logger.exception("Exception Skipped: {}".format(str(exc.strerror)))  # noqa: E501
@@ -276,7 +327,7 @@ class SaltClientBase(ABC):
         self,
         fun,
         fun_fun: str,
-        fun_args: Union[List, Tuple, None] = None,
+        fun_args: Optional[Union[List, Tuple]] = None,
         **kwargs
     ):
         return self.run(
@@ -286,13 +337,103 @@ class SaltClientBase(ABC):
         )
 
     def state_apply(self, state: str, **kwargs):
-        return self.fun_fun('state.apply', state, **kwargs)
+        return self._fun_fun('state.apply', state, **kwargs)
 
     def cmd_run(self, cmd: str, **kwargs):
-        return self.fun_fun('cmd.run', cmd, **kwargs)
+        return self._fun_fun('cmd.run', cmd, **kwargs)
 
     def state_single(self, state_fun: str, **kwargs):
-        return self.fun_fun('state.single', state_fun, **kwargs)
+        return self._fun_fun('state.single', state_fun, **kwargs)
 
     def pillar_get(self, **kwargs):
         return self.run('pillar.items', **kwargs)
+
+    def pillar_refresh(self, **kwargs):
+        return self.run('saltutil.refresh_pillar', **kwargs)
+
+    @staticmethod
+    def process_provisioner_cmd_res(res, runner_minion_id):
+        if not isinstance(res, dict) or len(res) != 1:
+            raise ProvisionerError(
+                f"Expected a dictionary of len = 1, "
+                f"provided: {type(res)}, {res}"
+            )
+
+        # FIXME EOS-9581 it might be other minion id in case of HA
+        if runner_minion_id not in res:
+            logger.warning(
+                f"local minion id {runner_minion_id} is not listed "
+                f"in results: {list(res)}, might be initiated by other node"
+            )
+
+        # provisioner cli output
+        prvsnr_res = next(iter(res.values()))
+        return process_cli_result(prvsnr_res)
+
+    def provisioner_cmd(
+        self,
+        cmd,
+        runner_minion_id,
+        fun_args: Optional[Union[List, Tuple]] = None,
+        fun_kwargs: Optional[Dict] = None,
+        **kwargs
+    ):
+        def _value(v):
+            return str(v) if is_special(v) else v
+
+        _fun_args = fun_args
+        if isinstance(fun_args, Iterable):
+            _fun_args = [_value(v) for v in fun_args]
+
+        _fun_kwargs = fun_kwargs
+        if isinstance(fun_kwargs, Dict):
+            _fun_kwargs = {k: _value(v) for k, v in fun_kwargs.items()}
+
+        try:
+            res = self.run(
+                'provisioner.{}'.format(cmd),
+                fun_args=_fun_args,
+                fun_kwargs=_fun_kwargs,
+                targets=runner_minion_id,
+                **kwargs
+            )
+        except SaltCmdResultError as exc:
+            # XXX async error case
+            # if nowait:
+            #     raise ProvisionerError(
+            #         'SaltCmdResultError is unexpected here: {!r}'.format(exc)
+            #     ) from exc
+            # else:
+            return self.process_provisioner_cmd_res(
+                exc.reason, runner_minion_id
+            )
+        else:
+            # XXX async return case
+            # if nowait:
+            #     return res
+            # else:
+            return self.process_provisioner_cmd_res(res, runner_minion_id)
+
+    def pillar_updater(self, targets=config.ALL_MINIONS):
+        return PillarUpdaterNew(
+            pillar_path=self.pillar_path,
+            targets=targets,
+            client=self
+        )
+
+    def fileroot_writer(self):
+        from ..fileroot import FileRoot  # FIXME
+        return FileRoot(self.fileroot_path)
+
+    def add_file_roots(self, roots: List[Path]):
+        raise NotImplementedError
+
+    def pillar_set(
+        self,
+        pillar_items: Union[Dict, List, Tuple],
+        fpath: str = None,
+        targets=config.ALL_MINIONS
+    ):
+        pi_updater = self.pillar_updater(targets)
+        pi_updater.update(PillarIterable(pillar_items, fpath=fpath))
+        pi_updater.apply()

--- a/api/python/provisioner/scm/__init__.py
+++ b/api/python/provisioner/scm/__init__.py
@@ -14,29 +14,3 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
-
-__title__ = 'cortx-prvsnr'
-__version__ = '2.0.43'
-__author__ = "Seagate"
-__author_email__ = 'support@seagate.com'  # TODO
-__maintainer__ = 'Seagate'
-__maintainer_email__ = __author_email__
-__url__ = 'https://github.com/Seagate/cortx-prvsnr'
-__description__ = 'Provisioner API for CORTX components'
-__long_description__ = __description__
-__download_url__ = f"{__url__}"
-__license__ = "Seagate"  # TODO
-
-__all__ = [
-    '__title__',
-    '__version__',
-    '__author__',
-    '__author_email__',
-    '__maintainer__',
-    '__maintainer_email__',
-    '__url__',
-    '__description__',
-    '__long_description__',
-    '__download_url__',
-    '__license__',
-]

--- a/api/python/provisioner/scm/saltstack/__init__.py
+++ b/api/python/provisioner/scm/saltstack/__init__.py
@@ -14,29 +14,3 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
-
-__title__ = 'cortx-prvsnr'
-__version__ = '2.0.43'
-__author__ = "Seagate"
-__author_email__ = 'support@seagate.com'  # TODO
-__maintainer__ = 'Seagate'
-__maintainer_email__ = __author_email__
-__url__ = 'https://github.com/Seagate/cortx-prvsnr'
-__description__ = 'Provisioner API for CORTX components'
-__long_description__ = __description__
-__download_url__ = f"{__url__}"
-__license__ = "Seagate"  # TODO
-
-__all__ = [
-    '__title__',
-    '__version__',
-    '__author__',
-    '__author_email__',
-    '__maintainer__',
-    '__maintainer_email__',
-    '__url__',
-    '__description__',
-    '__long_description__',
-    '__download_url__',
-    '__license__',
-]

--- a/api/python/provisioner/scm/saltstack/rc_sls/__init__.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/__init__.py
@@ -14,29 +14,3 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
-
-__title__ = 'cortx-prvsnr'
-__version__ = '2.0.43'
-__author__ = "Seagate"
-__author_email__ = 'support@seagate.com'  # TODO
-__maintainer__ = 'Seagate'
-__maintainer_email__ = __author_email__
-__url__ = 'https://github.com/Seagate/cortx-prvsnr'
-__description__ = 'Provisioner API for CORTX components'
-__long_description__ = __description__
-__download_url__ = f"{__url__}"
-__license__ = "Seagate"  # TODO
-
-__all__ = [
-    '__title__',
-    '__version__',
-    '__author__',
-    '__author_email__',
-    '__maintainer__',
-    '__maintainer_email__',
-    '__url__',
-    '__description__',
-    '__long_description__',
-    '__download_url__',
-    '__license__',
-]

--- a/api/python/provisioner/scm/saltstack/rc_sls/base.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/base.py
@@ -1,0 +1,123 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import ClassVar, Optional, Dict, Union, Any
+from pathlib import Path
+import importlib
+import logging
+
+from provisioner.values import _Singletone
+from provisioner.vendor import attr
+from provisioner.resources.base import (
+    ResourceTransition,
+    ResourceManagerT,
+    ResourceManager
+)
+from provisioner.salt_api.base import SaltClientBase
+from provisioner.fileroot import ResourcePath
+from provisioner import config
+
+logger = logging.getLogger(__name__)
+
+MODULE_PATH = Path(__file__)
+MODULE_DIR = MODULE_PATH.resolve().parent
+
+
+@attr.s(auto_attribs=True)
+class ResourceSLS(ResourceTransition):  # XXX ??? inheritance
+    """Base class for Salt state formulas that implement transitions."""
+    sls: ClassVar[Optional[str]] = None
+
+    client: SaltClientBase
+    pillar_inline: Dict = None
+
+    def r_path(self, path: Union[str, Path]):
+        return ResourcePath(self.resource_t, path)
+
+    def fileroot_path(self, path: Union[str, Path]):
+        return self.fileroot.path(self.r_path(path))
+
+    def setup_roots(self, targets):
+        pass
+
+    def run(self, targets: Any = config.ALL_TARGETS):
+        self.setup_roots(targets)
+
+        # XXX possibly a divergence with a design
+        # some SLS may just shifts root without any states appliance
+        if self.sls:
+            fun_kwargs = {}
+            if self.pillar_inline:
+                fun_kwargs['pillar'] = self.pillar_inline
+
+            self.client.state_apply(
+                self.sls, targets=targets, fun_kwargs=fun_kwargs
+            )
+
+
+# arbitrary dir and recursive are not support for now
+class TypesLoader:
+
+    @staticmethod
+    def load(
+        base_t: Any, base_dir: Path = MODULE_DIR, recursive=False
+    ):
+        res = []
+
+        if base_dir != MODULE_DIR or recursive:
+            raise NotImplementedError()
+
+        py_files = [
+            i for i in base_dir.glob('**/.*.py' if recursive else '*.py')
+            # if i.name not in (MODULE_PATH.name, '__init__.py')
+        ]
+
+        modules = [
+            importlib.import_module(f'{__package__}.{f.stem}')
+            for f in py_files
+        ]
+
+        for mod in modules:
+            for _attr_name in dir(mod):
+                _attr = getattr(mod, _attr_name)
+
+                try:
+                    # we either fails with TypeError (not a class) or
+                    # we raise the error explicitly if False (not a subclass)
+                    if not issubclass(_attr, base_t):
+                        raise TypeError
+                except TypeError:
+                    pass
+                else:
+                    res.append(_attr)
+
+        return res
+
+
+@attr.s(auto_attribs=True)
+class SLSResourceManager(ResourceManager, _Singletone):
+
+    engine_t = ResourceManagerT.SALTSTACK
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        sls_types = TypesLoader.load(ResourceSLS)
+
+        self.transitions.update(
+            {sls_t.state_t: sls_t for sls_t in sls_types if sls_t.state_t}
+        )

--- a/api/python/provisioner/scm/saltstack/rc_sls/cortx_repos.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/cortx_repos.py
@@ -1,0 +1,217 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import logging
+
+from .base import ResourceSLS
+
+from provisioner.resources import cortx_repos
+from provisioner import config
+
+
+logger = logging.getLogger(__name__)
+
+
+# XXX validation after setup
+class CortxReposSetupSLS(ResourceSLS):
+    sls = 'repos'
+    state_t = cortx_repos.CortxReposSetup
+
+    @staticmethod
+    def _iso_or_dir(path):
+        return (
+            path and (
+                path.is_dir() or (path.is_file() and path.suffix == '.iso')
+            )
+        )
+
+    @staticmethod
+    def _add_3rd_parties(repos, deps_url):
+        repos.update({
+            # TODO hard-coded
+            '3rd_party_epel': (
+                f"{deps_url}/EPEL-7" if deps_url else None
+            ),
+            '3rd_party_saltstack': (
+                f"{deps_url}/commons/saltstack-3001" if deps_url else None
+            ),
+            '3rd_party_glusterfs': (
+                f"{deps_url}/commons/glusterfs" if deps_url else None
+            )
+        })
+
+    def _prepare_release_pillar(
+        self, deps_url, repos, python_repo=None
+    ):
+        return {
+            'release': {
+                'type': str(self.state.dist_type),
+                'target_build': self.state.target_build,
+                'deps_bundle_url': deps_url,
+                'base': {
+                    'repos': repos
+                },
+                'python_repo': python_repo
+            }
+        }
+
+    def setup_roots_for_bundle(self, targets):
+        file_roots = [self.state.cortx.parent]
+
+        deps_bundle_url = (
+            f"{self.state.target_build}/{config.CORTX_3RD_PARTY_ISO_DIR}"
+        )
+
+        repos = {
+            config.CORTX_SINGLE_ISO_DIR: {
+                'source': f"salt://{self.state.cortx.name}",
+                'is_repo': False
+            },
+            config.CORTX_ISO_DIR: (
+                f"{self.state.target_build}/{config.CORTX_ISO_DIR}"
+            ),
+            config.CORTX_3RD_PARTY_ISO_DIR: deps_bundle_url
+        }
+
+        self._add_3rd_parties(repos, deps_bundle_url)
+
+        if self.state.os:
+            repos[config.OS_ISO_DIR] = f"salt://{self.state.os.name}"
+            file_roots.append(self.state.os.parent)
+        else:
+            repos[config.OS_ISO_DIR] = None
+
+        python_repo = (
+            f"{self.state.target_build}/{config.CORTX_PYTHON_ISO_DIR}"
+            if self.state.py_index else None
+        )
+        pillar = self._prepare_release_pillar(
+            deps_bundle_url, repos, python_repo
+        )
+
+        return file_roots, pillar
+
+    def setup_roots_for_cortx(self, targets):
+        repos = {}
+        file_roots = []
+
+        # XXX copy validation routine from SetSWUpdateRepo
+        if self._iso_or_dir(self.state.cortx):
+            repos[config.CORTX_ISO_DIR] = f"salt://{self.state.cortx.name}"
+            file_roots.append(self.state.cortx.parent)
+        else:
+            repos[config.CORTX_ISO_DIR] = str(self.state.cortx)
+
+        # XXX copy validation routine from SetSWUpdateRepo
+        if self._iso_or_dir(self.state.deps):
+            deps_url = 'file://{}'.format(
+                config.PRVSNR_CORTX_REPOS_BASE_DIR /
+                config.CORTX_3RD_PARTY_ISO_DIR
+            )
+            repos[config.CORTX_3RD_PARTY_ISO_DIR] = (
+                f"salt://{self.state.deps.name}"
+            )
+            file_roots.append(self.state.deps.parent)
+        elif self.state.deps:  # url
+            deps_url = self.state.deps
+            repos[config.CORTX_3RD_PARTY_ISO_DIR] = str(self.state.deps)
+        else:
+            deps_url = None
+            repos[config.CORTX_3RD_PARTY_ISO_DIR] = None
+
+        self._add_3rd_parties(repos, deps_url)
+
+        if self.state.os:
+            if self._iso_or_dir(self.state.os):
+                repos[config.OS_ISO_DIR] = f"salt://{self.state.os.name}"
+                file_roots.append(self.state.os.parent)
+            else:
+                repos[config.OS_ISO_DIR] = str(self.state.os)
+        else:
+            repos[config.OS_ISO_DIR] = None
+
+        pillar = self._prepare_release_pillar(deps_url, repos)
+
+        return file_roots, pillar
+
+    def setup_roots(self, targets):
+        logger.info("Preparing CORTX repos roots")
+        if self.state.dist_type == config.DistrType.BUNDLE:
+            file_roots, pillar = self.setup_roots_for_bundle(targets)
+        else:
+            file_roots, pillar = self.setup_roots_for_cortx(targets)
+
+        if file_roots:
+            self.client.add_file_roots(file_roots)
+
+        if pillar:
+            self.client.pillar_set(pillar)
+
+        # TODO IMPROVE DOC EOS-12076 Iso installation logic:
+        #   - iso files are copied to user local file roots on all remotes
+        #     (TODO consider user shared, currently glusterfs
+        #      is not enough trusted)
+        #   - iso is mounted to a location inside user local data
+        #   - a repo file is created and pointed to the mount directory
+        # TODO EOS-12076 IMPROVE hard-coded
+        # do not copy ISO for the node where we are now already
+
+#    def run(self):
+#        if (
+#            self.field_setup
+#            and self.source == 'iso'
+#            and (
+#                not self.iso_os
+#                or self.iso_os == config.PRVSNR_OS_ISO
+#            )
+#            and (
+#                self.iso_cortx == config.PRVSNR_CORTX_SINGLE_ISO
+#                or (
+#                    self.iso_cortx == config.PRVSNR_CORTX_ISO and
+#                    self.iso_deps == config.PRVSNR_CORTX_DEPS_ISO
+#                )
+#            )
+#        ):
+#            # FIXME it is valid only for replace_node logic,
+#            #       not good to rely on some specific case here
+#            # FIXME hardcoded pillar key
+#            ssh_client.state_apply(
+#                'repos', targets=self.primary.minion_id,
+#                fun_kwargs={
+#                    'pillar': {
+#                        'skip_iso_copy': True
+#                    }
+#                }
+#            )
+#            # NOTE for now salt-ssh supports only glob and regex targetting
+#            # https://docs.saltstack.com/en/latest/topics/ssh/#targeting-with-salt-ssh  # noqa: E501
+#            ssh_client.state_apply(
+#                'repos',
+#                targets='|'.join([
+#                    node.minion_id for node in self.secondaries
+#                ]),
+#                tgt_type='pcre'
+#            )
+#        else:
+#            # copy ISOs onto all remotes and mount
+#            ssh_client.state_apply('repos')
+#
+#        ssh_client.state_apply('cortx_repos')  # FIXME EOS-12076
+#
+#        if not self.pypi_repo:
+#            logger.info("Setting up custom python repository")
+#            ssh_client.state_apply('repos.pip_config')

--- a/api/python/provisioner/srv/salt/_modules/prvsnr.py
+++ b/api/python/provisioner/srv/salt/_modules/prvsnr.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+
+# HOW TO DEBUG:
+# - set a breakpoint: import pdb; pdb.set_trace()
+# - salt-run saltutil.sync_modules
+# - salt-run salt.cmd provisioner.<fun> ... <args>
+
+__virtualname__ = 'provisioner'
+
+try:
+    import provisioner  # pylint: disable=unused-import
+except ImportError:
+    import subprocess  # nosec
+    from pathlib import Path
+    # TODO pip3 installs provisioner to /usr/local/lib/python3.6/site-packages
+    #      but that directory is not listed in salt's sys.path,
+    #      EOS-5401 might be related
+    try:
+        prvsnr_pkg_path = subprocess.run(  # nosec
+            "python3 -c 'import provisioner; print(provisioner.__file__)'",
+            check=True,
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+            shell=True
+        ).stdout.strip()
+        sys.path.insert(0, str(Path(prvsnr_pkg_path).parent.parent))
+        import provisioner  # noqa
+    except Exception:
+        HAS_PROVISIONER = False
+    else:
+        HAS_PROVISIONER = True
+else:
+    HAS_PROVISIONER = True
+
+
+# TODO generate docs
+def _api_wrapper(fun):
+    from provisioner._api_cli import api_args_to_cli
+    from shlex import quote
+
+    # TODO subprocess.list2cmdline is an another option
+    #      but it is not documented as API
+
+    def _f(*args, **kwargs):
+        _kwargs = {k: v for k, v in kwargs.items() if not k.startswith('__')}
+
+        _kwargs['noconsole'] = True
+        _kwargs['rsyslog'] = True
+        _kwargs['rsyslog-level'] = 'DEBUG'
+        _kwargs['rsyslog-formatter'] = 'full'
+
+        # don't make sense here
+        for k in ('nowait', 'username', 'password', 'eauth'):
+            _kwargs.pop(k, None)
+
+        # turn off salt job mode as well to prevent infinite api loop
+        env = {
+            'PRVSNR_SALT_JOB': 'no',
+            'PRVSNR_OUTPUT': 'json'
+        }
+
+        cmd = ['provisioner']
+        cmd.extend(api_args_to_cli(fun, *args, **_kwargs))
+        cmd = [quote(p) for p in cmd]
+        return __salt__['cmd.run'](' '.join(cmd), env=env)  # noqa: F821 pylint: disable=undefined-variable
+
+    return _f
+
+
+if HAS_PROVISIONER:
+    from provisioner.api_spec import api_spec
+    mod = sys.modules[__name__]
+    for fun in api_spec:
+        setattr(mod, fun, _api_wrapper(fun))
+
+
+def __virtual__():  # noqa: N807
+    if HAS_PROVISIONER:
+        return __virtualname__
+
+    return (
+        False,
+        (
+            'The provisioner execution module cannot be loaded:'
+            ' provisioner package unavailable.'
+        )
+    )

--- a/api/python/provisioner/srv/salt/repos/_macros.sls
+++ b/api/python/provisioner/srv/salt/repos/_macros.sls
@@ -66,7 +66,7 @@
 
         {% else  %}
 
-unexpected_repo_source:
+unexpected_repo_source_{{ source }}:
   test.fail_without_changes:
     - name: {{ source }}
 

--- a/api/python/provisioner/srv/salt/resources/misc/repos
+++ b/api/python/provisioner/srv/salt/resources/misc/repos
@@ -1,0 +1,1 @@
+/home/and/Projects/GitHub/cortx-prvsnr/api/python/provisioner/srv/salt/repos

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -20,6 +20,7 @@ import logging
 import subprocess
 import time
 import yaml
+from shlex import quote
 
 from pathlib import Path, PosixPath
 from typing import (
@@ -39,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO TEST
-
+# FIXME remove on behalf of ones from attr_gen
 def validator_path(instance, attribute, value):
     if value is None:
         if attribute.default is not None:
@@ -61,6 +62,14 @@ def converter_path(value):
 
 def converter_path_resolved(value):
     return value if value is None else Path(str(value)).resolve()
+
+
+def validator__subclass_of(classinfo):
+    def _f(attribute, value):
+        if not issubclass(value, classinfo):
+            raise TypeError(
+                f"'{attribute.name}' must be subclass of {classinfo}"
+            )
 
 
 def load_yaml_str(data):
@@ -120,6 +129,10 @@ def load_yaml(path):
 def dump_yaml(path, data, **kwargs):
     path = Path(str(path))
     path.write_text(dump_yaml_str(data, **kwargs))
+
+
+def quote_shell_cmd(cmd: List):
+    return [quote(p) for p in cmd]
 
 
 # TODO IMPROVE:


### PR DESCRIPTION
### Overview

The PR introduces a new design of integration between provisioner API and salt states based on understanding of resources.

The changes include implementation of the base abstractions

  - `ResourceBase`
  - `ResourceParams`
  - `ResourceState`
  - `ResourceTransition`
  - `ResourceManagerBase`
  
... along with specific implementation for cortx repositories resource:
  - `CortxRepos`
  - `CortxReposSetup`
  - `CortxReposParams`

... and SaltStack as a resource manager:
  - `SLSResourceManager`
  -  `CortxReposSetupSLS`

Also the change introduces the following CLI commands:

- `provisioner helper` a group of helper commands, in particular
  - `provisioner helper generate-profile` to generate ssh profile when salt-ssh is run in a custom env (e.g. at bootstrap)
  - `provisioner helper ensure-nodes-ready` to ensure that node targets are accessible and salt-ssh functions might be run there
- `provisioner resource` a group of commands to configure target system resources, the only `cortx_repos` resource is supported for now:
  - `provisioner resource cortx_repos setup` - a command to setup repositories on target machines

### How to test:

- setup docker and python environment as described [here](https://github.com/Seagate/cortx-prvsnr/blob/pre-cortx-1.0/docs/testing.md)
- run `pytest test/build_helpers -k test_build_setup_env -s --docker-mount-dev --nodes-num 3` to create 3 docker containers
  - Note. by default it would set `root` as password for root user there
  - Note. in output you will see ssh configuration along with path to ssh-config file
- run `provisioner helper generate-profile --profile-name EOS-17600-test --cleanup` to generate ssh profile
- run `provisioner helper ensure-nodes-ready --profile-name EOS-17600-test srvnode-1:<IP1> srvnode-2:<IP2> srvnode-3:<IP3>` to ensure that nodes are ready for provisioner setup routine
  - values of IP* might be get from ssh configuration mentioned above
  - Note. you would be prompted for root password for an initial access to the nodes
  - Note. you may try more automated options passing a key from ssh configuration as `--ssh-key` (would be used for access) or as `--bootstrap-key` (would be used for initial access only). In both cases root password won't be required.
- run `provisioner resource cortx_repos setup --dist-type bundle --salt-client-type ssh --salt-ssh-profile-name EOS-17600-test <PATH-TO-BUNDLE>`
  -  `PATH-TO-BUNDLE` is path to a single repo image used currently for deployment
  - Note. `--dist-type cortx` is supported and implies a flat yum repository with only cortx packages inside