### PR TITLE
EOS-19834: Fix issues for Cortx-ha deployment for 3 node

### DIFF
--- a/api/python/provisioner/commands/deploy.py
+++ b/api/python/provisioner/commands/deploy.py
@@ -309,7 +309,8 @@ class Deploy(CommandParserFillerMixin):
                     "sync.software.rabbitmq",
                     "sync.software.openldap",
                     "system.storage.multipath",
-                    "sync.files"
+                    "sync.files",
+                    "ha.cortx-ha"
                 ):
                     # Execute first on primary then on secondaries.
                     self._apply_state(f"components.{state}", primary, stages)

--- a/api/python/provisioner/commands/deploy_vm.py
+++ b/api/python/provisioner/commands/deploy_vm.py
@@ -169,7 +169,6 @@ class DeployVM(Deploy):
                 #       for legacy dual node setup
                 if state in (
                     "sspl",
-                    "ha.cortx-ha"
                 ):
                     # Execute first on secondaries then on primary.
                     self._apply_state(
@@ -179,7 +178,8 @@ class DeployVM(Deploy):
 
                 elif state in (
                     "sync.software.rabbitmq",
-                    "sync.software.openldap"
+                    "sync.software.openldap",
+                    "ha.cortx-ha"
                 ):
                     # Execute first on primary then on secondaries.
                     self._apply_state(f"components.{state}", primary, stages)

--- a/api/python/provisioner/commands/destroy.py
+++ b/api/python/provisioner/commands/destroy.py
@@ -226,7 +226,8 @@ class DestroyNode(Deploy):
                     "provisioner.teardown",
                     "provisioner.passwordless_remove",
                     "misc_pkgs.openldap.teardown",
-                    "misc_pkgs.rabbitmq"
+                    "misc_pkgs.rabbitmq",
+                    "ha.cortx-ha.teardown"
                 ):
 
                     logger.info(f"Applying '{state}' on {secondaries}")
@@ -237,7 +238,6 @@ class DestroyNode(Deploy):
                     self._apply_states(state, primary)
 
                 elif state in (
-                    "ha.cortx-ha.teardown",
                     "sspl.teardown"
                 ):
                     logger.info(f"Applying '{state}' on {primary}")

--- a/api/python/provisioner/srv/salt/ssh/check.sls
+++ b/api/python/provisioner/srv/salt/ssh/check.sls
@@ -23,4 +23,12 @@ check_{{ node_id }}_reachable:
   cmd.run:
     - name: ssh -q -o "ConnectTimeout=5" {{ node_id }} exit
 
+check_{{ node_id }}.data.private_reachable:
+  cmd.run:
+    - name: ssh -q -o "ConnectTimeout=5" {{ node_id }}.data.private exit
+
+check_{{ node['host'] }}_reachable:
+  cmd.run:
+    - name: ssh -q -o "ConnectTimeout=5" {{ node['host'] }} exit
+
 {% endfor %}

--- a/api/python/provisioner/srv/salt/ssh/files/config
+++ b/api/python/provisioner/srv/salt/ssh/files/config
@@ -11,7 +11,7 @@ Host {{ node['host'] }}
     LogLevel ERROR
     BatchMode yes
 
-Host {{ node_id }} {{ node_id }}.data.private
+Host {{ node_id }}
     HostName {{ node_id }}.data.private
     Port {{ node['port'] }}
     User {{ node['user'] }}

--- a/api/python/provisioner/srv/salt/ssh/files/config
+++ b/api/python/provisioner/srv/salt/ssh/files/config
@@ -1,7 +1,18 @@
 {% for node_id, node in pillar['node_specs'].items() %}
 
-Host {{ node_id }} {{ node['host'] }}
+Host {{ node['host'] }}
     HostName {{ node['host'] }}
+    Port {{ node['port'] }}
+    User {{ node['user'] }}
+    UserKnownHostsFile /dev/null
+    StrictHostKeyChecking no
+    IdentityFile /root/.ssh/id_rsa_prvsnr
+    IdentitiesOnly yes
+    LogLevel ERROR
+    BatchMode yes
+
+Host {{ node_id }} {{ node_id }}.data.private
+    HostName {{ node_id }}.data.private
     Port {{ node['port'] }}
     User {{ node['user'] }}
     UserKnownHostsFile /dev/null

--- a/api/python/provisioner/utils.py
+++ b/api/python/provisioner/utils.py
@@ -408,7 +408,7 @@ def generate_random_secret():
     Generates a random 14 character password
     """
 
-    special_characters = '=+-()_'
+    special_characters = '=+-_'
     passwd_seed = random.sample(string.ascii_uppercase,
                                 4) + random.sample(string.digits,
                                                    3) + random.sample(string.ascii_lowercase,


### PR DESCRIPTION
1. Change deployment sequence for cortx-ha:
   First deploy on Primary then on secondaries in a set.
2. Add private fqdns in passwordless ssh configuration
3. Remove "(" & ")" chars from set of special chars for
   random password generation module.

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>