### PR TITLE
[EOS-18679] TUI for main menu of northbound interface

### DIFF
--- a/api/python/provisioner/ui/README.md
+++ b/api/python/provisioner/ui/README.md
@@ -1,0 +1,11 @@
+# Provisioner TUI
+
+This is northbound interface TUI for CORTX components that provides terminal UI
+to configure system.
+
+## start with provisioner TUI
+
+1. command to start provisioner TUI 
+```
+python3 api/python/provisioner/ui/main.py
+```

--- a/api/python/provisioner/ui/color_code.py
+++ b/api/python/provisioner/ui/color_code.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+#
+import curses
+import config
+
+
+class ColorCode:
+    _instance = None
+
+    def __init__(self):
+        if self._instance:
+            return self._instance
+        else:
+            curses.start_color()
+            self._instance = self
+
+    def create_color_pair(self, code, color1, color2):
+        curses.init_pair(code, color1, color2)
+
+    def get_color_pair(self, color_code):
+        if not config.color_codes.get(color_code, None):
+            raise Exception("No color code defined")
+        return curses.color_pair(color_code)

--- a/api/python/provisioner/ui/color_code.py
+++ b/api/python/provisioner/ui/color_code.py
@@ -21,19 +21,17 @@ import config
 
 
 class ColorCode:
-    _instance = None
 
-    def __init__(self):
-        if self._instance:
-            return self._instance
-        else:
-            curses.start_color()
-            self._instance = self
+    @staticmethod
+    def init():
+        curses.start_color()
 
-    def create_color_pair(self, code, color1, color2):
+    @staticmethod
+    def create_color_pair(code, color1, color2):
         curses.init_pair(code, color1, color2)
 
-    def get_color_pair(self, color_code):
+    @staticmethod
+    def get_color_pair(color_code):
         if not config.color_codes.get(color_code, None):
             raise Exception("No color code defined")
         return curses.color_pair(color_code)

--- a/api/python/provisioner/ui/config.py
+++ b/api/python/provisioner/ui/config.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+#
+import curses
+
+color_codes = {
+    1: [curses.COLOR_BLACK, curses.COLOR_WHITE],
+    2: [curses.COLOR_GREEN, curses.COLOR_BLACK],
+    3: [curses.COLOR_RED, curses.COLOR_BLACK]
+}
+
+error_color = 3
+default_window_color = 2
+menu_color = 2
+
+tittle = "Lvye Rack II"
+
+menu = [
+    'Set Hostname',
+    'Set Managment VIP',
+    'Setup Netowrk',
+    'Setup Storage',
+    'EXIT'
+]
+
+short_menu = ['hostname', 'management vip', 'network', 'storage']

--- a/api/python/provisioner/ui/main.py
+++ b/api/python/provisioner/ui/main.py
@@ -25,9 +25,9 @@ from color_code import ColorCode
 def main(stdscr):
     curses.initscr()
     curses.curs_set(0)
-    cod = ColorCode()
+    ColorCode.init()
     for code, color in config.color_codes.items():
-        cod.create_color_pair(code, color[0], color[1])
+        ColorCode.create_color_pair(code, color[0], color[1])
     wind = MainMenu(stdscr)
     wind.create_default_window(config.default_window_color)
     wind.create_window(color_code=config.menu_color, menu_code=0)

--- a/api/python/provisioner/ui/main.py
+++ b/api/python/provisioner/ui/main.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+#
+import curses
+import config
+from main_menu import MainMenu
+from color_code import ColorCode
+
+
+def main(stdscr):
+    curses.initscr()
+    curses.curs_set(0)
+    cod = ColorCode()
+    for code, color in config.color_codes.items():
+        cod.create_color_pair(code, color[0], color[1])
+    wind = MainMenu(stdscr)
+    wind.create_default_window(config.default_window_color)
+    wind.create_window(color_code=config.menu_color, menu_code=0)
+    wind.process_input(config.menu_color)
+
+
+if __name__ == '__main__':
+    curses.wrapper(main)

--- a/api/python/provisioner/ui/main_menu.py
+++ b/api/python/provisioner/ui/main_menu.py
@@ -35,7 +35,7 @@ class MainMenu(Window):
     def create_window(self, **kwargs):
         color_code = kwargs['color_code']
         selected_rows = kwargs['menu_code']
-        col_code_attr = ColorCode().get_color_pair(color_code)
+        col_code_attr = ColorCode.get_color_pair(color_code)
         for idx, row in enumerate(self._menu):
             x = self.get_max_width() // 2 - len(row)//2
             y = self.get_max_height() // 2 - len(self._menu)//2 + idx

