### PR TITLE
EOS-19102: Erroneous HAproxy configuration

### DIFF
--- a/srv/components/ha/haproxy/files/haproxy.cfg
+++ b/srv/components/ha/haproxy/files/haproxy.cfg
@@ -73,27 +73,27 @@ defaults
 #---------------------------------------------------------------------
 # main frontend which proxys to the backends
 #---------------------------------------------------------------------
-frontend main
-    bind *:5000
-    acl url_static       path_beg       -i /static /images /javascript /stylesheets
-    acl url_static       path_end       -i .jpg .gif .png .css .js
+# frontend main
+#     bind *:5000
+#     acl url_static       path_beg       -i /static /images /javascript /stylesheets
+#     acl url_static       path_end       -i .jpg .gif .png .css .js
 
-    use_backend static          if url_static
-    default_backend             app
+#     use_backend static          if url_static
+#     default_backend             app
 
 #---------------------------------------------------------------------
 # static backend for serving up images, stylesheets and such
 #---------------------------------------------------------------------
-backend static
-    balance     roundrobin
-    server      static 127.0.0.1:4331 check
+# backend static
+#     balance     roundrobin
+#     server      static 127.0.0.1:4331 check
 
 #---------------------------------------------------------------------
 # round robin balancing between the various backends
 #---------------------------------------------------------------------
-backend app
-    balance     roundrobin
-    server  app1 127.0.0.1:5001 check
-    server  app2 127.0.0.1:5002 check
-    server  app3 127.0.0.1:5003 check
-    server  app4 127.0.0.1:5004 check
+# backend app
+#     balance     roundrobin
+#     server  app1 127.0.0.1:5001 check
+#     server  app2 127.0.0.1:5002 check
+#     server  app3 127.0.0.1:5003 check
+#     server  app4 127.0.0.1:5004 check

--- a/srv/components/ha/haproxy/init.sls
+++ b/srv/components/ha/haproxy/init.sls
@@ -20,8 +20,6 @@ include:
   - components.ha.haproxy.prepare
   - components.ha.haproxy.install
   - components.ha.haproxy.config
-  # Disable start to be explicitly started later
-  # Requires Cluster_IP to be set by corosync-pacemaker before start in HW
-  # - components.ha.haproxy.start
+  - components.ha.haproxy.start
   # - components.ha.haproxy.sanity_check
-  - components.ha.haproxy.stop
+  # - components.ha.haproxy.stop

--- a/srv/components/provisioner/files/setup.yaml
+++ b/srv/components/provisioner/files/setup.yaml
@@ -17,22 +17,20 @@
 
 provisioner:
   post_install:
-    script: null
+    cmd: null
     args: null
   config:
-    script: null
+    cmd: null
     args: null
   init:
-    script: null
+    cmd: null
     args: null
   test:
-    script: null
+    cmd: null
     args: null
   reset:
-    cmd: /opt/seagate/cortx/s3/bin/s3_setup
-    args:
-      - restore
-      - --config $URL
+    cmd: null
+    args: null
   backup:
     files:
       - /var/lib/seagate/cortx/provisioner/shared


### PR DESCRIPTION
Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>

### Erroneous HAproxy configuration is binding to *:5000
Such configuration has been introduced with https://github.com/Seagate/cortx-prvsnr/pull/868/commits/17a9c556717b0dc65087e8458eb94891ba1d72f8.

Because HAproxy binds to *:5000, UDS cannot bind to port 5000 and hence CSM cannot reach its server.