### PR TITLE
[testing][mocks] Pack provisioner pkgs into bundles

### DIFF
--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -19,8 +19,9 @@ import logging
 from copy import deepcopy
 import ipaddress
 import functools
-from typing import List, Union, Any, Iterable, Tuple, Dict
+from typing import List, Union, Any, Iterable, Tuple, Dict, Type
 from pathlib import Path
+import argparse
 
 from .vendor import attr
 from .errors import UnknownParamError, SWUpdateRepoSourceError
@@ -96,7 +97,7 @@ class AttrParserArgs:
         self.name = self.name.lstrip('_')
 
         if self.prefix:
-            self.name = self.prefix + self.name
+            self.name = f"{self.prefix}{self.name}"
 
         parser_args = {}
 
@@ -184,7 +185,10 @@ class InputAttrParserArgs(AttrParserArgs):
 
 class ParserFiller:
     @staticmethod
-    def fill_parser(cls, parser, attr_parser_cls=AttrParserArgs):
+    def prepare_args(
+        cls, attr_parser_cls: Type[AttrParserArgs] = AttrParserArgs
+    ):
+        res = {}
         for _attr in attr.fields(cls):
             if METADATA_ARGPARSER in _attr.metadata:
                 parser_prefix = getattr(cls, 'parser_prefix', None)
@@ -215,19 +219,98 @@ class ParserFiller:
                             }
                         )
                         args = attr_parser_cls(attr_copy, prefix=parser_prefix)
-                        parser.add_argument(args.name, **args.kwargs)
                 else:
                     args = attr_parser_cls(_attr, prefix=parser_prefix)
-                    parser.add_argument(args.name, **args.kwargs)
+                res[args.name] = args.kwargs
+
+        return res
+
+    @staticmethod
+    def fill_parser(cls, parser, attr_parser_cls=AttrParserArgs):
+        _args = ParserFiller.prepare_args(cls, attr_parser_cls)
+        for name, kwargs in _args.items():
+            parser.add_argument(name, **kwargs)
+
+    @staticmethod
+    def extract_args(
+        cls, kwargs, positional=True, optional=True, pop=True
+    ):
+        _args = {}
+        _kwargs = {}
+
+        parser_prefix = getattr(cls, 'parser_prefix', '')
+
+        for _attr in attr.fields(cls):
+            if METADATA_ARGPARSER in _attr.metadata:
+                # name = (
+                #     _attr.name.split(parser_prefix, 1)[-1]
+                #     if parser_prefix else _attr.name
+                # )
+                arg_name = f"{parser_prefix}{_attr.name}".replace('-', '_')
+                if arg_name in kwargs:
+                    if positional and _attr.default is attr.NOTHING:
+                        _dest = _args
+                    elif optional and _attr.default is not attr.NOTHING:
+                        _dest = _kwargs
+                    _dest[_attr.name] = kwargs[arg_name]
+                    if pop:
+                        kwargs.pop(arg_name)
+
+        return _args.values(), _kwargs, kwargs
 
     @staticmethod
     def extract_positional_args(cls, kwargs):
-        _args = []
+        _args, _, kwargs = ParserFiller.extract_args(
+            cls, kwargs, positional=True, optional=False
+        )
+        return _args, kwargs
+
+    @staticmethod
+    def extract_optional_args(cls, parsed_args):
+        _, _kwargs, kwargs = ParserFiller.extract_args(
+            cls, parsed_args, positional=False, optional=True
+        )
+        return _kwargs, kwargs
+
+    @staticmethod
+    def from_args(cls, parsed_args: Union[dict, argparse.Namespace], pop=True):
+        if isinstance(parsed_args, argparse.Namespace):
+            parsed_args = vars(parsed_args)
+
+        _args, _kwargs, parsed_args = ParserFiller.extract_args(
+            cls, parsed_args, positional=True, optional=True, pop=pop
+        )
+
+        return cls(*_args, **_kwargs), parsed_args
+
+
+@attr.s(auto_attribs=True)
+class ParserMixin:
+
+    parser_prefix = ''
+
+    @classmethod
+    def parser_attrs(cls):
         for _attr in attr.fields(cls):
             if METADATA_ARGPARSER in _attr.metadata:
