### PR TITLE
Hide unwanted cache logs from salt-ssh

### DIFF
--- a/api/python/provisioner/commands/destroy.py
+++ b/api/python/provisioner/commands/destroy.py
@@ -263,6 +263,10 @@ class DestroyNode(Deploy):
         temp_dir = config.PRVSNR_TMP_DIR
         temp_dir.mkdir(parents=True, exist_ok=True)
 
+        # hide cache logs for salt-ssh
+        salt_logger = logging.getLogger('salt.fileclient')
+        salt_logger.setLevel(logging.WARNING)
+
         salt_config_master = str(
             '/etc/salt/master'
         )


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>


removed unwanted cache logs during destroy API