### PR TITLE
EOS-19760: fix for OVA bootstrap script issue

### DIFF
--- a/cli/src/virtual_appliance/bootstrap.sh
+++ b/cli/src/virtual_appliance/bootstrap.sh
@@ -40,8 +40,13 @@ salt-call state.apply components.system.network.mgmt.public
 salt-call state.apply components.system.network.data.public
 salt-call state.apply components.system.network.data.direct
 
+salt-call state.apply components.system.config.sync_salt
+
 #reconfigure /etc/hosts
 salt-call state.apply components.system.config.hosts
+
+#reconfigure kafka
+salt-call state.apply components.misc_pkgs.kafka.start 
 
 #reconfigure firewall
 salt-call state.apply components.system.firewall.teardown
@@ -50,9 +55,6 @@ salt-call state.apply components.system.firewall
 #reconfigure lustre
 salt-call state.apply components.misc_pkgs.lustre.stop
 salt-call state.apply components.misc_pkgs.lustre.config
-
-#reconfigure hare CDF
-salt-call state.apply components.hare.config
 
 #configure haproxy
 echo "INFO: Configuring haproxy and s3" | tee -a "${LOG_FILE}"
@@ -63,6 +65,9 @@ DATA_IP=$(salt-call grains.get ip4_interfaces:${DATA_IF}:0 --output=newline_valu
 provisioner pillar_set s3clients/s3server/ip \"${DATA_IP}\"
 salt "*" state.apply components.s3clients.config | tee -a "${LOG_FILE}"
 provisioner confstore_export
+
+#reconfigure hare CDF
+# salt-call state.apply components.hare.config.prepare
 
 #restart services
 echo "INFO: Restarting haproxy" | tee -a "${LOG_FILE}"

--- a/srv/components/misc_pkgs/kafka/start.sls
+++ b/srv/components/misc_pkgs/kafka/start.sls
@@ -30,7 +30,7 @@ Start zoopkeper:
 Wait for zookeeper to start:
   module.run:
     - test.sleep:
-      - length: 10
+      - length: 30
     - require:
       - Start zoopkeper
 


### PR DESCRIPTION
Signed-off-by: Rahul Jyoti <rahul.jyoti@seagate.com>
Bootstrap script execution was not proceeding further and was stuck at "Configuring haproxy and s3" stage. This was because kafka was not running.
Fix:
1. starting kafka before configuring s3server.
2. increased the delay to 30s after starting zookeeper. ( bcoz on executing kafta.start using salt only zookeeper was starting and not kafka)