### PR TITLE
EOS-15752: Document API for SW upgrade release bundle setup/teardown

### DIFF
--- a/docs/Architecture/SW-Upgrade.md
+++ b/docs/Architecture/SW-Upgrade.md
@@ -2,18 +2,34 @@
 
 Table of contents:
 
+- [High Level SW Upgrade logic](#high-level-sw-upgrade-logic)
 - [Setup SW upgrade repository](#setup-sw-upgrade-repository)
 - [Apply SW upgrade](#apply-sw-upgrade)
 - [SW upgrade single ISO bundle structure](#sw-upgrade-single-iso-bundle-structure)
 - [Delete SW upgrade repository](#delete-sw-upgrade-repository)
+- [References](#references)
 
+
+## High Level SW Upgrade logic
+
+The high level logic of SW upgrade is:
+
+    1. Validate candidate SW upgrade single ISO bundle:
+        a. Mount ISO
+        b. ISO catalog structure validation
+        c. Validate content of `RELEASE.INFO` file for each separate bundle's repository
+        d. Setup yum repositories
+        e. Validate each separate yum repo
+    2. SW upgrade repositories setup:
+        a. Mount ISO
+        b. Setup yum repositories
+        c. Return the metadata information about installed SW upgrade repositories
 
 ## Setup SW upgrade repository
 
 The common structure of the `set_swupgrade_repo` command:
 ```bash
-provisioner set_swupgrade_repo </path/to/single/iso/bundle> --hash="<hash_type>:<hash> <filename>"  --hash-type="<hash_type>" \ 
---username=<provisioner_user> --password=<provisioner_user_password>`
+provisioner set_swupgrade_repo </path/to/single/iso/bundle> --hash="<hash_type>:<hash> <filename>"  --hash-type="<hash_type>"
 ```
 
 where
@@ -35,15 +51,19 @@ where
 - `<check_sum>`: hexadecimal representation of hash checksum
 - `<file_name>`: a file name to which <hash_type> and <hash_sum> belongs to
 
- `--hash-type="<hash_type>"` **Optional**. Type of hash value. Supported values: `md5`, `sha256`, `sha512`. See `config.HashType` for all possible values. 
+ `--hash-type="<hash_type>"` **Optional**. Type of hash value. Supported values: `md5`, `sha256`, `sha512`. See `config.HashType` for all possible values.
 
-`--username=<provisioner_user>`: **Optional**. Provisioner user which has necessary permissions
+:warning: **NOTE**: The `md5` is the default hash type. So you can omit hash type in `--hash` and in `--hash-type` options.
+Hash type in `--hash` option has the higher priority than `--hash-type`.
+As mentioned in the `--hash` option description, you can specify a path to a file that contains hash data. The format of this file is
+the same as for the hash string.
 
-`--password=<provisioner_user_password>`: **Optional**. Password of the provisioner user
+See [Passing crdedentials to CLI](#passing-crdedentials-to-cliapipythonreadmemdpassing-crdedentials-to-cli) how to pass
+credential for command authorization.
 
 Examples:
 ```bash
-provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"  --hash-type="md5" --username=123456 --password=123456
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"
 provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha256:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12b"
 provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="md5:fefa1db67588d2783b83f07f4f5beb5c /opt/iso/single_cortx.iso"
 ```
@@ -81,35 +101,38 @@ All fields above except `RELEASE` are mandatory fields for the `RELEASE.INFO` fi
 To initiate SW upgrade procedure run the command
 
 ```bash
-provisioner sw_upgrade --targets=<hosts> --username=<provisioner_user> --password=<provisioner_user_password>
+provisioner sw_upgrade --targets=<hosts>
 ```
 
 where
 
 `--targets=<hosts>`: **Optional**. Hosts for SW upgrade
 
-`--username=<provisioner_user>`: **Optional**. Provisioner user which has necessary permissions
-
-`--password=<provisioner_user_password>`: **Optional**. Password of the provisioner user
+See [Passing crdedentials to CLI](#passing-crdedentials-to-cliapipythonreadmemdpassing-crdedentials-to-cli) how to pass
+credential for command authorization.
 
 ## Delete SW upgrade repository
 
 To remove installed SW upgrade repository run the command:
 ```bash
-provisioner remove_swupgrade_repo <release> --username=<provisioner_user> --password=<provisioner_user_password>
+provisioner remove_swupgrade_repo <release>
 ```
 
 where
 
 `<release>`: **Mandatory**. Release version of the SW upgrade repository
 
-`--username=<provisioner_user>`: **Optional**. Provisioner user which has necessary permissions
+See [Passing crdedentials to CLI](#passing-crdedentials-to-cliapipythonreadmemdpassing-crdedentials-to-cli) how to pass
+credential for command authorization.
 
-`--password=<provisioner_user_password>`: **Optional**. Password of the provisioner user
-
-**NOTE:**
+:warning: **NOTE**:
 
 To see the list of SW upgrade repositories:
 ```bash
 yum repolist
 ```
+
+
+## References
+
+#### [Passing crdedentials to CLI](../../api/python/README.md#passing-crdedentials-to-cli)

--- a/docs/Architecture/SW-Upgrade.md
+++ b/docs/Architecture/SW-Upgrade.md
@@ -1,0 +1,115 @@
+# SW Upgrade
+
+Table of contents:
+
+- [Setup SW upgrade repository](#setup-sw-upgrade-repository)
+- [Apply SW upgrade](#apply-sw-upgrade)
+- [SW upgrade single ISO bundle structure](#sw-upgrade-single-iso-bundle-structure)
+- [Delete SW upgrade repository](#delete-sw-upgrade-repository)
+
+
+## Setup SW upgrade repository
+
+The common structure of the `set_swupgrade_repo` command:
+```bash
+provisioner set_swupgrade_repo </path/to/single/iso/bundle> --hash="<hash_type>:<hash> <filename>"  --hash-type="<hash_type>" \ 
+--username=<provisioner_user> --password=<provisioner_user_password>`
+```
+
+where
+
+`</path/to/single/iso/bundle>`: **Mandatory**. Path to the single SW upgrade ISO bundle file
+
+`--hash="<hash_type>:<hash> <filename>"`: **Optional**. Setups hash value of single SW upgrade bundle ISO for verification.
+Can be either string with hash data or path to the file with that data.
+Supported formats of checksum string
+
+1. <hash_type>:<check_sum> <file_name>
+2. <hash_type>:<check_sum>
+3. <check_sum> <file_name>
+4. <check_sum>
+
+where
+
+- `<hash_type>`: one of the values from `config.HashType` enumeration. Supported values: `md5`, `sha256`, `sha512`.
+- `<check_sum>`: hexadecimal representation of hash checksum
+- `<file_name>`: a file name to which <hash_type> and <hash_sum> belongs to
+
+ `--hash-type="<hash_type>"` **Optional**. Type of hash value. Supported values: `md5`, `sha256`, `sha512`. See `config.HashType` for all possible values. 
+
+`--username=<provisioner_user>`: **Optional**. Provisioner user which has necessary permissions
+
+`--password=<provisioner_user_password>`: **Optional**. Password of the provisioner user
+
+Examples:
+```bash
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"  --hash-type="md5" --username=123456 --password=123456
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha256:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12b"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="md5:fefa1db67588d2783b83f07f4f5beb5c /opt/iso/single_cortx.iso"
+```
+
+## SW upgrade single ISO bundle structure
+
+Expected minimum structure of single SW upgrade ISO bundle:
+```
+sw_upgrade_bundle.iso
+    - 3rd_party/
+        - THIRD_PARTY_RELEASE.INFO
+    - cortx_iso/
+        - RELEASE.INFO
+    - python_deps/
+    - os/
+```
+
+The following basic and minimum necessary structure of `RELEASE.INFO`
+
+```yaml
+RELEASE.INFO:
+    NAME:
+    RELEASE: (can be absent)
+    VERSION:
+    BUILD:
+    OS:
+    COMPONENTS:
+```
+
+All fields above except `RELEASE` are mandatory fields for the `RELEASE.INFO` file
+
+
+## Apply SW upgrade
+
+To initiate SW upgrade procedure run the command
+
+```bash
+provisioner sw_upgrade --targets=<hosts> --username=<provisioner_user> --password=<provisioner_user_password>
+```
+
+where
+
+`--targets=<hosts>`: **Optional**. Hosts for SW upgrade
+
+`--username=<provisioner_user>`: **Optional**. Provisioner user which has necessary permissions
+
+`--password=<provisioner_user_password>`: **Optional**. Password of the provisioner user
+
+## Delete SW upgrade repository
+
+To remove installed SW upgrade repository run the command:
+```bash
+provisioner remove_swupgrade_repo <release> --username=<provisioner_user> --password=<provisioner_user_password>
+```
+
+where
+
+`<release>`: **Mandatory**. Release version of the SW upgrade repository
+
+`--username=<provisioner_user>`: **Optional**. Provisioner user which has necessary permissions
+
+`--password=<provisioner_user_password>`: **Optional**. Password of the provisioner user
+
+**NOTE:**
+
+To see the list of SW upgrade repositories:
+```bash
+yum repolist
+```

--- a/docs/Architecture/SW-Upgrade.md
+++ b/docs/Architecture/SW-Upgrade.md
@@ -58,7 +58,7 @@ Hash type in `--hash` option has the higher priority than `--hash-type`.
 As mentioned in the `--hash` option description, you can specify a path to a file that contains hash data. The format of this file is
 the same as for the hash string.
 
-See [Passing crdedentials to CLI](#passing-crdedentials-to-cliapipythonreadmemdpassing-crdedentials-to-cli) how to pass
+See [Passing crdedentials to CLI](#passing-crdedentials-to-cli) how to pass
 credential for command authorization.
 
 Examples:
@@ -108,7 +108,7 @@ where
 
 `--targets=<hosts>`: **Optional**. Hosts for SW upgrade
 
-See [Passing crdedentials to CLI](#passing-crdedentials-to-cliapipythonreadmemdpassing-crdedentials-to-cli) how to pass
+See [Passing crdedentials to CLI](#passing-crdedentials-to-cli) how to pass
 credential for command authorization.
 
 ## Delete SW upgrade repository
@@ -122,7 +122,7 @@ where
 
 `<release>`: **Mandatory**. Release version of the SW upgrade repository
 
-See [Passing crdedentials to CLI](#passing-crdedentials-to-cliapipythonreadmemdpassing-crdedentials-to-cli) how to pass
+See [Passing crdedentials to CLI](#passing-crdedentials-to-cli) how to pass
 credential for command authorization.
 
 :warning: **NOTE**:

--- a/test/r2.md
+++ b/test/r2.md
@@ -92,7 +92,7 @@ c) After the steps mentioned above we have the `sw_upgrade.iso` which can be use
 Step-3: Run provisioner command:
 
 ```bash
-provisioner set_swupgrade_repo 1.0.0 --source="./sw_upgrade.iso" --username=<provisioner_user> --password=<provisioner_user_password>`
+provisioner set_swupgrade_repo "./sw_upgrade.iso" --username=<provisioner_user> --password=<provisioner_user_password>`
 ```
 
 Command should be finished successfully.
@@ -260,7 +260,7 @@ yum install /root/rpmbuild/RPMS/x86_64/cortx-prvsnr-2.0.0-0_git123456_el7.x86_64
 Step-6: Using the built single ISO SW upgrade bundle, run the command
 
 ```bash
-provisioner set_swupgrade_repo 2.0.1 --source=/<path>/<to>/sw_upgrade_bundle.iso
+provisioner set_swupgrade_repo /<path>/<to>/sw_upgrade_bundle.iso
 ```
 
 Command should not failed. Expected output should be like the following one
@@ -304,10 +304,10 @@ NOTE: Please, note that output of the command above will be different from prese
 b) Using the output from the command above run the following provisioner commands one by one
 
 ```bash
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"  --hash-type="md5"
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="md5:fefa1db67588d2783b83f07f4f5beb5c"
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="md5:fefa1db67588d2783b83f07f4f5beb5c /opt/iso/single_cortx.iso"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"  --hash-type="md5"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="md5:fefa1db67588d2783b83f07f4f5beb5c"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="md5:fefa1db67588d2783b83f07f4f5beb5c /opt/iso/single_cortx.iso"
 ```
 
 All commands should be succeeded. And output always should be the same as like output in [EOS-16883: SW Upgrade structure validation](#eos-16883-sw-upgrade-structure-validation): Step-6
@@ -325,9 +325,9 @@ NOTE: Please, note that output of the command above will be different from prese
 b) Using the output from the command above run the following provisioner commands one by one
 
 ```bash
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"  --hash-type="sha256"
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="sha256:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="sha256:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a /opt/iso/single_cortx.iso"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"  --hash-type="sha256"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha256:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha256:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a /opt/iso/single_cortx.iso"
 ```
 
 All commands should be succeeded. And output always should be the same as like output in [EOS-16883: SW Upgrade structure validation](#eos-16883-sw-upgrade-structure-validation): Step-6
@@ -345,9 +345,9 @@ NOTE: Please, note that output of the command above will be different from prese
 b) Using the output from the command above run the following provisioner commands one by one
 
 ```bash
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="ca6cb2dd717bbde5de59ba69b3d5178184e357b706dba87080f0c0801fe34c99efb5ba0e23b7f98b99ce3df209cff287d18214d21fa16288ab6b9ac4194ba14b"  --hash-type="sha512"
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="sha512:ca6cb2dd717bbde5de59ba69b3d5178184e357b706dba87080f0c0801fe34c99efb5ba0e23b7f98b99ce3df209cff287d18214d21fa16288ab6b9ac4194ba14b"
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="sha512:ca6cb2dd717bbde5de59ba69b3d5178184e357b706dba87080f0c0801fe34c99efb5ba0e23b7f98b99ce3df209cff287d18214d21fa16288ab6b9ac4194ba14b /opt/iso/single_cortx.iso"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="ca6cb2dd717bbde5de59ba69b3d5178184e357b706dba87080f0c0801fe34c99efb5ba0e23b7f98b99ce3df209cff287d18214d21fa16288ab6b9ac4194ba14b"  --hash-type="sha512"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha512:ca6cb2dd717bbde5de59ba69b3d5178184e357b706dba87080f0c0801fe34c99efb5ba0e23b7f98b99ce3df209cff287d18214d21fa16288ab6b9ac4194ba14b"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha512:ca6cb2dd717bbde5de59ba69b3d5178184e357b706dba87080f0c0801fe34c99efb5ba0e23b7f98b99ce3df209cff287d18214d21fa16288ab6b9ac4194ba14b /opt/iso/single_cortx.iso"
 ```
 
 All commands should be succeeded. And output always should be the same as like output in [EOS-16883: SW Upgrade structure validation](#eos-16883-sw-upgrade-structure-validation): Step-6
@@ -369,7 +369,7 @@ NOTE: Please, note that output of the command above will be different from prese
 b) Using the file created in previous step, run the `set_swupgrade_repo` command
 
 ```bash
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash=/root/hash.data
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash=/root/hash.data
 ```
 
 Command should be succeeded. Output should be the same as like output in [EOS-16883: SW Upgrade structure validation](#eos-16883-sw-upgrade-structure-validation): Step-6
@@ -393,7 +393,7 @@ hash string should be like that
 c) Run the `set_swupgrade_repo` command with wrong hash string:
 
 ```bash
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12b"  --hash-type="sha256"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12b"  --hash-type="sha256"
 ```
 
 The exception output should be something like that and provisioner should stop command execution:
@@ -406,7 +406,7 @@ d) With correct hash sum `ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea2
 
 ```bash
 
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"  --hash-type="md5"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"  --hash-type="md5"
 
 ```
 
@@ -417,7 +417,7 @@ Be default we use MD5 hash sum
 
 ```bash
 
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"
 
 ```
 
@@ -427,7 +427,7 @@ f) With correct hash sum `ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea2
 
 ```bash
 
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso --hash="sha512:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha512:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12a"
 
 ```
 
@@ -451,7 +451,7 @@ And create the new ISO file with this change.
 
 The following command with broken `single_cortx.iso` should be failed
 ```bash
-provisioner set_swupgrade_repo 2.0.1 --source=/opt/iso/single_cortx.iso
+provisioner set_swupgrade_repo /opt/iso/single_cortx.iso
 ```
 
 ## EOS-18917: Creation of custom grains for enclosure_id,netmask, serial number and multipath


### PR DESCRIPTION
I committed the initial version of architecture docs for SW upgrade. I updated also the testing docs for SW upgrade testing
