### PR TITLE
Improvement - Network configuration and prepare

### DIFF
--- a/lr-cli/cortx_setup/commands/network/config.py
+++ b/lr-cli/cortx_setup/commands/network/config.py
@@ -27,53 +27,39 @@ from provisioner.salt import local_minion_id
 
 class NetworkConfig(Command):
     _args = {
-        'transport_type': {
+        'mode': {
             'type': str,
             'default': None,
             'optional': True,
-            'help': 'Transport type for network e.g {lnet|libfabric}'
-        },
-        'interface_type': {
-            'type': str,
-            'default': None,
-            'optional': True,
-            'help': 'Interface type for network e.g {tcp|o2ib}'
+            'choices': ['lnet', 'libfabric', 'tcp', 'o2ib'],
+            'help': 'Network transport or interface type'
         },
         'type': {
             'type': str,
             'default': None,
             'optional': True,
             'dest': 'network_type',
-            'choices': ['data', 'mgmt'],
-            'help': 'Network type for provided interfaces'
+            'choices': ['data', 'private', 'management'],
+            'help': 'Type of network to configure'
         },
         'interfaces': {
             'type': str,
             'nargs': '+',
             'optional': True,
-            'help': 'List of interfaces for provided type '
-                    'e.g eth1 eth2'
-        },
-        'private': {
-            'default': False,
-            'optional': True,
-            'action': 'store_true',
-            'help': 'Use provided interfaces for private network'
+            'help': 'List of interfaces e.g eth1 eth2'
         }
     }
 
-    def run(self, transport_type=None, interface_type=None, network_type=None,
-                interfaces=None, private=False
-    ):
+    def run(self, mode=None, network_type=None, interfaces=None):
 
         """Network config execution method.
 
         Execution:
-        `cortx_setup network config --transport-type lent`
-        `cortx_setup network config --interface-type tcp`
+        `cortx_setup network config --mode lent`
+        `cortx_setup network config --mode tcp`
         `cortx_setup network config --type mgmt --interfaces eth0`
         `cortx_setup network config --type data --interfaces eth1 eth2`
-        `cortx_setup network config --type data --interfaces eth3 eth4 --mode private`
+        `cortx_setup network config --type private --interfaces eth3 eth4`
 
         """
 
@@ -84,46 +70,29 @@ class NetworkConfig(Command):
             f'json://{CONFSTORE_CLUSTER_FILE}'
         )
 
-        if transport_type is not None:
+        if mode is not None:
+            mode_type = 'transport_type' if mode in ['lnet', 'libfabric'] else 'interface_type'
             self.logger.debug(
-                f"Updating transport type to {transport_type} in confstore"
+                f"Set {mode_type} to {mode}"
             )
             PillarSet().run(
-                f'cluster/{node_id}/network/data/transport_type',
-                f'{transport_type}',
+                f'cluster/{node_id}/network/data/{mode_type}',
+                f'{mode}',
                 targets=node_id,
                 local=True
             )
             Conf.set(
                 'node_config_index',
-                f'server_node>{machine_id}>network>data>transport_type',
-                transport_type
+                f'server_node>{machine_id}>network>data>{mode_type}',
+                mode
             )
-
-        if interface_type is not None:
-            self.logger.debug(
-                f"Updating interface type to {interface_type} in confstore"
-                )
-            PillarSet().run(
-                f'cluster/{node_id}/network/data/interface_type',
-                f'{interface_type}',
-                targets=node_id,
-                local=True
-            )
-            Conf.set(
-                'node_config_index',
-                f'server_node>{machine_id}>network>data>interface_type',
-                interface_type
-            )
-
         if interfaces is not None:
-            if network_type == 'data':
+            if network_type == 'data' or network_type == 'private':
                 iface_key = (
-                    'private_interfaces' if private else 'public_interfaces'
+                    'private_interfaces' if network_type == 'private' else 'public_interfaces'
                 )
                 self.logger.debug(
-                    f"Updating {iface_key} to {interfaces} for data network "
-                    "in confstore"
+                    f"Set {iface_key} to {interfaces} for {network_type} network"
                 )
                 PillarSet().run(
                     f'cluster/{node_id}/network/data/{iface_key}',
@@ -136,10 +105,9 @@ class NetworkConfig(Command):
                     f'server_node>{machine_id}>network>data>{iface_key}',
                     interfaces
                 )
-            elif network_type == 'mgmt':
+            elif network_type == 'management':
                 self.logger.debug(
-                    f"Updating interfaces to {interfaces} for management "
-                    "network in confstore"
+                    f"Set interfaces to {interfaces} for {network_type} network"
                 )
                 PillarSet().run(
                     f'cluster/{node_id}/network/mgmt/interfaces',
@@ -153,7 +121,7 @@ class NetworkConfig(Command):
                     interfaces
                 )
             else:
-                self.logger.error(
+                raise Exception(
                     "Network type should specified for provided interfaces"
                 )
         Conf.save('node_config_index')


### PR DESCRIPTION
1. Updated --type argument to support `private` network
2. Used --mode argument instead of `transport_type` and `interface_type` arguments
3. Renamed `mgmt` input value to `management`



Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>