-                if _attr.default is attr.NOTHING and _attr.name in kwargs:
-                    _args.append(kwargs.pop(_attr.name))
-        return _args, kwargs
+                yield _attr
+
+    @classmethod
+    def parser_args(cls):
+        for _attr in cls.parser_attrs():
+            yield f"{cls.parser_prefix}{_attr.name.replace('_', '-')}"
+
+    @classmethod
+    def prepare_args(cls, *args, **kwargs):
+        return ParserFiller.prepare_args(cls, *args, **kwargs)
+
+    @classmethod
+    def fill_parser(cls, parser, *args, **kwargs):
+        return ParserFiller.fill_parser(cls, parser, *args, **kwargs)
+
+    @classmethod
+    def from_args(cls, parsed_args, *args, **kwargs):
+        return ParserFiller.from_args(cls, parsed_args, *args, **kwargs)[0]
 
 
 @attr.s(auto_attribs=True)

--- a/devops/rpms/buildrpm.sh
+++ b/devops/rpms/buildrpm.sh
@@ -86,7 +86,7 @@ pushd ~/rpmbuild/SOURCES/
         --define "_cortx_prvsnr_version ${CORTX_PRVSNR_VERSION}" \
         --define "_cortx_prvsnr_git_ver git${GIT_VER}" \
         --define "_build_number ${BUILD_NUMBER}" \
-        ${BASEDIR}/cortx-prvsnr.spec
+        "${BASEDIR}/cortx-prvsnr.spec"
 
 popd
 

--- a/devops/rpms/buildrpm.sh
+++ b/devops/rpms/buildrpm.sh
@@ -82,7 +82,11 @@ pushd ~/rpmbuild/SOURCES/
 
     yum-builddep -y ${BASEDIR}/cortx-prvsnr.spec
 
-    rpmbuild -bb --define "_cortx_prvsnr_version ${CORTX_PRVSNR_VERSION}" --define "_cortx_prvsnr_git_ver git${GIT_VER}" --define "_build_number ${BUILD_NUMBER}" ${BASEDIR}/cortx-prvsnr.spec
+    rpmbuild -bb \
+        --define "_cortx_prvsnr_version ${CORTX_PRVSNR_VERSION}" \
+        --define "_cortx_prvsnr_git_ver git${GIT_VER}" \
+        --define "_build_number ${BUILD_NUMBER}" \
+        ${BASEDIR}/cortx-prvsnr.spec
 
 popd
 

--- a/devops/rpms/cortx-prvsnr.spec
+++ b/devops/rpms/cortx-prvsnr.spec
@@ -33,6 +33,8 @@ rm -rf %{buildroot}
 # Turn off the brp-python-bytecompile automagic
 %global _python_bytecompile_extra 0
 %global __python %{__python3}
+# helps with newer builders (e.g. on centos 8.2)
+%global debug_package %{nil}
 
 
 

--- a/docs/mocks.md
+++ b/docs/mocks.md
@@ -65,18 +65,32 @@ Builds different types of CORTX distribution.
 The type of a distribution, release version and output directory
 can be configured.
 
-If '--gen-iso' is specified then an ISO file is generated as well.
+If location of an original Cortx single repo image is specified
+(using '--orig-iso') then EPEL-7, SaltStack and GlusterFS repositories
+along with provisioner release packages would be copied from the ISO
+to a new bundle.
+
+Custom provisioner packages might be packed inside a bundle using
+'--prvsnr-pkg' and '--prvsnr-api-pkg' options.
+
+Finally if '--gen-iso' is specified then an ISO file is generated as well.
 
 Options:
