### PR TITLE
EOS-19470: Remove Opendistro rpm used for elasticsearch and kibana deployment

### DIFF
--- a/srv/components/misc_pkgs/elasticsearch/teardown.sls
+++ b/srv/components/misc_pkgs/elasticsearch/teardown.sls
@@ -38,6 +38,10 @@ Remove elasticsearch logs:
   file.absent:
     - name: /var/log/elasticsearch
 
+Remove opnedistro repo:
+  file.absent:
+    -name: /etc/yum.repos.d/opendistro.repo
+
 Delete elasticsearch checkpoint flag:
   file.absent:
     - name: /opt/seagate/cortx_configs/provisioner_generated/{{ grains['id'] }}.elasticsearch

--- a/srv/components/misc_pkgs/elasticsearch/teardown.sls
+++ b/srv/components/misc_pkgs/elasticsearch/teardown.sls
@@ -40,7 +40,7 @@ Remove elasticsearch logs:
 
 Remove opnedistro repo:
   pkgrepo.absent:
-    - name: /etc/yum.repos.d/opendistro.repo
+    - name: opendistro
 
 Delete elasticsearch checkpoint flag:
   file.absent:

--- a/srv/components/misc_pkgs/elasticsearch/teardown.sls
+++ b/srv/components/misc_pkgs/elasticsearch/teardown.sls
@@ -39,8 +39,8 @@ Remove elasticsearch logs:
     - name: /var/log/elasticsearch
 
 Remove opnedistro repo:
-  file.absent:
-    -name: /etc/yum.repos.d/opendistro.repo
+  pkgrepo.absent:
+    - name: /etc/yum.repos.d/opendistro.repo
 
 Delete elasticsearch checkpoint flag:
   file.absent:


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>