### PR TITLE
[EOS-18935] Consul rolling upgrade

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,0 +1,2 @@
+-R
+--exclude=@.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ build
 .coverage
 tmp
 venv/
+api/python/provisioner/srv/salt-vendor/*
+!api/python/provisioner/srv/salt-vendor/README.md

--- a/api/python/provisioner/api.py
+++ b/api/python/provisioner/api.py
@@ -262,7 +262,8 @@ def set_swupgrade_repo(release, source=None, hash_str=None,
         where
         <hash_type> - one of the values from `config.HashType` enumeration
         <check_sum> - hexadecimal representation of hash checksum
-        <file_name> - a file name to which <hash_type> and <hash_sum> belongs to
+        <file_name> - a file name to which <hash_type>
+                      and <hash_sum> belongs to
 
     hash_type
         (optional) type of hash value. See `config.HashType` for

--- a/api/python/provisioner/attr_gen.py
+++ b/api/python/provisioner/attr_gen.py
@@ -19,6 +19,7 @@ import sys
 import logging
 from packaging.version import Version
 from packaging.specifiers import SpecifierSet
+from ipaddress import IPv4Address
 
 from provisioner.vendor import attr
 
@@ -53,11 +54,18 @@ def converter__nodes(*specs):
 
 
 def converter__version(value):
-    return (value if isinstance(value, Version) else Version(value))
+    return (
+        value if value is None or isinstance(value, Version)
+        else Version(value)
+    )
 
 
 def converter__version_specifier(value):
     return (value if isinstance(value, SpecifierSet) else SpecifierSet(value))
+
+
+def converter__ipv4(value) -> IPv4Address:
+    return IPv4Address(value)
 
 
 # VALIDATORS
@@ -75,6 +83,10 @@ def validator__subclass_of(instance, attribute, value):
 
 def validator__version(instance, attribute, value):
     return attr.validators.instance_of(Version)(instance, attribute, value)
+
+
+def validator__ipv4(instance, attribute, value):
+    return attr.validators.instance_of(IPv4Address)(instance, attribute, value)
 
 
 def validator__version_specifier(instance, attribute, value):

--- a/api/python/provisioner/attr_gen.py
+++ b/api/python/provisioner/attr_gen.py
@@ -17,6 +17,8 @@
 
 import sys
 import logging
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 
 from provisioner.vendor import attr
 
@@ -50,6 +52,14 @@ def converter__nodes(*specs):
     ]
 
 
+def converter__version(value):
+    return (value if isinstance(value, Version) else Version(value))
+
+
+def converter__version_specifier(value):
+    return (value if isinstance(value, SpecifierSet) else SpecifierSet(value))
+
+
 # VALIDATORS
 def validator__path(instance, attribute, value):
     utils.validator_path(instance, attribute, value)
@@ -61,6 +71,16 @@ def validator__path_exists(instance, attribute, value):
 
 def validator__subclass_of(instance, attribute, value):
     utils.validator__subclass_of(instance, attribute, value)
+
+
+def validator__version(instance, attribute, value):
+    return attr.validators.instance_of(Version)(instance, attribute, value)
+
+
+def validator__version_specifier(instance, attribute, value):
+    return attr.validators.instance_of(SpecifierSet)(
+        instance, attribute, value
+    )
 
 
 def load_attrs_spec():

--- a/api/python/provisioner/attr_gen.py
+++ b/api/python/provisioner/attr_gen.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import sys
+import logging
+
+from ..vendor import attr
+from . import utils
+from . import config, inputs
+from .node import Node
+from .pillar import KeyPath
+
+_mod = sys.modules[__name__]
+
+logger = logging.getLogger(__name__)
+
+attrs_spec = utils.load_yaml(config.ATTRS_SPEC_PATH)
+
+
+# CONVERTERS FIXME move here from utils
+def converter__path(value):
+    return utils.converter_path(value)
+
+
+def converter__path_resolved(value):
+    return utils.converter__path_resolved(value)
+
+
+def converter__nodes(*specs):
+    return [
+        (s if isinstance(s, Node) else Node.from_spec(s))
+        for s in specs
+    ]
+
+
+# VALIDATORS
+def validator__path(instance, attribute, value):
+    utils.validator_path(instance, attribute, value)
+
+
+def validator__path_exists(instance, attribute, value):
+    utils.validator_path_exists(instance, attribute, value)
+
+
+def validator__subclass_of(instance, attribute, value):
+    utils.validator__subclass_of(instance, attribute, value)
+
+
+VALIDATOR = 'validator'
+CONVERTER = 'converter'
+SEP = '__'
+
+
+def attr_ib(key: str = None, **kwargs):
+    _kwargs = {}
+
+    if key:
+        _kwargs = KeyPath(key).value(attrs_spec)
+
+    _kwargs.update(kwargs)
+
+    for fun_t in (CONVERTER, VALIDATOR):
+        try:
+            fun = _kwargs[fun_t]
+        except KeyError:
+            # to support validators named as a key
+            _kwargs[fun_t] = getattr(_mod, f'{fun_t}{SEP}{key}', None)
+        else:
+            # to support validators explicitly defined
+            _kwargs[fun_t] = getattr(_mod, f'{fun_t}{SEP}{fun}')
+
+    cli_spec = _kwargs.pop('cli_spec')
+    if cli_spec:
+        _kwargs['metadata'] = _kwargs.pop('metadata', {})
+        _kwargs['metadata'][inputs.METADATA_ARGPARSER] = cli_spec
+
+    return attr.ib(**_kwargs)

--- a/api/python/provisioner/attrs_spec.yaml
+++ b/api/python/provisioner/attrs_spec.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+nodes: {}
+path: {}
+path_exists:
+  converter: path_resolved

--- a/api/python/provisioner/attrs_spec.yaml
+++ b/api/python/provisioner/attrs_spec.yaml
@@ -26,3 +26,5 @@ nodes: {}
 path: {}
 path_exists:
   converter: path_resolved
+version: {}
+version_specifier: {}

--- a/api/python/provisioner/attrs_spec.yaml
+++ b/api/python/provisioner/attrs_spec.yaml
@@ -22,6 +22,7 @@
 #     - if `validator` is specified explicitly as a key it overrides
 #   - converter: (the same as for validators)
 
+ipv4: {}
 nodes: {}
 path: {}
 path_exists:

--- a/api/python/provisioner/attrs_spec.yaml
+++ b/api/python/provisioner/attrs_spec.yaml
@@ -15,6 +15,13 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+# Format notes:
+#   - top level keys are types of attributes
+#   - validators:
+#     - each type may have related validator as validator__<type>
+#     - if `validator` is specified explicitly as a key it overrides
+#   - converter: (the same as for validators)
+
 nodes: {}
 path: {}
 path_exists:

--- a/api/python/provisioner/cli_spec.yaml
+++ b/api/python/provisioner/cli_spec.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+glusterfs:
+  peers:
+    help: gluster peer host (IP/domain)
+    nargs: +
+  in_docker:
+    help: configure Dockerized glusterfs servers
+  add_repo:
+    help: configure glusterfs 3rd party repo
+  cleanup:
+    help: clean up the current configuration
+roster:
+  nodes:
+    help: "cluster node specification, format: id:[user@]hostname[:port]"
+    nargs: +
+    metavar: NODESPEC
+  path:
+    help: path to roster file
+pillar:
+  release_type:
+    help: release type
+    choices: ['bundle', 'internal']
+  release_deps_bundle_url:
+    help: 3rd party dependencies repo url/path
+  release_target_build:
+    help: release type
+  service_user_password:
+    help: >-
+      a password for the CORTX service user, a special value __GENERATE__
+      might be used to generate a new one on the fly
+setup:
+  ha:
+    help: turn on high availability mode
+  salt_master:
+    help: domain name or IP of the salt-master

--- a/api/python/provisioner/cli_spec.yaml
+++ b/api/python/provisioner/cli_spec.yaml
@@ -43,12 +43,17 @@ upgrade:
   new_version: new version number
 consul:
     server: This flag is used to control if an agent is in server or client mode
-    bind_addr: The address that should be bound to for internal Consul cluster communications
+    bind_addr:
+      help: The address that should be bound to for internal Consul cluster communications
+      metavar: ipv4
     retry_join:
       help: Consul server for retry-join at start
       nargs: '*'
-    vendor:
-      version: Consul version to setup
+      metavar: ipv4
+    version: Consul version to setup
+    bootstrap_expect:
+      help: the number of expected servers in the Consul datacenter
+      metavar: number
 glusterfs:
   peers:
     help: gluster peer host (IP/domain)

--- a/api/python/provisioner/cli_spec.yaml
+++ b/api/python/provisioner/cli_spec.yaml
@@ -15,37 +15,52 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+# Format notes:
+#   - higher level keys - for groupping only
+#   - lowest level dictionaries will be passed
+#     to argparse's add_argument (like **kwargs)
+#   - TODO support for the leaf <spec_name>: <help string>
+#          as a shorthand for:
+#          <spec_name>:
+#            help: <help string>
+
+repos:
+  cortx: path/url to a CORTX distribution
+  dist_type:
+    help: the type of the distribution
+    choices: __py__:provisioner.config.DistrType
+  deps: path/url to a CORTX 3rd parties distribution
+  os: path/url to a CORTX OS distribution
+  py_index: >-
+    consider a custom python index inside CORTX distribution
+    (for bundle distribution only)
+upgrade:
+  level:
+    help: configuration level
+    choices: __py__:provisioner.config.ConfigLevelT
+  iteration: upgrade round number
 glusterfs:
   peers:
     help: gluster peer host (IP/domain)
     nargs: +
-  in_docker:
-    help: configure Dockerized glusterfs servers
-  add_repo:
-    help: configure glusterfs 3rd party repo
-  cleanup:
-    help: clean up the current configuration
+  in_docker: configure Dockerized glusterfs servers
+  add_repo: configure glusterfs 3rd party repo
+  cleanup: clean up the current configuration
 roster:
   nodes:
     help: "cluster node specification, format: id:[user@]hostname[:port]"
     nargs: +
     metavar: NODESPEC
-  path:
-    help: path to roster file
+  path: path to roster file
 pillar:
   release_type:
     help: release type
     choices: ['bundle', 'internal']
-  release_deps_bundle_url:
-    help: 3rd party dependencies repo url/path
-  release_target_build:
-    help: release type
-  service_user_password:
-    help: >-
-      a password for the CORTX service user, a special value __GENERATE__
-      might be used to generate a new one on the fly
+  release_deps_bundle_url: 3rd party dependencies repo url/path
+  release_target_build: release type
+  service_user_password: >-
+    a password for the CORTX service user, a special value __GENERATE__
+    might be used to generate a new one on the fly
 setup:
-  ha:
-    help: turn on high availability mode
-  salt_master:
-    help: domain name or IP of the salt-master
+  ha: turn on high availability mode
+  salt_master: domain name or IP of the salt-master

--- a/api/python/provisioner/cli_spec.yaml
+++ b/api/python/provisioner/cli_spec.yaml
@@ -39,6 +39,8 @@ upgrade:
     help: configuration level
     choices: __py__:provisioner.config.ConfigLevelT
   iteration: upgrade round number
+  old_version: old version number
+  new_version: new version number
 glusterfs:
   peers:
     help: gluster peer host (IP/domain)

--- a/api/python/provisioner/cli_spec.yaml
+++ b/api/python/provisioner/cli_spec.yaml
@@ -19,10 +19,11 @@
 #   - higher level keys - for groupping only
 #   - lowest level dictionaries will be passed
 #     to argparse's add_argument (like **kwargs)
-#   - TODO support for the leaf <spec_name>: <help string>
-#          as a shorthand for:
-#          <spec_name>:
-#            help: <help string>
+#   - a shorthand for a help-only spec is available:
+#           <spec_name>: <help string>
+#       is an equivalent for
+#           <spec_name>:
+#              help: <help string>
 
 repos:
   cortx: path/url to a CORTX distribution

--- a/api/python/provisioner/cli_spec.yaml
+++ b/api/python/provisioner/cli_spec.yaml
@@ -41,6 +41,14 @@ upgrade:
   iteration: upgrade round number
   old_version: old version number
   new_version: new version number
+consul:
+    server: This flag is used to control if an agent is in server or client mode
+    bind_addr: The address that should be bound to for internal Consul cluster communications
+    retry_join:
+      help: Consul server for retry-join at start
+      nargs: '*'
+    vendor:
+      version: Consul version to setup
 glusterfs:
   peers:
     help: gluster peer host (IP/domain)
@@ -66,3 +74,4 @@ pillar:
 setup:
   ha: turn on high availability mode
   salt_master: domain name or IP of the salt-master
+  vendored: The flag to use setup logic from a vendor

--- a/api/python/provisioner/commands/pillar_export.py
+++ b/api/python/provisioner/commands/pillar_export.py
@@ -106,51 +106,36 @@ class PillarExport(PillarGet):
                 targets=local_minion_id()
             )[local_minion_id()]["ip4_interfaces"]
 
+            network_pillar = full_pillar_load["cluster"][
+                local_minion_id()]["network"]
+
             # Update interface IPs
             # Public Management Interface
             mgmt_if_public = (
                 "mgmt0" if "mgmt0" in ip4_interfaces
-                else full_pillar_load["cluster"] \
-                    [local_minion_id()] \
-                    ["network"] \
-                    ["mgmt"] \
-                    ["interfaces"][0]
+                else network_pillar["mgmt"]["interfaces"][0]
             )
-            full_pillar_load["cluster"] \
-                [local_minion_id()] \
-                ["network"] \
-                ["mgmt"] \
-                ["public_ip"] = ip4_interfaces[mgmt_if_public][0]
+            network_pillar["mgmt"]["public_ip"] = (
+                ip4_interfaces[mgmt_if_public][0]
+            )
 
             # Public Data Interface
             data_if_public = (
                 "data0" if "data0" in ip4_interfaces
-                else full_pillar_load["cluster"] \
-                    [local_minion_id()] \
-                    ["network"] \
-                    ["data"] \
-                    ["public_interfaces"][0]
+                else network_pillar["data"]["public_interfaces"][0]
             )
-            full_pillar_load["cluster"] \
-                [local_minion_id()] \
-                ["network"] \
-                ["data"] \
-                ["public_ip"] = ip4_interfaces[data_if_public][0]
+            network_pillar["data"]["public_ip"] = (
+                ip4_interfaces[data_if_public][0]
+            )
 
             # Private Data Interface
             data_if_private = (
                 "data0" if "data0" in ip4_interfaces
-                else full_pillar_load["cluster"] \
-                    [local_minion_id()] \
-                    ["network"] \
-                    ["data"] \
-                    ["private_interfaces"][0]
+                else network_pillar["data"]["private_interfaces"][0]
             )
-            full_pillar_load["cluster"] \
-                [local_minion_id()] \
-                ["network"] \
-                ["data"] \
-                ["private_ip"] = ip4_interfaces[data_if_private][0]
+            network_pillar["data"]["private_ip"] = (
+                ip4_interfaces[data_if_private][0]
+            )
 
             convert_data = self._convert_to_str(full_pillar_load, "")
 
@@ -163,7 +148,8 @@ class PillarExport(PillarGet):
             with open(pillar_dump_file, "w") as file_value:
                 json.dump(convert_data, file_value)
 
-            logger.info("SUCCESS: Pillar data exported as JSON to file "
+            logger.info(
+                "SUCCESS: Pillar data exported as JSON to file "
                 f"'{pillar_dump_file}'."
             )
 

--- a/api/python/provisioner/commands/set_cluster_id.py
+++ b/api/python/provisioner/commands/set_cluster_id.py
@@ -87,7 +87,9 @@ class SetClusterId(CommandParserFillerMixin):
                     "ClusterID is not found in grains data. Generating one.."
                 )
                 cluster_uuid = str(uuid.uuid4())
-                logger.info("Setting the generated ClusterID across all nodes..")
+                logger.info(
+                    "Setting the generated ClusterID across all nodes.."
+                )
 
                 PillarSet().run(
                     'cluster/cluster_id',
@@ -97,7 +99,8 @@ class SetClusterId(CommandParserFillerMixin):
 
             elif cluster_id_from_grains and not cluster_id_from_pillar:
                 logger.info(
-                    "ClusterID is not set in pillar data. Proceeding to set now.."
+                    "ClusterID is not set in pillar data."
+                    " Proceeding to set now.."
                 )
                 PillarSet().run(
                     'cluster/cluster_id',

--- a/api/python/provisioner/commands/setup_provisioner.py
+++ b/api/python/provisioner/commands/setup_provisioner.py
@@ -622,7 +622,9 @@ class SetupProvisioner(SetupCmdBase, CommandParserFillerMixin):
         self, nodes: List[Node], priv_key, roster_path
     ):
         tmp_dir = os.getenv('TMPDIR')
-        thin_dir = (Path(tmp_dir).resolve() / 'salt_thin_dir') if tmp_dir else None
+        thin_dir = (
+            (Path(tmp_dir).resolve() / 'salt_thin_dir') if tmp_dir else None
+        )
 
         roster = {}
         for node in nodes:

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -268,6 +268,7 @@ class LogLevelTypes(Enum):
 # bundled salt roots dirs
 BUNDLED_SALT_DIR = CONFIG_MODULE_DIR / 'srv'
 BUNDLED_SALT_FILEROOT_DIR = BUNDLED_SALT_DIR / 'salt'
+BUNDLED_SALT_FILEROOT_VENDOR_DIR = BUNDLED_SALT_DIR / 'salt-vendor'
 BUNDLED_SALT_PILLAR_DIR = BUNDLED_SALT_DIR / 'pillar'
 
 # profile parameters

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -159,6 +159,7 @@ ALL_TARGETS = ALL_MINIONS  # XXX rethink later
 LOCAL_MINION = '__local__'
 
 PRVSNR_VALUES_PREFIX = 'PRVSNR_'
+CLI_SPEC_PY_OBJS_PREFIX = '__py__:'
 
 SECRET_MASK = '*' * 7
 
@@ -560,3 +561,10 @@ class HashType(Enum):
     MD5 = "md5"
     SHA256 = "sha256"
     SHA512 = "sha512"
+
+# UPGRADE ROUTINE
+class ConfigLevelT(Enum):
+    """CORTX configuration levels"""
+
+    CLUSTER = "cluster"
+    NODE = "node"

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -544,6 +544,7 @@ class CortxResourceT(Enum):
     """Resource types in CORTX provisioner"""
 
     REPOS = "cortx_repos"
+    CONSUL = "consul"
 
 
 class ContentType(Enum):

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -564,6 +564,7 @@ class HashType(Enum):
     SHA256 = "sha256"
     SHA512 = "sha512"
 
+
 # UPGRADE ROUTINE
 class ConfigLevelT(Enum):
     """CORTX configuration levels"""

--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -22,6 +22,8 @@ import functools
 from typing import List, Union, Any, Iterable, Tuple, Dict, Type, Optional
 from pathlib import Path
 import argparse
+import importlib
+from enum import Enum
 
 from .vendor import attr
 from .errors import UnknownParamError, SWUpdateRepoSourceError
@@ -38,12 +40,56 @@ from .serialize import PrvsnrType, loads
 
 from . import config, utils
 
-cli_spec = utils.load_yaml(config.CLI_SPEC_PATH)
 
 METADATA_PARAM_GROUP_KEY = '_param_group_key'
 METADATA_ARGPARSER = '_param_argparser'
 
 logger = logging.getLogger(__name__)
+
+
+def load_cli_spec():
+    res = utils.load_yaml(config.CLI_SPEC_PATH)
+
+    def _choices_filter(leaf: utils.DictLeaf):
+        return (
+            leaf.key == 'choices'
+            and isinstance(leaf.value, str)
+            and leaf.value.startswith(config.CLI_SPEC_PY_OBJS_PREFIX)
+        )
+
+    # convert choices to objects
+    for leaf in utils.iterate_dict(res, filter_f=_choices_filter):
+        choices_spec = leaf.value.split(
+            config.CLI_SPEC_PY_OBJS_PREFIX
+        )[1].split('.')
+
+        mod_name = '.'.join(choices_spec[0:-1])
+        attr_name = choices_spec[-1]
+        module = importlib.import_module(mod_name)
+
+        choices = getattr(module, attr_name)
+
+        if issubclass(choices, Enum):
+            choices = [i.value for i in choices]
+
+        leaf.parent[leaf.key] = choices
+
+    # convert trivial descriptions (no help)
+    def _nohelp_filter(leaf: utils.DictLeaf):
+        return (
+            leaf.key != 'help'
+            and ('help' not in leaf.parent)
+            and isinstance(leaf.value, str)
+        )
+
+    # convert choices to objects
+    for leaf in utils.iterate_dict(res, filter_f=_nohelp_filter):
+        leaf.parent[leaf.key] = dict(help=leaf.value)
+
+    return res
+
+
+cli_spec = load_cli_spec()
 
 
 # TODO IMPROVE use some attr api to copy spec
@@ -196,6 +242,11 @@ class ParserFiller:
 
                 if isinstance(metadata, str):
                     metadata = KeyPath(metadata).value(cli_spec)
+                    _attr = copy_attr(
+                        _attr, metadata={
+                            METADATA_ARGPARSER: metadata
+                        }
+                    )
 
                 if metadata.get('action') == 'store_bool':
                     for name, default, m_changes in (

--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -74,7 +74,6 @@ def load_cli_spec():
 
         leaf.parent[leaf.key] = choices
 
-    # convert trivial descriptions (no help)
     def _nohelp_filter(leaf: utils.DictLeaf):
         return (
             leaf.key != 'help'
@@ -82,7 +81,7 @@ def load_cli_spec():
             and isinstance(leaf.value, str)
         )
 
-    # convert choices to objects
+    # convert trivial descriptions (no help)
     for leaf in utils.iterate_dict(res, filter_f=_nohelp_filter):
         leaf.parent[leaf.key] = dict(help=leaf.value)
 

--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -36,9 +36,9 @@ from .values import (
 )
 from .serialize import PrvsnrType, loads
 
-from . import config
+from . import config, utils
 
-# cli_spec = load_yaml(config.CLI_SPEC_PATH)
+cli_spec = utils.load_yaml(config.CLI_SPEC_PATH)
 
 METADATA_PARAM_GROUP_KEY = '_param_group_key'
 METADATA_ARGPARSER = '_param_argparser'
@@ -194,8 +194,8 @@ class ParserFiller:
                 parser_prefix = getattr(cls, 'parser_prefix', None)
                 metadata = _attr.metadata[METADATA_ARGPARSER]
 
-                # if isinstance(metadata, str):
-                #    metadata = KeyPath(metadata).value(cli_spec)
+                if isinstance(metadata, str):
+                    metadata = KeyPath(metadata).value(cli_spec)
 
                 if metadata.get('action') == 'store_bool':
                     for name, default, m_changes in (

--- a/api/python/provisioner/log.py
+++ b/api/python/provisioner/log.py
@@ -80,7 +80,7 @@ class NoTraceExceptionFormatter(logging.Formatter):
         record.exc_text = ''
         return super().format(record)
 
-    def formatException(self, exc_info):
+    def formatException(self, exc_info):  # noqa: N802
         # TODO IMPROVE check docs for exc_info
         return repr(getattr(exc_info[1], 'reason', exc_info[1]))
 
@@ -113,7 +113,7 @@ class NoErrorSysLogHandler(logging.handlers.SysLogHandler):
                 else:
                     break
 
-    def handleError(self, record):
+    def handleError(self, record):  # noqa: N802
         t, v, _ = sys.exc_info()
         if issubclass(t, OSError) and 'Message too long' in str(v):
             raise LogMsgTooLong()
@@ -184,7 +184,7 @@ def build_log_args_cls(log_config=None):  # noqa: C901 FIXME
                     },
                     default=hattrs['filename']
                 )
-                maxBytes: int = attr.ib(
+                maxBytes: int = attr.ib(  # noqa: N815
                     metadata={
                         inputs.METADATA_ARGPARSER: {
                             'help': (
@@ -198,7 +198,7 @@ def build_log_args_cls(log_config=None):  # noqa: C901 FIXME
                     default=hattrs['maxBytes'],
                     converter=int
                 )
-                backupCount: int = attr.ib(
+                backupCount: int = attr.ib(  # noqa: N815
                     metadata={
                         inputs.METADATA_ARGPARSER: {
                             'help': (

--- a/api/python/provisioner/paths.py
+++ b/api/python/provisioner/paths.py
@@ -74,7 +74,7 @@ class PillarPath(RootPath):
     def host_path(self, path, target: str):
         return self.add_merge_prefix(
             self, (
-                Path(self.all_hosts_dir.format(minion_id=target))
+                Path(self.host_dir_tmpl.format(minion_id=target))
                 / path
             )
         )

--- a/api/python/provisioner/profile.py
+++ b/api/python/provisioner/profile.py
@@ -72,7 +72,8 @@ def setup(
             'base': [str(d.resolve()) for d in add_file_roots] + [
                 str(profile_paths['salt_fileroot_dir']),
                 str(profile_paths['salt_factory_fileroot_dir']),
-                str(config.BUNDLED_SALT_FILEROOT_DIR)
+                str(config.BUNDLED_SALT_FILEROOT_DIR),
+                str(config.BUNDLED_SALT_FILEROOT_VENDOR_DIR),
             ]
         },
         'pillar_roots': {

--- a/api/python/provisioner/resources/base.py
+++ b/api/python/provisioner/resources/base.py
@@ -131,8 +131,10 @@ class ResourceManager:
         if trans_kwargs is None:
             trans_kwargs = {}
 
-        trans = transition_t(state, *trans_args, **trans_kwargs)
-        return trans.run(*args, targets=targets, **kwargs)
+        trans = transition_t(
+            state, *trans_args, targets=targets, **trans_kwargs
+        )
+        return trans.run(*args, **kwargs)
 
 
 # class ResourceManagerBase(ABC):

--- a/api/python/provisioner/resources/consul.py
+++ b/api/python/provisioner/resources/consul.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import Union
+from pathlib import Path
+import logging
+from packaging.version import Version
+
+from .base import (
+    ResourceParams, ResourceBase, ResourceState
+)
+from provisioner import config
+from provisioner.vendor import attr
+from provisioner.attr_gen import attr_ib
+
+logger = logging.getLogger(__name__)
+
+
+class UpgradeParams(ResourceParams):
+    old_version: Union[str, Version] = attr_ib(
+        'version', cli_spec='upgrade/old_version',
+    )
+    new_version: Union[str, Version] = attr_ib(
+        'version', cli_spec='upgrade/new_version',
+    )
+    iteration: Union[str, int] = attr_ib(
+        cli_spec='upgrade/iteration',
+        default=0,
+        converter=int
+    )
+    level: config.ConfigLevelT = attr_ib(
+        cli_spec='upgrade/level',
+        default=config.ConfigLevelT.NODE.value,
+        converter=config.ConfigLevelT
+    )
+
+
+class ConsulParams(UpgradeParams):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class Consul(ResourceBase):
+    resource_t_id = config.CortxResourceT.CONSUL
+    params_t = ConsulParams
+
+
+@attr.s(auto_attribs=True)
+class ConsulState(ResourceState):
+    resource_t = Consul
+
+
+@attr.s
+class ConsulUpgrade(ConsulState):
+    name = 'upgrade'
+
+    old_version = ConsulParams.old_version
+    new_version = ConsulParams.new_version
+    level = ConsulParams.level
+    iteration = ConsulParams.iteration
+
+    # XXX - for UNCHANCGED values we may resolve real values here
+    #       and validate only after that
+    def __attrs_post_init__(self):  # noqa: C901
+        if not (self.new_version > self.old_version):
+            raise ValueError(
+                f"New version '{self.new_version}' is less"
+                f" than old one '{self.old_version}'"
+            )

--- a/api/python/provisioner/resources/consul.py
+++ b/api/python/provisioner/resources/consul.py
@@ -123,6 +123,11 @@ class ConsulTeardown(ConsulState):
 
 
 @attr.s
+class ConsulSanityCheck(ConsulState):
+    name = 'sanity-check'
+
+
+@attr.s
 class ConsulUpgrade(ConsulState):
     name = 'upgrade'
 

--- a/api/python/provisioner/resources/cortx_repos.py
+++ b/api/python/provisioner/resources/cortx_repos.py
@@ -22,9 +22,9 @@ import logging
 from .base import (
     ResourceParams, ResourceBase, ResourceState
 )
-from provisioner import config, inputs, utils
+from provisioner import config
 from provisioner.vendor import attr
-
+from provisioner.attr_gen import attr_ib
 
 logger = logging.getLogger(__name__)
 
@@ -33,69 +33,34 @@ logger = logging.getLogger(__name__)
 #       e.g. might be UNCHANGED or a real current value
 class CortxReposParams(ResourceParams):
     # TODO EOS-12076 validate it is a file or dir or url
-    cortx: Union[str, Path] = attr.ib(
-        metadata={
-            inputs.METADATA_ARGPARSER: {
-                'help': (
-                    "path/url to a CORTX distribution"
-                ),
-            }
-        },
+    cortx: Union[str, Path] = attr_ib(
+        'path_exists',
+        cli_spec='repos/cortx',
         # FIXME allow url as well
         # XXX copy validation routine from SetSWUpdateRepo
-        converter=utils.converter_path_resolved,
-        validator=utils.validator_path_exists
     )
-    dist_type: config.DistrType = attr.ib(
-        metadata={
-            inputs.METADATA_ARGPARSER: {
-                'help': (
-                    "the type of the distribution"
-                ),
-                'choices': [dt.value for dt in config.DistrType]
-            },
-        },
+    dist_type: config.DistrType = attr_ib(
+        cli_spec='repos/dist_type',
         default=config.DistrType.BUNDLE.value,
         # TODO EOS-12076 better validation
-        converter=(lambda v: config.DistrType(v))  # pylint: disable=unnecessary-lambda
+        converter=config.DistrType
     )
-    deps: Union[str, Path] = attr.ib(
-        metadata={
-            inputs.METADATA_ARGPARSER: {
-                'help': (
-                    "path/url to a CORTX 3rd parties distribution"
-                ),
-            }
-        },
+    deps: Union[str, Path] = attr_ib(
+        'path_exists',
+        cli_spec='repos/deps',
         default=None,
         # FIXME allow url as well
         # XXX copy validation routine from SetSWUpdateRepo
-        converter=utils.converter_path_resolved,
-        validator=utils.validator_path_exists
     )
-    os: Union[str, Path] = attr.ib(
-        metadata={
-            inputs.METADATA_ARGPARSER: {
-                'help': (
-                    "path/url to a CORTX OS distribution"
-                ),
-            }
-        },
+    os: Union[str, Path] = attr_ib(
+        'path_exists',
+        cli_spec='repos/os',
         default=None,
         # FIXME allow url as well
         # XXX copy validation routine from SetSWUpdateRepo
-        converter=utils.converter_path_resolved,
-        validator=utils.validator_path_exists
     )
-    py_index: bool = attr.ib(
-        metadata={
-            inputs.METADATA_ARGPARSER: {
-                'help': (
-                    "consider a custom python index inside CORTX distribution "
-                    "(for bundle distribution only)"
-                )
-            }
-        },
+    py_index: bool = attr_ib(
+        cli_spec='repos/py_index',
         default=False
     )
 
@@ -121,7 +86,7 @@ class CortxReposSetup(CortxReposState):
     os = CortxReposParams.os
     py_index = CortxReposParams.py_index
 
-    target_build: Path = attr.ib(
+    target_build: Path = attr_ib(
         init=False, default=None
     )
 

--- a/api/python/provisioner/salt_api/base.py
+++ b/api/python/provisioner/salt_api/base.py
@@ -432,8 +432,11 @@ class SaltClientBase(ABC):
         self,
         pillar_items: Union[Dict, List, Tuple],
         fpath: str = None,
+        expand: bool = False,
         targets=config.ALL_MINIONS
     ):
         pi_updater = self.pillar_updater(targets)
-        pi_updater.update(PillarIterable(pillar_items, fpath=fpath))
+        pi_updater.update(
+            PillarIterable(pillar_items, fpath=fpath, expand=expand)
+        )
         pi_updater.apply()

--- a/api/python/provisioner/salt_api/ssh.py
+++ b/api/python/provisioner/salt_api/ssh.py
@@ -272,7 +272,7 @@ class SaltSSHClient(SaltClientBase):
             inputs.METADATA_ARGPARSER: {
                 'help': (
                     "name of the ssh profile. Ignored if"
-                    f" '--profile' is specified"
+                    " '--profile' is specified"
                 )
             }
         }

--- a/api/python/provisioner/salt_api/ssh.py
+++ b/api/python/provisioner/salt_api/ssh.py
@@ -266,6 +266,17 @@ class SaltSSHClient(SaltClientBase):
         },
         converter=utils.converter_path_resolved
     )
+    profile_name: str = attr.ib(
+        default=None,
+        metadata={
+            inputs.METADATA_ARGPARSER: {
+                'help': (
+                    "name of the ssh profile. Ignored if"
+                    f" '--profile' is specified"
+                )
+            }
+        }
+    )
     ssh_options: Optional[Dict] = attr.ib(
         default=attr.Factory(
             lambda: [
@@ -298,6 +309,11 @@ class SaltSSHClient(SaltClientBase):
 
     def __attrs_post_init__(self):
         """Do post init."""
+
+        if not self.profile and self.profile_name:
+            self.profile = (
+                config.profile_base_dir().parent / self.profile_name
+            )
 
         if self.profile:
             paths = config.profile_paths(

--- a/api/python/provisioner/scm/saltstack/rc_sls/base.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/base.py
@@ -15,7 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-from typing import ClassVar, Optional, Dict, Union, Any
+from typing import ClassVar, Optional, Dict, Union, Any, Iterable
 from pathlib import Path
 import importlib
 import logging
@@ -64,9 +64,12 @@ class ResourceSLS(ResourceTransition):  # XXX ??? inheritance
             if self.pillar_inline:
                 fun_kwargs['pillar'] = self.pillar_inline
 
-            self.client.state_apply(
-                self.sls, targets=targets, fun_kwargs=fun_kwargs
-            )
+            sls = (self.sls if isinstance(self.sls, Iterable) else [self.sls])
+
+            for _sls in sls:
+                self.client.state_apply(
+                    _sls, targets=targets, fun_kwargs=fun_kwargs
+                )
 
 
 # arbitrary dir and recursive are not support for now

--- a/api/python/provisioner/scm/saltstack/rc_sls/base.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/base.py
@@ -116,6 +116,7 @@ class ResourceSLS(ResourceTransition):  # XXX ??? inheritance
     def run(self):
         self.setup_roots()
 
+        res = []
         # XXX possibly a divergence with a design
         # some SLS may just shifts root without any states appliance
         if self.sls:
@@ -134,9 +135,12 @@ class ResourceSLS(ResourceTransition):  # XXX ??? inheritance
                 slss = [f'{self.base_sls}.{sls}' for sls in slss]
 
             for sls in slss:
-                self.client.state_apply(
+                _res = self.client.state_apply(
                     sls, targets=self.targets, fun_kwargs=fun_kwargs
                 )
+                res.append(_res)
+
+            return res
 
 
 # arbitrary dir and recursive are not support for now

--- a/api/python/provisioner/scm/saltstack/rc_sls/consul.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/consul.py
@@ -114,6 +114,16 @@ class ConsulTeardownSLS(ConsulSLS):
             )
 
 
+@attr.s
+class ConsulSanityCheckSLS(ConsulSLS):
+    sls = 'sanity_check'
+    state_t = consul.ConsulSanityCheck
+
+    @property
+    def is_vendored(self) -> bool:
+        return False
+
+
 # XXX validation after setup
 @attr.s
 class ConsulUpgradeSLS(ConsulSLS):

--- a/api/python/provisioner/scm/saltstack/rc_sls/consul.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/consul.py
@@ -17,7 +17,6 @@
 
 from typing import Union
 import logging
-from pathlib import Path
 
 from .base import ResourceSLS
 

--- a/api/python/provisioner/scm/saltstack/rc_sls/consul.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/consul.py
@@ -15,7 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-from typing import Any, Union
+from typing import Union
 import logging
 from pathlib import Path
 
@@ -50,12 +50,6 @@ class ConsulSLS(ResourceSLS):
     def version(self) -> str:
         return self.pillar.get('version', VERSION_LATEST)
 
-    def setup_roots(self, targets):
-        logger.info(
-            f"Preparing Consul roots for '{self.state.name}'"
-            f" on targets: {targets}"
-        )
-
 
 @attr.s
 class ConsulInstallSLS(ConsulSLS):
@@ -70,8 +64,8 @@ class ConsulInstallSLS(ConsulSLS):
         self._version = self.state.consul_version or VERSION_LATEST
         self.set_vendored(self.state.vendored)
 
-    def setup_roots(self, targets):
-        super().setup_roots(targets)
+    def setup_roots(self):
+        super().setup_roots()
         self.pillar_set(dict(version=str(self._version)))
 
 
@@ -80,8 +74,8 @@ class ConsulConfigSLS(ConsulSLS):
     sls = 'config'
     state_t = consul.ConsulConfig
 
-    def setup_roots(self, targets):
-        super().setup_roots(targets)
+    def setup_roots(self):
+        super().setup_roots()
 
         config = {}
         pillar = {'config': config, 'service': self.state.service}
@@ -139,7 +133,7 @@ class ConsulUpgradeSLS(ConsulSLS):
         }
     }
 
-    def run(self, targets: Any = config.ALL_TARGETS):
+    def run(self):
         for m_range, m_spec in self.migrations.items():
             if (
                 self.state.new_version == m_range.new_version
@@ -153,4 +147,4 @@ class ConsulUpgradeSLS(ConsulSLS):
             )
 
         self.sls = m_spec.get((self.state.iteration, self.state.level), None)
-        super().run(targets)
+        super().run()

--- a/api/python/provisioner/scm/saltstack/rc_sls/consul.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/consul.py
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+from typing import Any, Union
+import logging
+from pathlib import Path
+
+from .base import ResourceSLS
+
+from provisioner.vendor import attr
+from provisioner.resources import consul
+from provisioner import config
+from packaging.specifiers import SpecifierSet
+from provisioner.attr_gen import attr_ib
+
+
+logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class VersionRange:
+    old_versions: Union[str, SpecifierSet] = attr_ib('version_specifier')
+    new_version: Union[str, Path] = attr_ib('version')
+
+
+migrations = {
+    VersionRange('>=1.2.4,<1.4.0', '1.6.9'): {
+        (1, config.ConfigLevelT.NODE): [
+            'consul.upgrade.ACL_tokens',
+            'consul.upgrade.1_6_9_config'
+        ]
+    },
+    VersionRange('>=1.4.0,<1.4.0', '1.6.9'): {
+        (1, config.ConfigLevelT.NODE): [
+            'consul.upgrade.ACL_tokens'
+        ]
+    }
+}
+
+
+# XXX validation after setup
+class ConsulUpgradeSLS(ResourceSLS):
+    sls = None
+    state_t = consul.ConsulUpgrade
+
+    def setup_roots(self, targets):
+        pass
+
+    def run(self, targets: Any = config.ALL_TARGETS):
+        for m_range, m_spec in migrations.items():
+            if (
+                self.state.new_version == m_range.new_version
+                and m_range.old_versions.contains(self.state.old_version)
+            ):
+                break
+        else:
+            raise ValueError(
+                f"Consul migration from '{self.state.old_version}'"
+                f" to '{self.state.new_version}' is not supported"
+            )
+
+        self.sls = m_spec.get((self.state.iteration, self.state.level), None)
+        super().run(targets)

--- a/api/python/provisioner/scm/saltstack/rc_sls/cortx_repos.py
+++ b/api/python/provisioner/scm/saltstack/rc_sls/cortx_repos.py
@@ -149,7 +149,8 @@ class CortxReposSetupSLS(ResourceSLS):
         return file_roots, pillar
 
     def setup_roots(self, targets):
-        logger.info("Preparing CORTX repos roots")
+        super().setup_roots()
+
         if self.state.dist_type == config.DistrType.BUNDLE:
             file_roots, pillar = self.setup_roots_for_bundle(targets)
         else:

--- a/api/python/provisioner/srv/salt-vendor/README.md
+++ b/api/python/provisioner/srv/salt-vendor/README.md
@@ -1,0 +1,18 @@
+# Vendor SaltStack formulas
+
+The directory is intedened to be used as a fileroot for SaltStack community formulas
+like ones from [SaltStack Formulas](https://github.com/saltstack-formulas) repository.
+
+Usually such 3rd party formulas are considered to be installed as described in
+[SALT FORMULAS](https://docs.saltproject.io/en/latest/topics/development/conventions/formulas.html)
+doc.
+
+You may follow the doc or just put a formula here using the fileroot as a common
+location for all 3rd party formulas.
+
+Example for [consul-formula](https://github.com/saltstack-formulas/consul-formula):
+
+```bash
+SW=consul; curl -L https://github.com/saltstack-formulas/"$SW"-formula/archive/master.tar.gz \
+    | tar -xzf - --strip-components=1 "$SW"-formula-master/"$SW"
+```

--- a/api/python/provisioner/srv/salt/_modules/prvsnr.py
+++ b/api/python/provisioner/srv/salt/_modules/prvsnr.py
@@ -79,7 +79,7 @@ def _api_wrapper(fun):
         cmd = ['provisioner']
         cmd.extend(api_args_to_cli(fun, *args, **_kwargs))
         cmd = [quote(p) for p in cmd]
-        return __salt__['cmd.run'](' '.join(cmd), env=env)  # noqa: F821 pylint: disable=undefined-variable
+        return __salt__['cmd.run'](' '.join(cmd), env=env)  # noqa: F821, E501 pylint: disable=undefined-variable
 
     return _f
 

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/1_9_0lt-1_9_0ge-1.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/1_9_0lt-1_9_0ge-1.sls
@@ -15,21 +15,11 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Format notes:
-#   - top level keys are types of attributes
-#   - validators:
-#     - each type may have related validator as validator__<type>
-#     - if `validator` is specified explicitly as a key it overrides
-#   - converter: (the same as for validators)
+{% set consul_config = '/etc/consul.d/config.json' %}
 
-# TODO:
-# - optional support for validators
-# - None support for converters
-
-ipv4: {}
-nodes: {}
-path: {}
-path_exists:
-  converter: path_resolved
-version: {}
-version_specifier: {}
+# TODO ??? use file.managed instead to have better changes representations
+migration-1.9.0lt-1.9.0ge-1:
+  cmd.script:
+    - name: salt://resources/3rd_party/consul/migrations/files/1.9.0lt-1.9.0ge-1.py
+    - unless:
+      - grep ui_config {{ consul_config }}

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/1_9_0lt-1_9_0ge-2.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/1_9_0lt-1_9_0ge-2.sls
@@ -15,21 +15,11 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Format notes:
-#   - top level keys are types of attributes
-#   - validators:
-#     - each type may have related validator as validator__<type>
-#     - if `validator` is specified explicitly as a key it overrides
-#   - converter: (the same as for validators)
+{% set consul_config = '/etc/consul.d/config.json' %}
 
-# TODO:
-# - optional support for validators
-# - None support for converters
-
-ipv4: {}
-nodes: {}
-path: {}
-path_exists:
-  converter: path_resolved
-version: {}
-version_specifier: {}
+# TODO ??? use file.managed instead to have better changes representations
+migration-1.9.0lt-1.9.0ge-2:
+  cmd.script:
+    - name: salt://resources/3rd_party/consul/migrations/files/1.9.0lt-1.9.0ge-2.py
+    - unless:
+      - grep disable_compat_1.9 {{ consul_config }}

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/files/1.9.0lt-1.9.0ge-1.py
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/files/1.9.0lt-1.9.0ge-1.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 #
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
@@ -15,21 +16,20 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Format notes:
-#   - top level keys are types of attributes
-#   - validators:
-#     - each type may have related validator as validator__<type>
-#     - if `validator` is specified explicitly as a key it overrides
-#   - converter: (the same as for validators)
 
-# TODO:
-# - optional support for validators
-# - None support for converters
+import json
+from pathlib import Path
 
-ipv4: {}
-nodes: {}
-path: {}
-path_exists:
-  converter: path_resolved
-version: {}
-version_specifier: {}
+CONFIG_PATH = '/etc/consul.d/config.json'
+
+config_path = Path(CONFIG_PATH)
+
+config = json.loads(config_path.read_text())
+
+config['ui_config'] = (
+    config.get('ui_config') or {'enabled': config.get('ui', False)}
+)
+
+config.pop('ui', None)
+
+config_path.write_text(json.dumps(config, indent=4))

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/files/1.9.0lt-1.9.0ge-2.py
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations/files/1.9.0lt-1.9.0ge-2.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 #
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
@@ -15,21 +16,25 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Format notes:
-#   - top level keys are types of attributes
-#   - validators:
-#     - each type may have related validator as validator__<type>
-#     - if `validator` is specified explicitly as a key it overrides
-#   - converter: (the same as for validators)
 
-# TODO:
-# - optional support for validators
-# - None support for converters
+import json
+from pathlib import Path
 
-ipv4: {}
-nodes: {}
-path: {}
-path_exists:
-  converter: path_resolved
-version: {}
-version_specifier: {}
+CONFIG_PATH = '/etc/consul.d/config.json'
+TELEMETRY_KEY = 'telemetry'
+DISABLE_KEY = 'disable_compat_1.9'
+
+config_path = Path(CONFIG_PATH)
+
+config = json.loads(config_path.read_text())
+
+if TELEMETRY_KEY not in config:
+    config[TELEMETRY_KEY] = {}
+
+telemetry = config[TELEMETRY_KEY]
+
+telemetry[DISABLE_KEY] = (
+    telemetry.get(DISABLE_KEY) or True
+)
+
+config_path.write_text(json.dumps(config, indent=4))

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/sanity_check.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/sanity_check.sls
@@ -15,5 +15,11 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-include:
-  - ..start
+Check Consul version:
+  cmd.run:
+    - name: consul -v
+
+# TODO better check basing on service module
+Check Consul service:
+  cmd.run:
+    - name: systemctl status consul

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/start.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/start.sls
@@ -15,5 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-include:
-  - ..start
+Start Consul:
+  service.running:
+    - name: consul.service
+    - enable: True

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/stop.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/stop.sls
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+Start Consul:
+  service.dead:
+    - name: consul.service
+    - enable: False

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/config.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/config.sls
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# XXX have to call install and service as well since
+#     config implies external linkage with them
+#     (there are few requisites and in-requisites between
+#     config and these states)
+include:
+  - consul.install
+  - consul.config
+  - consul.service

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/init.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/init.sls
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+include:
+  - consul

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/install.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/install.sls
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+include:
+  - consul.install

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/start.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/start.sls
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+include:
+  - consul.service

--- a/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/stop.sls
+++ b/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor/stop.sls
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+include:
+  - ..stop

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -68,7 +68,7 @@ def iterate_dict(d, path: Path = None, filter_f=None) -> Iterator[DictLeaf]:
     # list: considering changes in base dictionary during the iteration
     for k in list(d):
         v = d[k]
-        _path = (Path(k) if path is None else (path / k))
+        _path = (Path(str(k)) if path is None else (path / k))
         if isinstance(v, dict):
             yield from iterate_dict(v, _path, filter_f)
         else:

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -15,6 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+from typing import Iterator
 import configparser
 import json
 import logging
@@ -56,6 +57,24 @@ HashInfo = attr.make_class(
                    if isinstance(x, str) else x),
                'filename': attr.ib(default=None)
            })
+
+
+DictLeaf = attr.make_class(
+    "DictLeaf", ('key', 'value', 'parent', 'keypath')
+)
+
+
+def iterate_dict(d, path: Path = None, filter_f=None) -> Iterator[DictLeaf]:
+    # list: considering changes in base dictionary during the iteration
+    for k in list(d):
+        v = d[k]
+        _path = (Path(k) if path is None else (path / k))
+        if isinstance(v, dict):
+            yield from iterate_dict(v, _path, filter_f)
+        else:
+            leaf = DictLeaf(k, v, d, _path)
+            if not filter_f or filter_f(leaf):
+                yield leaf
 
 
 # TODO TEST

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -95,7 +95,8 @@ setup(
     },
     install_requires=[
         'PyYAML',
-        'salt == 3002.2'
+        'salt == 3002.2',
+        'packaging==20.4'
     ],  # TODO
     setup_requires=([] + pytest_runner),
     extras_require={

--- a/test/build_helpers/build_env/test_build_env.py
+++ b/test/build_helpers/build_env/test_build_env.py
@@ -56,11 +56,16 @@ def hosts_spec(hosts_spec, hosts, tmpdir_function, request):
 
 
 @pytest.mark.isolated
-@pytest.mark.env_level('utils')
 def test_build_setup_env(
     request, root_passwd, nodes_num, ssh_config, env_provider,
     ask_proceed
 ):
+    request.applymarker(
+        pytest.mark.env_level(
+            request.config.getoption("env_level") or 'utils'
+        )
+    )
+
     request.applymarker(
         pytest.mark.hosts([f'srvnode{i}' for i in range(1, nodes_num + 1)])
     )

--- a/test/build_helpers/build_env/test_build_env.py
+++ b/test/build_helpers/build_env/test_build_env.py
@@ -56,6 +56,7 @@ def hosts_spec(hosts_spec, hosts, tmpdir_function, request):
 
 
 @pytest.mark.isolated
+@pytest.mark.timeout(86400)  # one day timeout
 def test_build_setup_env(
     request, root_passwd, nodes_num, ssh_config, env_provider,
     ask_proceed

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -109,6 +109,7 @@ ENV_LEVELS_HIERARCHY = {
 
 
 BASE_OS_NAMES = list(ENV_LEVELS_HIERARCHY['base'])
+ENV_LEVELS = list(ENV_LEVELS_HIERARCHY)
 DEFAULT_BASE_OS_NAME = 'centos7.8.2003'
 
 DEFAULT_CLUSTER_SPEC = {
@@ -398,6 +399,12 @@ prvsnr_pytest_options = {
         choices=['host', 'docker', 'vbox'],
         default='docker',
         help="test environment provider, defaults to docker"
+    ),
+    "env-level": dict(
+        action='store',
+        choices=ENV_LEVELS,
+        default=None,
+        help="test environment level"
     ),
     "prvsnr-src": dict(
         action='store', choices=['rpm', 'github', 'local'],


### PR DESCRIPTION
The PR introduces the following changes:
- base approach to support migrations for a resource configuration
- [consul resource presentation](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/resources/consul.py) and [setup routine for consul](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/scm/saltstack/rc_sls/consul.py) (including upgrade with [migrations around v1.9.0](https://github.com/Seagate/cortx-prvsnr/tree/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/srv/salt/resources/3rd_party/consul/migrations) as a demo implementation)
- adds [helpers to simplify pillar operations](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/scm/saltstack/rc_sls/base.py#L55-L102) and other routine for salt based resource transitions
- introduces support for [vendor setups](https://github.com/Seagate/cortx-prvsnr/tree/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/srv/salt/resources/3rd_party/consul/vendor)
- [helpers](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/attr_gen.py) to shorten specifications for class attributes and CLI arguments that might be defined as yaml specs ([cli spec](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/cli_spec.yaml) and [attrs spec](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/attrs_spec.yaml))
- [updates cortx repos](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/resources/cortx_repos.py) setup routine to use cli and attrs specs
- helper to set pillar for a dict object as [expanded](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/pillar.py#L171-L176) into a set of leaves
- [improves ssh](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/provisioner/salt_api/ssh.py#L109-L115) to support some specific return results
- [adds dependency](https://github.com/Seagate/cortx-prvsnr/blob/1b481a0c0bd1fdc4eba1f3bcf26e0233d10d4385/api/python/setup.py#L99) on `packaging==20.4` module (which is a part of cortx python dependency list)