-  -h,  --help           print this help and exit
-  -o,  --out-dir DIR    output dir,
-                            default: .
-  -r,  --cortx-ver      cortx release version,
-                            default: 2.0.0
-  -t,  --out-type       output type. Possible values: {deploy-cortx|deploy-single|upgrade}
-                            default: deploy-cortx,
-  -v,  --verbose        be more verbose
-       --gen-iso        generate ISO
+  -h,  --help                   print this help and exit
+  -i,  --orig-iso FILE          original ISO for partial use,
+                                    default:
+  -o,  --out-dir DIR            output dir,
+                                    default: .
+  -r,  --cortx-ver              cortx release version,
+                                    default: 2.0.0
+  -t,  --out-type               output type. Possible values: {deploy-cortx|deploy-single|upgrade}
+                                    default: deploy-cortx,
+  -v,  --verbose                be more verbose
+       --gen-iso                generate ISO
+       --prvsnr-pkg FILE        provisioner package location
+                                    default:
+       --prvsnr-api-pkg FILE    provisioner api package location
+                                    default:
 ```
 
 Where output types are:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,6 +17,11 @@
     - [Docker configuration](#docker-configuration)
     - [Docker on Fedora 32/33](#docker-on-fedora-33)
     - [Docker test helpers](#Docker-test-helpers)
+      - [Docker environment creation](#docker-environment-creation)
+      - [Building provisioner packages](#building-provisioner-packages)
+      - [Building testing bundles](#building-testing-bundles)
+    - [Integration test cases](#Integration-test-cases)
+      - [Provisioner setup](#Provisioner-setup)
 - [Appendix](#appendix)
   - [Basic Docker commands](#basic-docker-commands)
 
@@ -238,14 +243,74 @@ sudo docker run hello-world
 
 #### Docker test helpers
 
-- docker environment creation
+##### Building provisioner packages
+
+  ```bash
+  pytest test/build_helpers/build_prvsnr_pkgs
+  ```
+
+  The command above will create provisioner packages (core and api) in the current directory.
+
+  You may check the full list of options using `pytest test/build_helpers/build_prvsnr_pkgs --help`
+  (`custom options` part):
+
+  - `--build-version=STR` release version (source version). Note. ignored for
+     api package, to set version for package please edit
+     `api/python/provisioner/__metadata__.py`
+  - `--build-pkg-version=INT` package version (release tag),
+     should be greater or  equal 1
+  - `--build-output=DIR` path to directory to output
+
+##### Building testing bundles
+
+  ```bash
+  pytest test/build_helpers/build_bundles
+  ```
+
+  The command above will create three bundles in the current directory.
+
+  They would respect the structure of CORTX distributions for deployment and upgrade
+  but include mocks for CORTX packages instead of real ones. Non CORTX yum repositories
+  inside would be just empty.
+
+  Optionally you may pack inside real repositories of EPEL-7, SaltStack and
+  GlusterFS along with provisioner release packages that are distributed inside
+  official CORTX bundles. For that you need to download a bundle locally
+  and run the following command:
+
+  ```bash
+  pytest test/build_helpers/build_bundles --build-orig-single-iso <path-to-official-bundle>
+  ```
+
+  Also you may pack custom provisioner packages available locally:
+
+  ```bash
+  pytest test/build_helpers/build_bundles \
+            --build-prvsnr-pkg=<path-to-prvsnr-pkg> \
+            --build-prvsnr-api-pkg=<path-to-prvsnr-api-pkg>
+  ```
+
+  For the full list of available options please run
+  `pytest test/build_helpers/build_bundles --help` (`custom options` part):
+
+  - `--build-type=TYPE` type of the bundle [choices: deploy-cortx, deploy-bundle, upgrade, all]
+  - `--build-version=STR` version of the release, ignored if 'all' type is used
+  - `--build-output=BUILD_OUTPUT` path to file or directory to output
+  - `--build-orig-single-iso=BUILD_ORIG_SINGLE_ISO` original CORTX single ISO for partial use
+  - `--build-prvsnr-pkg=BUILD_PRVSNR_PKG PATH` to provisioner core rpm package
+  - `--build-prvsnr-api-pkg=BUILD_PRVSNR_API_PKG PATH` to provisioner API rpm package
+
+
+##### Docker environment creation
 
   ```bash
   pytest test/build_helpers/build_env -s --root-passwd root --nodes-num 1
   ```
 
+  The command above will create the docker container.
+
   <details>
-  <summary>The command above will create the docker container and will have the following output</summary>
+  <summary>It will result with the following example output</summary>
 
   ```
     ========================================================================================= test session starts ==========================================================================================
@@ -267,52 +332,27 @@ sudo docker run hello-world
       IdentitiesOnly yes
       LogLevel FATAL
 
-    ```
+  ```
   </details>
 
-    Possible options (you may check them using `pytest test/build_helpers/build_env --help`, `custom options` part)
+  You may check the full list of options using `pytest test/build_helpers/build_env --help`
+  (`custom options` part):
+
     - `--docker-mount-dev` to mount `/dev` into containers (necessary if you need to mount ISO inside a container)
     - `--root-passwd <STR>` to set a root password for initial ssh access
     - `--nodes-num <INT>` number of nodes, currently it can be from 1 to 6
 
