### PR TITLE
EOS-19490: Fix - hostname reset on reboot

### DIFF
--- a/srv/components/system/config/set_hostname.sls
+++ b/srv/components/system/config/set_hostname.sls
@@ -15,12 +15,21 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-Update hostname file permissions:
+Make hostname file modifiable:
   cmd.run:
     - name: "chattr -i /etc/hostname"
 
 Set hostname:
-  cmd.run:
-    - name: "hostnamectl set-hostname {{ pillar['cluster'][grains['id']]['hostname'] }}"
+  network.system:
+    - name: set_hostname
+    - hostname: {{ pillar['cluster'][grains['id']]['hostname'] }}
+    - apply_hostname: True
+    - retain_settings: True
     - require:
-      - Update hostname file permissions
+      - Make hostname file modifiable
+
+Restore hostname file protection:
+  cmd.run:
+    - name: "chattr +i /etc/hostname"
+    - require:
+      - Make hostname file modifiable

--- a/srv/components/system/config/set_hostname.sls
+++ b/srv/components/system/config/set_hostname.sls
@@ -15,9 +15,12 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
+Update hostname file permissions:
+  cmd.run:
+    - name: "chattr -i /etc/hostname"
+
 Set hostname:
-  network.system:
-    - name: set_hostname
-    - hostname: {{ pillar['cluster'][grains['id']]['hostname'] }}
-    - apply_hostname: True
-    - retain_settings: True
+  cmd.run:
+    - name: "hostnamectl set-hostname {{ pillar['cluster'][grains['id']]['hostname'] }}"
+    - require:
+      - Update hostname file permissions


### PR DESCRIPTION
hostname was getting reset to old one on reboot due to "operation not permitted" error
fix:
1. Remove `i` attribute from /etc/hostname 
2. Use hostnamectl command to set the hostname

Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>