### PR TITLE
[EOS-19173] build 607 - Update - Release Version is Still shown as 1.0

### DIFF
--- a/EOS-19173.patch
+++ b/EOS-19173.patch
@@ -1,0 +1,13 @@
+diff --git a/api/python/provisioner/commands/__init__.py b/api/python/provisioner/commands/__init__.py
+index 0aec6b12..0e1227a0 100644
+--- a/api/python/provisioner/commands/__init__.py
++++ b/api/python/provisioner/commands/__init__.py
+@@ -834,7 +834,7 @@ class GetReleaseVersion(CommandParserFillerMixin):
+     @property
+     def installed_rpms(self) -> List:
+         if self._installed_rpms is None:
+-            exclude_rpms = 'cortx-py|prvsnr-cli'
++            exclude_rpms = 'cortx-py|prvsnr-cli|cortx-sspl-test'
+             res = salt_cmd_run(f"rpm -qa|grep '^cortx-'|grep -Ev '{exclude_rpms}'",  # noqa: E501
+                                targets=LOCAL_MINION)
+             rpms = res[next(iter(res))].split("\n")

--- a/api/python/provisioner/commands/__init__.py
+++ b/api/python/provisioner/commands/__init__.py
@@ -834,7 +834,7 @@ class GetReleaseVersion(CommandParserFillerMixin):
     @property
     def installed_rpms(self) -> List:
         if self._installed_rpms is None:
-            exclude_rpms = 'cortx-py|prvsnr-cli'
+            exclude_rpms = 'cortx-py|prvsnr-cli|cortx-sspl-test'
             res = salt_cmd_run(f"rpm -qa|grep '^cortx-'|grep -Ev '{exclude_rpms}'",  # noqa: E501
                                targets=LOCAL_MINION)
             rpms = res[next(iter(res))].split("\n")


### PR DESCRIPTION
The PR has follwing changes:
'cortx-sspl-test' added in exclude rpms within GetReleaseVersion