### PR TITLE
EOS-19815: Update eth3 as part of private data network configuration

### DIFF
--- a/srv/components/system/network/data/direct/init.sls
+++ b/srv/components/system/network/data/direct/init.sls
@@ -26,9 +26,9 @@
 
 Private data network configuration:
   network.managed:
-    - name: {{ pillar['cluster'][node]['network']['data']['private_interfaces'][1] }}
+    - name: {{ pillar['cluster'][node]['network']['data']['private_interfaces'][0] }}
     - enabled: True
-    - device: {{ pillar['cluster'][node]['network']['data']['private_interfaces'][1] }}
+    - device: {{ pillar['cluster'][node]['network']['data']['private_interfaces'][0] }}
     - type: eth
     # - onboot: yes             # [WARNING ] The 'onboot' option is controlled by the 'enabled' option.
     - defroute: no


### PR DESCRIPTION
Currently we are using `private_interfaces[1]` for private_data configuration but it will fail if only one interface is present in `cluster:node_id:data_private_interfaces` 

to fix this issue, updated `private_interfaces[0]` for private data network configuration 


Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>