### PR TITLE
Fix minor issues in deploy and destroy.

### DIFF
--- a/api/python/provisioner/commands/deploy.py
+++ b/api/python/provisioner/commands/deploy.py
@@ -313,6 +313,9 @@ class Deploy(CommandParserFillerMixin):
                     self._apply_state(
                         f"components.{state}", secondaries, stages
                     )
+                else:
+                     # Execute on all targets
+                    self._apply_state(f"components.{state}", targets, stages)
 
     def _update_salt(self, targets=config.ALL_MINIONS):
         # TODO IMPROVE why do we need that

--- a/api/python/provisioner/commands/deploy.py
+++ b/api/python/provisioner/commands/deploy.py
@@ -307,14 +307,12 @@ class Deploy(CommandParserFillerMixin):
                     "ha.cortx-ha"
                 ):
                     # Execute first on primary then on secondaries.
+                    if state == "ha.cortx-ha":
+                        self.ensure_consul_running()
                     self._apply_state(f"components.{state}", primary, stages)
                     self._apply_state(
                         f"components.{state}", secondaries, stages
                     )
-                else:
-                    self._apply_state(f"components.{state}", targets, stages)
-                    if state == "ha.cortx-ha":
-                        self.ensure_consul_running()
 
     def _update_salt(self, targets=config.ALL_MINIONS):
         # TODO IMPROVE why do we need that

--- a/api/python/provisioner/commands/destroy.py
+++ b/api/python/provisioner/commands/destroy.py
@@ -226,7 +226,7 @@ class DestroyNode(Deploy):
                     "provisioner.teardown",
                     "provisioner.passwordless_remove",
                     "misc_pkgs.openldap.teardown",
-                    "misc_pkgs.rabbitmq",
+                    "misc_pkgs.rabbitmq.teardown",
                     "ha.cortx-ha.teardown"
                 ):
 


### PR DESCRIPTION
1. Move the dead code of validation check for consul before running
   cortx-ha component.
2. Fix typo in destroy - change rabbitmq to rabbitmq.teardown

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>