### PR TITLE
EOS-20863: Ensure response from Zookeeper before starting Kafka

### DIFF
--- a/srv/components/misc_pkgs/kafka/files/zookeeper.properties
+++ b/srv/components/misc_pkgs/kafka/files/zookeeper.properties
@@ -38,3 +38,4 @@ server.{{ loop.index }}={{ pillar['cluster'][node]['network']['data']['private_f
 {%- endfor %}
 autopurge.snapRetainCount=3
 autopurge.purgeInterval=24
+4lw.commands.whitelist=*

--- a/srv/components/misc_pkgs/kafka/start.sls
+++ b/srv/components/misc_pkgs/kafka/start.sls
@@ -37,8 +37,8 @@ Ensure kafka-zookeeper has started:
         # The reverse happens when shell we have a true condition with ret-code '0'. until results in false.
         # Note this when interpreting the next line.
         until: True
-        attempts: 12
-        interval: 10
+        attempts: 40
+        interval: 5
     - require:
       - Start zoopkeper
 
@@ -56,8 +56,8 @@ Ensure kafka-zookeeper is responsive for {{ node }}:
         # The reverse happens when shell we have a true condition with ret-code '0'. until results in false.
         # Note this when interpreting the next line.
         until: True
-        attempts: 12
-        interval: 10
+        attempts: 40
+        interval: 5
     - require:
       - Start zoopkeper
 {% endif %}
@@ -82,7 +82,7 @@ Ensure kafka has started:
         # The reverse happens when shell we have a true condition with ret-code '0'. until results in false.
         # Note this when interpreting the next line.
         until: True
-        attempts: 12
-        interval: 10
+        attempts: 40
+        interval: 5
     - require:
       - Start kafka

--- a/srv/components/misc_pkgs/kafka/stop.sls
+++ b/srv/components/misc_pkgs/kafka/stop.sls
@@ -38,8 +38,8 @@ Ensure kafka has stopped:
         # The reverse happens when shell we have a true condition with ret-code '0'. until results in false.
         # Note this when interpreting the next line.
         until: True
-        attempts: 10
-        interval: 2
+        attempts: 40
+        interval: 5
     - require:
       - Stop kafka
 
@@ -70,7 +70,7 @@ Ensure kafka-zookeeper has stopped:
         # The reverse happens when shell we have a true condition with ret-code '0'. until results in false.
         # Note this when interpreting the next line.
         until: True
-        attempts: 10
-        interval: 2
+        attempts: 40
+        interval: 5
     - require:
       - Stop zookeeper


### PR DESCRIPTION
Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>

-----------------------------------------------------------------------------------------
Change ensure Zookeeper response is checked before proceeding to start Kafka service
```
ID: Ensure kafka-zookeeper is responsive for srvnode-1
    Function: cmd.run
        Name: echo ruok|nc srvnode-1 2181|grep imok
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Command "echo ruok|nc srvnode-1 2181|grep imok" run"
              Command "echo ruok|nc srvnode-1 2181|grep imok" run
     Started: 18:17:02.101428
    Duration: 10062.195 ms
     Changes:
              ----------
              pid:
                  30861
              retcode:
                  0
              stderr:
              stdout:
                  imok
```