### PR TITLE
EOS-17828: firewall ports adjustments

### DIFF
--- a/pillar/components/firewall.sls
+++ b/pillar/components/firewall.sls
@@ -2,43 +2,9 @@ firewall:
   data_public:
     services: []
     ports:
-      consul:
-        - 8600/tcp
-        - 8600/udp
-        - 8500/tcp
-        - 8301/tcp
-        - 8301/udp
-        - 8302/tcp
-        - 8302/udp
-        - 8300/tcp
-      dhclient:
-        - 68/udp
-      dhserver:
-        - 67/udp
       haproxy:
         - 443/tcp
-      hare:
-        - 8008/tcp
-      nfs:
-        - 2049/tcp
-        - 2049/udp
-        - 32803/tcp
-        - 892/tcp
-        - 875/tcp
-      s3:
-        - 7081/tcp
-        {% for port in range(8081, 8092) %}
-        - {{ port }}/tcp
-        {% endfor %}
-        - 514/tcp
-        - 514/udp
-        - 8125/tcp
-        - 6379/tcp
         - 9443/tcp
-        - 9086/tcp
-      uds:
-        - 5000/tcp
-        - 5125/udp
   mgmt_public:
     services:
       - ssh
@@ -47,29 +13,19 @@ firewall:
       - glusterfs
       {%- endif %}
     ports:
-      consul:
-        - 8600/tcp
-        - 8600/udp
-        - 8500/tcp
-        - 8301/tcp
-        - 8301/udp
-        - 8302/tcp
-        - 8302/udp
-        - 8300/tcp
       csm:
         - 28100/tcp
-        - 28101/tcp
-        - 28102/tcp
-        - 28103/tcp
       dhclient:
         - 68/udp
-      elasticsearch:
-        - 9200/tcp
-        - 9300/tcp
+      dns:
+        - 53/tcp
+        - 53/udp
       ntpd:
+        - 123/tcp
         - 123/udp
-      openldap:
-        - 389/tcp
+      redis:
+        - 6379/tcp
+        - 6379/udp
       smtp:
         - 25/tcp
       saltmaster:
@@ -77,4 +33,4 @@ firewall:
         - 4506/tcp
       uds:
         - 5000/tcp
-        - 5125/udp
+        - 5000/udp

--- a/pillar/components/firewall.sls
+++ b/pillar/components/firewall.sls
@@ -4,6 +4,7 @@ firewall:
     ports:
       haproxy:
         - 443/tcp
+      s3:
         - 9443/tcp
   mgmt_public:
     services:


### PR DESCRIPTION
[Firewall-Ports-R2](https://seagatetechnology.sharepoint.com/:x:/s/gteamdrv1/tdrive1224/EZRT8UanK0RNi35n8a6uplQBLL-WmNhfjaXElJ7Iq70u2Q?e=tlNe7H) 

Strictly followed this list for open ports and tested on 3-node cluster. 
Removed all Private and Internal network ports and kept only incoming ports and data-public and mgmt-public ports. 
Apart from the list, only retained the initial default services ssh, salt (incoming) and glusterfs (not mentioned in sheet) as such.

Signed-off-by: Divya Vijayakumar <divya.vijaykumar@seagate.com>