### PR TITLE
EOS-19816: hostname updates twice in /etc/sysconfig/network

### DIFF
--- a/srv/components/system/config/set_hostname.sls
+++ b/srv/components/system/config/set_hostname.sls
@@ -20,11 +20,8 @@ Make hostname file modifiable:
     - name: "chattr -i /etc/hostname"
 
 Set hostname:
-  network.system:
-    - name: set_hostname
-    - hostname: {{ pillar['cluster'][grains['id']]['hostname'] }}
-    - apply_hostname: True
-    - retain_settings: True
+  cmd.run:
+    - name: "hostnamectl set-hostname {{ pillar['cluster'][grains['id']]['hostname'] }}"
     - require:
       - Make hostname file modifiable
 


### PR DESCRIPTION
Run `set-hostname` command using `cmd.run` module since `network.system` has below issue currently
https://github.com/saltstack/salt/issues/59973

Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>