-- building testing bundles
-
-  ```bash
-  pytest test/build_helpers/build_bundles
-  ```
-
-  The command above will create three bundles in the root of the project.
-
-  They would respect the structure of CORTX distributions for deployment and upgrade
-  but include mocks for CORTX packages instead of real ones. Non CORTX yum repositories
-  inside would be just empty.
-
-  Optionally you may pack inside it real repositories of EPEL-7, SaltStack and GlusterFS that
-  are distributed inside official CORTX bundles. For that you need to download a bundle locally
-  and run the following command:
-
-  ```bash
-  pytest test/build_helpers/build_bundles --bundle-orig-single-iso <path-to-official-bundle>
-  ```
-
-  Options (you may check them using `pytest test/build_helpers/build_bundles --help`, `custom options` part)
-  - `--bundle-orig-single-iso=PATH`: original CORTX single ISO for partial use
-  - `--bundle-output=PATH`:  path to file or directory to output
-  - `--bundle-type=TYPE`: type of the bundle
-  - `--bundle-version=PATH`: version of the release, ignored if 'all' type is used
-
 #### Integration test cases
-
 
 ##### Provisioner setup
 
-- You may set up a provisioner inside the container using the local source mode
+You may set up a provisioner inside the container using the local source mode
 
-  ```bash
-  provisioner setup_provisioner --source local --logfile --logfile-filename ./setup.log --console-formatter full srvnode-1:172.17.0.2
-  ```
+```bash
+provisioner setup_provisioner --source local --logfile --logfile-filename ./setup.log --console-formatter full srvnode-1:172.17.0.2
+```
 
-  **:warning:** NOTE: For **srvnode-1**, **srvnode-2**, etc. parameter values use the **Hostname** output from previous step
+**:warning:** NOTE: For **srvnode-1**, **srvnode-2**, etc. parameter values use the **Hostname** output from previous step
 
 **TBD: Test other types of sources.**
 

--- a/images/docker/setup_fpm.sh
+++ b/images/docker/setup_fpm.sh
@@ -19,7 +19,9 @@
 
 set -eux
 
-yum install -y ruby-devel gcc make rpm-build rubygems python36
+NO_YUM_CLEAN="${NO_YUM_CLEAN:-}"
+
+yum install -y ruby-devel gcc make rpm-build rubygems python36 git
 
 # issues with pip>=10:
 # https://github.com/pypa/pip/issues/5240
@@ -28,4 +30,6 @@ python3 -m pip install -U pip setuptools
 
 gem install --no-ri --no-rdoc rake fpm
 
-rm -rf /var/cache/yum
+if [[ -z "$NO_YUM_CLEAN" ]]; then
+    rm -rf /var/cache/yum
+fi

