### PR TITLE
EOS-20627:destroy api does not remove uds packages

### DIFF
--- a/srv/components/uds/teardown.sls
+++ b/srv/components/uds/teardown.sls
@@ -24,7 +24,7 @@ Remove USL cert file:
 
 Remove uds package:
   pkg.purged:
-    - name: uds
+    - name: uds-pyi
 
 Delete uds yum repo:
   pkgrepo.absent:


### PR DESCRIPTION
Signed-off-by: sradhanandpati <sradhanand.pati@seagate.com>