### PR TITLE
[EOS-19218] Remove hctl cluster shutdown from hare

### DIFF
--- a/api/python/provisioner/commands/destroy.py
+++ b/api/python/provisioner/commands/destroy.py
@@ -156,8 +156,8 @@ class DestroyNode(Deploy):
                 self.setup_ctx.ssh_client.state_apply(
                     f"components.{state}"
                 )
-        except Exception:
-            logger.warn(f"Failed {state} on {targets}")
+        except Exception as exc:
+            logger.warn(f"Failed {state} on {targets} Error: {str(exc)}")
 
     def _run_cmd(self, cmds, targets=None):
         for cmd in cmds:
@@ -173,8 +173,8 @@ class DestroyNode(Deploy):
                     self.setup_ctx.ssh_client.cmd_run(
                         f"{cmd}"
                     )
-            except Exception:
-                logger.warn(f"Failed cmd {cmd} on {targets}")
+            except Exception as exc:
+                logger.warn(f"Failed cmd {cmd} on {targets} Error: {str(exc)}")
 
     def _run_states(self,  # noqa: C901 FIXME
         states_group: str, run_args: run_args_type):

--- a/srv/components/hare/teardown.sls
+++ b/srv/components/hare/teardown.sls
@@ -17,8 +17,6 @@
 
 {% import_yaml 'components/defaults.yaml' as defaults %}
 {% if "primary" in pillar["cluster"][grains["id"]]["roles"] %}
-include:
-  - components.hare.stop
 
 Stage - Reset Hare:
   cmd.run:


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

1. hctl cluster start / shutdown is not part of hare.
2. Improve error logging