--- a/test/build_helpers/build_bundles/test_build_bundles.py
+++ b/test/build_helpers/build_bundles/test_build_bundles.py
@@ -51,7 +51,7 @@ def test_build_bundles(
         upgrade_ver = upgrade_ver.split('.')
         upgrade_ver[-1] = str(int(upgrade_ver[-1]) + 1)
         upgrade_ver = '.'.join(upgrade_ver)
-        b_types = h.BUNDLE_TYPES
+        b_types = [t.value for t in h.BundleT]
 
     bundles = []
     for bt in b_types:
@@ -64,18 +64,39 @@ def test_build_bundles(
 
     # XXX hard-coded
     for b_dir, b_type, b_version in bundles:
-        add_opts = ''
-        if b_type == 'deploy-bundle' and orig_single_iso_on_host:
-            add_opts = f"--orig-iso {orig_single_iso_on_host}"
+        add_opts = []
+        if b_type == h.BundleT.DEPLOY_BUNDLE.value and orig_single_iso_on_host:
+            add_opts.append(f"--orig-iso {orig_single_iso_on_host}")
 
-        mhostsrvnode1.check_output(
+        if bundle_opts.prvsnr_pkg:
+            prvsnr_pkg = mhostsrvnode1.copy_to_host(
+                bundle_opts.prvsnr_pkg,
+                tmpdir_function / bundle_opts.prvsnr_pkg.name
+            )
+            add_opts.append(f"--prvsnr-pkg {prvsnr_pkg}")
+
+        if bundle_opts.prvsnr_api_pkg:
+            prvsnr_api_pkg = mhostsrvnode1.copy_to_host(
+                bundle_opts.prvsnr_api_pkg,
+                tmpdir_function / bundle_opts.prvsnr_api_pkg.name
+            )
+            add_opts.append(f"--prvsnr-api-pkg {prvsnr_api_pkg}")
+
+        cmd = (
             f"{build_script} -o {b_dir} -t {b_type} -r {b_version}"
-            f" --gen-iso {add_opts}"
+            f" --gen-iso {' '.join(add_opts)}"
         )
+
+        mhostsrvnode1.check_output(cmd)
         res.append(mhostsrvnode1.copy_from_host(b_dir.with_suffix('.iso')))
 
+    dest_dir = bundle_opts.output
+    dest_name = None
+
+    if not dest_dir.is_dir():
+        dest_name = dest_dir.name
+        dest_dir = dest_dir.parent
+
     for iso_path in res:
-        dest = bundle_opts.output
-        if dest.is_dir():
-            dest /= f"{iso_path.name}"
+        dest = dest_dir / (dest_name if dest_name else f"{iso_path.name}")
         dest.write_bytes(iso_path.read_bytes())

--- a/test/build_helpers/build_env/conftest.py
+++ b/test/build_helpers/build_env/conftest.py
@@ -51,8 +51,8 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def options_list(options_list):
-    return options_list + list(prvsnr_pytest_options)
+def run_options(run_options):
+    return run_options + list(prvsnr_pytest_options)
 
 
 @pytest.fixture(scope='session')

--- a/test/build_helpers/build_prvsnr_pkgs/__init__.py
+++ b/test/build_helpers/build_prvsnr_pkgs/__init__.py
@@ -14,31 +14,3 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
-
-import pytest
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--bvt-repo-path", action='store',
-        default='./cortx-test.tgz',
-        help="path to cortx-test repo tar gzipped file"
-    )
-    parser.addoption(
-        "--bvt-test-targets", action='store',
-        default='avocado_test/bvt_test.py',
-        help="bvt test targets to run"
-    )
-    parser.addoption(
-        "--bvt-results-path", action='store',
-        default='./bvt.job-results.tgz',
-        help="path to tar gzipped archive with bvt test job result"
-    )
-
-
-@pytest.fixture(scope="session")
-def run_options(run_options):
-    return (
-        run_options +
-        ["bvt-repo-path", "bvt-test-targets", "bvt-results-path"]
-    )

--- a/test/build_helpers/build_prvsnr_pkgs/conftest.py
+++ b/test/build_helpers/build_prvsnr_pkgs/conftest.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import pytest
+from typing import Union
+from pathlib import Path
+
+from provisioner.vendor import attr
+from provisioner import utils, inputs
+
+from test import helper as h
+
+
+@attr.s(auto_attribs=True)
+class BundleOpts(inputs.ParserMixin):
+    parser_prefix = 'build-'
+
+    version: str = attr.ib(
+        default='2.0.0',
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "release version (source version)."
+                    " Note. ignored for api package,"
+                    " to set version for package please edit"
+                    " 'api/python/provisioner/__metadata__.py'"
+                )
+            }
+        }
+    )
+    pkg_version: str = attr.ib(
+        default=1,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "package version (release tag),"
+                    " should be greater or equal 1"
+                ),
+                'metavar': 'INT'
+            },
+        },
+        converter=int,
+        validator=attr.validators.instance_of(int)
+    )
+    output: Union[str, Path] = attr.ib(
+        default='.',
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': "path to directory to output",
+                'metavar': 'DIR'
+            }
+        },
+        converter=utils.converter_path_resolved,
+        validator=utils.validator_path_exists
+    )
+
+    def __attrs_post_init__(self):
+        if not self.output.is_dir():
+            raise ValueError(
+                f"{self.output} is not a directory"
+            )
+
+        if self.pkg_version < 1:
+            raise ValueError(
+                "'pkg_version' should be greate or equal 1"
+            )
+
+
+def pytest_addoption(parser):
+    h.add_options(
+        parser, BundleOpts.prepare_args()
+    )
+
+
+@pytest.fixture(scope='session')
+def bundle_opts_t():
+    return BundleOpts

--- a/test/build_helpers/conftest.py
+++ b/test/build_helpers/conftest.py
@@ -17,28 +17,21 @@
 
 import pytest
 
+from provisioner import inputs
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--bvt-repo-path", action='store',
-        default='./cortx-test.tgz',
-        help="path to cortx-test repo tar gzipped file"
-    )
-    parser.addoption(
-        "--bvt-test-targets", action='store',
-        default='avocado_test/bvt_test.py',
-        help="bvt test targets to run"
-    )
-    parser.addoption(
-        "--bvt-results-path", action='store',
-        default='./bvt.job-results.tgz',
-        help="path to tar gzipped archive with bvt test job result"
-    )
+
+@pytest.fixture(scope='session')
+def bundle_opts_t():
+    return inputs.ParserMixin
 
 
 @pytest.fixture(scope="session")
