### PR TITLE
EOS-21181: cortx_setup command fails to set enclosure_id

### DIFF
--- a/lr-cli/cortx_setup/commands/storage/commons.py
+++ b/lr-cli/cortx_setup/commands/storage/commons.py
@@ -52,7 +52,7 @@ class Commons(Command):
             self.logger.info("Generating the enclosure ID")
             try:
                 _set_enclosure_id_state = "components.system.storage.enclosure_id.config.set"
-                StatesApplier.apply(_set_enclosure_id_state, targets)
+                StatesApplier.apply([_set_enclosure_id_state], targets)
                 return self.fetch_enc_id(targets)
             except:
                 raise exception("Error generating the enclosure ID")


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>