--- a/api/python/provisioner/ui/main_menu.py
+++ b/api/python/provisioner/ui/main_menu.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+#
+import curses
+import config
+from window import Window
+from color_code import ColorCode
+
+
+class MainMenu(Window):
+    _menu = None
+
+    def __init__(self, window):
+        super().__init__(window)
+        self._menu = config.menu
+
+    def get_menu(self):
+        return self._menu
+
+    def create_window(self, **kwargs):
+        color_code = kwargs['color_code']
+        selected_rows = kwargs['menu_code']
+        col_code_attr = ColorCode().get_color_pair(color_code)
+        for idx, row in enumerate(self._menu):
+            x = self.get_max_width() // 2 - len(row)//2
+            y = self.get_max_height() // 2 - len(self._menu)//2 + idx
+            if idx == selected_rows:
+                self.on_attr(col_code_attr)
+                self._window.addstr(y, x-3, ">> ")
+                self._window.addstr(y, x, row)
+                self.off_attr(col_code_attr)
+            else:
+                self._window.addstr(y, x, row)
+        self._window.refresh()
+
+    def process_input(self, color_code):
+        current_row = 0
+        while 1:
+            key = self._window.getch()
+            self._window.clear()
+
+            if key == curses.KEY_UP and current_row > 0:
+                current_row = current_row - 1
+            elif (
+                key == curses.KEY_DOWN and
+                current_row < len(self.get_menu()) - 1
+            ):
+                current_row = current_row + 1
+            elif key == 113:
+                return
+            elif key == curses.KEY_ENTER or key in (10, 13):
+                if current_row == len(self.get_menu()) - 1:
+                    return
+
+            self._window.clear()
+            self.create_default_window(config.default_window_color)
+            self.create_window(color_code=color_code, menu_code=current_row)
+            self._window.refresh()

--- a/api/python/provisioner/ui/window.py
+++ b/api/python/provisioner/ui/window.py
@@ -49,7 +49,7 @@ class Window:
         self._window.attroff(attr)
 
     def create_default_window(self, color_code):
-        col_code_attr = ColorCode().get_color_pair(color_code)
+        col_code_attr = ColorCode.get_color_pair(color_code)
         self.on_attr(col_code_attr)
         textpad.rectangle(
             self._window, 1, 1, self._max_h - 2, self._max_w - 2)

--- a/api/python/provisioner/ui/window.py
+++ b/api/python/provisioner/ui/window.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+#
+import curses
+import config
+from curses import textpad
+from color_code import ColorCode
+
+
+class Window:
+    _max_h = None
+    _max_w = None
+    _window = None
+    _stdscr = None
+
+    def __init__(self, window):
+        self._max_h, self._max_w = window.getmaxyx()
+        self._window = window
+        self._stdscr = window
+
+    def enable_keypad(self):
+        self._window.keypad(1)
+
+    def get_max_height(self):
+        return self._max_h
+
+    def get_max_width(self):
+        return self._max_w
+
+    def on_attr(self, attr):
+        self._window.attron(attr)
+
+    def off_attr(self, attr):
+        self._window.attroff(attr)
+
+    def create_default_window(self, color_code):
+        col_code_attr = ColorCode().get_color_pair(color_code)
+        self.on_attr(col_code_attr)
+        textpad.rectangle(
+            self._window, 1, 1, self._max_h - 2, self._max_w - 2)
+        self._window.addstr(
+            5, self._max_w//2 - len(config.tittle)//2, f"{config.tittle}")
+        self._window.hline(6, 2, "_", self._max_w - 4)
+        self._window.addstr(
+            self._max_h-1, 0,
+            " Key Commands : q - to quit ", curses.color_pair(color_code)
+        )
+        self.off_attr(col_code_attr)
+
+    def create_window(self, **kwargs):
+        pass


### PR DESCRIPTION
TUI Main menu to set hostname, mangment VIP and storage using curses

![menu_vip](https://user-images.githubusercontent.com/66406084/110900575-f490e880-8328-11eb-81f9-073fbb196cbb.PNG)
.

![Menu_hostname](https://user-images.githubusercontent.com/66406084/110900478-d1fecf80-8328-11eb-9cbb-335c3e5d19a9.PNG)


Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

-----
[View rendered api/python/provisioner/ui/README.md](https://github.com/Seagate/cortx-prvsnr/blob/EOS-18679/api/python/provisioner/ui/README.md)