### PR TITLE
[Fix] Fixes destroy API for 3 node

### DIFF
--- a/api/python/provisioner/commands/destroy.py
+++ b/api/python/provisioner/commands/destroy.py
@@ -289,7 +289,8 @@ class DestroyNode(Deploy):
         list_cmds.append(f"rm -rf {str(config.profile_base_dir().parent)}")
         list_cmds.append(f"rm -rf {config.CORTX_ROOT_DIR}")
         list_cmds.append(f"rm -rf {config.PRVSNR_DATA_SHARED_DIR}")
-        list_cmds.append("yum remove -y salt salt-minion salt-master")
+        list_cmds.append(
+            "yum remove -y salt salt-minion salt-master python36-m2crypto")
 
         if run_args.states is None:  # all states
             self._run_states('ha', run_args)

--- a/srv/components/motr/teardown/cleanup.sls
+++ b/srv/components/motr/teardown/cleanup.sls
@@ -14,11 +14,6 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
-Stage - Reset Motr:
+Stage - Cleanup Motr:
   cmd.run:
     - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/motr/conf/setup.yaml', 'motr:cleanup')
-
-Remove Motr package:
-  pkg.purged:
-    - pkgs:
-      - cortx-motr

--- a/srv/components/provisioner/teardown/package_remove.sls
+++ b/srv/components/provisioner/teardown/package_remove.sls
@@ -23,4 +23,3 @@ Remove_salt_packages:
       - cortx-prvsnr-cli
       - python36-cortx-prvsnr
       - rsync
-      - python36-m2crypto 

--- a/srv/components/sspl/teardown/init.sls
+++ b/srv/components/sspl/teardown/init.sls
@@ -18,7 +18,6 @@
 include:
   - components.sspl.teardown.reset
   - components.sspl.teardown.cleanup
-  - components.sspl.teardown.commons
 
 Remove sspl packages:
   pkg.purged:

--- a/srv/components/system/storage/glusterfs/teardown/cache_remove.sls
+++ b/srv/components/system/storage/glusterfs/teardown/cache_remove.sls
@@ -17,4 +17,4 @@
 
 Remove glusterd cache:
   file.absent:
-    name: /var/lib/glusterd
+    - name: /var/lib/glusterd


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

1. python36-m2crypto is removing salt packages because of which other steps are getting skip.
2. Removed conflicting of ID's in Motr teardown 
3. No need to call sspl.teardown.common as we are not adding anything in consul during deployment.
4. Fixed syntax of cache_remove from gluster.teardown

FYI: We have  not seen firewall issue ( 2hrs ) locally it is seen only in case of jenkins job.