-def run_options(run_options):
+def run_options(run_options, bundle_opts_t: inputs.ParserMixin):
     return (
-        run_options +
-        ["bvt-repo-path", "bvt-test-targets", "bvt-results-path"]
+        run_options + list(bundle_opts_t.parser_args())
     )
+
+
+@pytest.fixture(scope='session')
+def bundle_opts(request, bundle_opts_t: inputs.ParserMixin):
+    return bundle_opts_t.from_args(request.config.option)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -61,6 +61,9 @@ ENV_LEVELS_HIERARCHY = {
                 'vm_box_version': '1.2.17'
             }
         },
+        'centos7.8.2003': {
+            'docker': 'centos:7.8.2003'
+        },
         'centos8.2.2004': {
             'docker': 'centos:8.2.2004'
         }
@@ -103,7 +106,7 @@ ENV_LEVELS_HIERARCHY = {
 
 
 BASE_OS_NAMES = list(ENV_LEVELS_HIERARCHY['base'])
-DEFAULT_BASE_OS_NAME = 'centos7.7.1908'
+DEFAULT_BASE_OS_NAME = 'centos7.8.2003'
 
 DEFAULT_CLUSTER_SPEC = {
     f'srvnode{node_id}': {
@@ -366,27 +369,28 @@ prvsnr_pytest_options = {
         default='rpm',
         help="Provisioner source to use, defaults to 'rpm'"
     ),
-    "prvsnr-cli-release": dict(
-        action='store', default='integration/centos-7.7.1908/last_successful',
-        help=(
-            "Provisioner cli release to use, "
-            "defaults to 'integration/centos-7.7.1908/last_successful'"
-        )
-    ),
-    "prvsnr-release": dict(
-        action='store', default='integration/centos-7.7.1908/last_successful',
-        help=(
-            "Provisioner release to use, "
-            "defaults to 'integration/centos-7.7.1908/last_successful'"
-        )
-    ),
-    "cortx-release": dict(
-        action='store', default='integration/centos-7.7.1908/last_successful',
-        help=(
-            "Target release to verify, "
-            "defaults to 'integration/centos-7.7.1908/last_successful'"
-        )
-    )
+# XXX outdated options (bvt scope)
+#    "prvsnr-cli-release": dict(
+#        action='store', default='integration/centos-7.7.1908/last_successful',
+#        help=(
+#            "Provisioner cli release to use, "
+#            "defaults to 'integration/centos-7.7.1908/last_successful'"
+#        )
+#    ),
+#    "prvsnr-release": dict(
+#        action='store', default='integration/centos-7.7.1908/last_successful',
+#        help=(
+#            "Provisioner release to use, "
+#            "defaults to 'integration/centos-7.7.1908/last_successful'"
+#        )
+#    ),
+#    "cortx-release": dict(
+#        action='store', default='integration/centos-7.7.1908/last_successful',
+#        help=(
+#            "Target release to verify, "
+#            "defaults to 'integration/centos-7.7.1908/last_successful'"
+#        )
+#    )
 }
 
 
@@ -422,13 +426,13 @@ def integration2():
 
 
 @pytest.fixture(scope="session")
-def options_list():
+def run_options():
     return list(prvsnr_pytest_options)
 
 
 @pytest.fixture(scope="session", autouse=True)
-def dump_options(request, options_list):
-    h.dump_options(request, options_list)
+def dump_options(request, run_options):
+    h.dump_options(request, run_options)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Improves test helpers:

- (new) `pytest test/build_helpers/build_prvsnr_pkgs` to build provisioner packages in docker
- (improved) `pytest test/build_helpers/build_bundles` to build Cortx bundles in docker, changes:
  - improves command line args support
  - extends list of them to allow passing paths to provisioner packages so they would be packed inside a bundle (if not passed then ones from original single iso wouldbe used if the it is providede)

Please check updated docs for more details and examples.


-----
[View rendered docs/mocks.md](https://github.com/andkononykhin2/cortx-prvsnr/blob/pack-provisioner-pkgs-into-bundles/docs/mocks.md)
[View rendered docs/testing.md](https://github.com/andkononykhin2/cortx-prvsnr/blob/pack-provisioner-pkgs-into-bundles/docs/testing.md)