### PR TITLE
[HOTFIX] Fix firewall sanity issue

### DIFF
--- a/api/python/provisioner/commands/deploy.py
+++ b/api/python/provisioner/commands/deploy.py
@@ -57,6 +57,7 @@ deploy_states = dict(
         "system.network.data.direct",
         "misc_pkgs.rsyslog",
         "system.firewall",
+        "system.firewall.sanity_check",
         "system.logrotate",
         "system.chrony"
     ],

--- a/api/python/provisioner/commands/deploy_vm.py
+++ b/api/python/provisioner/commands/deploy_vm.py
@@ -52,6 +52,7 @@ deploy_states = dict(
         "system.network.data.direct",
         "misc_pkgs.rsyslog",
         "system.firewall",
+        "system.firewall.sanity_check",
         "system.logrotate",
         "system.chrony"
     ],

--- a/srv/components/system/firewall/init.sls
+++ b/srv/components/system/firewall/init.sls
@@ -20,7 +20,6 @@ include:
   - .prepare
   - .install
   - .config
-  - .sanity_check
 
 # Disable Firewall:
 #   service.dead:


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

Issue is it is trying to resolve all jinja template first so at initial level we don't have any zones created but in sanity jinja we are trying to fetch all zones that's why it is failing.

```
To apply the state, Salt needs to convert it from YAML format to a data structure. Since it is impossible to parse a YAML file that has Jinja statements inside, Salt needs to parse Jinja first.

In other words, the pipeline looks like this:

Parse Jinja
Parse the resulting YAML
Interpret the data structure
Apply the state```