### PR TITLE
EOS-21344, EOS-19911: Configure firewall settings

### DIFF
--- a/pillar/components/execution.sls
+++ b/pillar/components/execution.sls
@@ -1,3 +1,20 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
 execution:
   noncortx_components:
     platform:

--- a/pillar/components/firewall.sls
+++ b/pillar/components/firewall.sls
@@ -1,37 +1,108 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Check for default services udner:
+# /usr/lib/firewalld/services/
 firewall:
+  # data_private:
+  #   services:
+  #     # elasticsearch: 9200, 9300
+  #     - elasticsearch
+  #     # high-availability: 2224, 3121, 5403, 5404/udp, 5405-5412/udp, 9929, 9929/udp, 21064
+  #     - high-availability
+  #     # ldap: 389
+  #     - ldap
+  #     # ldaps: 636
+  #     - ldaps
+  #     - ssh
+  #   ports:
+  #     - consul:
+  #       - 8300/tcp
+  #       - 8301/tcp
+  #       - 8301/udp
+  #       - 8302/tcp
+  #       - 8302/udp
+  #       - 8500/tcp
+  #     - csm_agent:
+  #       - 28101/tcp
+  #     - haproxy_dummy:
+  #       - 28001/tcp
+  #       - 28002/tcp
+  #     - hax:
+  #       - 8008/tcp
+  #     - kafka:
+  #       - 9092/tcp
+  #     - lnet:
+  #       - 988/tcp
+  #     - s3server:
+  #       {% for port in range(28071,28093) %}
+  #       - {{ port }}/tcp
+  #       {% endfor %}
+  #       - 28049/tcp
+  #     - s3authserver:
+  #       - 28050/tcp
+  #     - statsd:
+  #       - 5601/tcp
+  #       - 8125/tcp
+  #     - rest_server:
+  #       - 28300/tcp
+  #     - rsyslog:
+  #       - 514/tcp
+  #     - zookeeper:
+  #       - 2181/tcp
+  #       - 2888/tcp
+  #       - 3888/tcp
   data_public:
-    services: []
+    services:
+      - http
+      - https
+      - salt-master
     ports:
-      haproxy:
-        - 443/tcp
       s3:
+        - 9080/tcp
         - 9443/tcp
+      uds:
+        - 5000/tcp
   mgmt_public:
     services:
-      - ssh
+      # - dns
+      # - dhcp
+      - http
+      - https
       - ftp
+      - ntp
+      - salt-master
+      - ssh
       {%- if salt['cmd.run']('rpm -qa glusterfs-server') %}
       - glusterfs
       {%- endif %}
     ports:
       csm:
         - 28100/tcp
-      dhclient:
-        - 68/udp
-      dns:
-        - 53/tcp
-        - 53/udp
-      ntpd:
-        - 123/tcp
-        - 123/udp
-      redis:
-        - 6379/tcp
-        - 6379/udp
-      smtp:
-        - 25/tcp
-      saltmaster:
-        - 4505/tcp
-        - 4506/tcp
-      uds:
-        - 5000/tcp
-        - 5000/udp
+      # dhclient:
+      #   - 68/udp
+      # chronyd:
+      #   - 123/tcp
+      #   - 123/udp
+      # redis:
+      #   - 6379/tcp
+      #   - 6379/udp
+      # smtp:
+      #   - 25/tcp
+      # saltmaster:
+      #   - 4505/tcp
+      #   - 4506/tcp

--- a/pillar/components/firewall.sls
+++ b/pillar/components/firewall.sls
@@ -15,11 +15,14 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Check for default services udner:
+# Check for default services under:
 # /usr/lib/firewalld/services/
 firewall:
   # data_private:
+  # # Configuration for Data Public network
   #   services:
+  #   # Specify standard firewalld supported services
+  #   # to be allowed through firewall on management network
   #     # elasticsearch: 9200, 9300
   #     - elasticsearch
   #     # high-availability: 2224, 3121, 5403, 5404/udp, 5405-5412/udp, 9929, 9929/udp, 21064
@@ -30,67 +33,87 @@ firewall:
   #     - ldaps
   #     - ssh
   #   ports:
-  #     - consul:
-  #       - 8300/tcp
+  #   # Specify ports to be allowed through firewall
+  #   # on management network
+  #     consul:
+  #      - 8300/tcp
   #       - 8301/tcp
   #       - 8301/udp
   #       - 8302/tcp
   #       - 8302/udp
   #       - 8500/tcp
-  #     - csm_agent:
+  #     csm_agent:
   #       - 28101/tcp
-  #     - haproxy_dummy:
+  #     haproxy_dummy:
   #       - 28001/tcp
   #       - 28002/tcp
-  #     - hax:
+  #     hax:
   #       - 8008/tcp
-  #     - kafka:
+  #     kafka:
   #       - 9092/tcp
-  #     - lnet:
+  #     lnet:
   #       - 988/tcp
-  #     - s3server:
-  #       {% for port in range(28071,28093) %}
+  #     s3server:
+  #       {%- for port in range(28071,28093) %}
   #       - {{ port }}/tcp
-  #       {% endfor %}
+  #       {% endfor -%}
   #       - 28049/tcp
-  #     - s3authserver:
+  #     s3authserver:
   #       - 28050/tcp
-  #     - statsd:
+  #     statsd:
   #       - 5601/tcp
   #       - 8125/tcp
-  #     - rest_server:
+  #     rest_server:
   #       - 28300/tcp
-  #     - rsyslog:
+  #     rsyslog:
   #       - 514/tcp
-  #     - zookeeper:
+  #     zookeeper:
   #       - 2181/tcp
   #       - 2888/tcp
   #       - 3888/tcp
   data_public:
+  # Configuration for Data Public network
     services:
+    # Specify standard firewalld supported services
+    # to be allowed through firewall on management network
+      # http: 80
       - http
+      # https: 443
       - https
+      # salt-master: 4505, 4506
       - salt-master
     ports:
+    # Specify ports to be allowed through firewall
+    # on management network
       s3:
         - 9080/tcp
         - 9443/tcp
       uds:
         - 5000/tcp
   mgmt_public:
+  # Configuration for Management network
     services:
+    # Specify standard firewalld supported services
+    # to be allowed through firewall on management network
       # - dns
       # - dhcp
+      # http: 80
       - http
+      # http: 443
       - https
       - ftp
+      # ntp: 123/udp
       - ntp
+      # salt-master: 4505, 4506
       - salt-master
+      # ssh: 22
       - ssh
       {%- if salt['cmd.run']('rpm -qa glusterfs-server') %}
       - glusterfs
       {%- endif %}
     ports:
+    # Specify ports to be allowed through firewall
+    # on management network
       csm:
         - 28100/tcp
       # dhclient:

--- a/pillar/components/glusterfs.sls
+++ b/pillar/components/glusterfs.sls
@@ -1,3 +1,20 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
 glusterfs:
   in_docker: false
   network_type: mgmt  # mgmt/data

--- a/srv/components/system/firewall/config.sls
+++ b/srv/components/system/firewall/config.sls
@@ -56,6 +56,7 @@ Public data zone:
     - prune_ports: True
     - prune_services: True
     - prune_interfaces: True
+    - prune_rich_rules: True
     - interfaces:
       {% for interface in data_if %}
       - {{ interface }}
@@ -91,6 +92,7 @@ Management zone:
     - prune_ports: True
     - prune_services: True
     - prune_interfaces: True
+    - prune_rich_rules: True
     - interfaces:
     {% for interface in mgmt_if %}
       - {{ interface }}
@@ -114,6 +116,20 @@ Management zone:
       pillar['firewall']['mgmt_public']['services']
     )
 %}
+Trusted zone for lo:
+  firewalld.present:
+    - name: trusted
+    - default: False
+    - masquerade: False
+    - prune_ports: True
+    - prune_services: True
+    - prune_interfaces: True
+    - prune_rich_rules: True
+    - interfaces:
+      - lo
+    - sources:
+      - 127.0.0.0/24
+
 Add private data zone:
   module.run:
     - firewalld.new_zone:
@@ -122,13 +138,14 @@ Add private data zone:
 
 Private data zone:
   firewalld.present:
-    - name: public-data-zone
+    - name: private-data-zone
     - default: False
     - prune_ports: True
     - prune_services: True
     - prune_interfaces: True
+    - prune_rich_rules: True
     - interfaces:
-      {% for interface in data_if %}
+      {% for interface in pillar['cluster'][grains['id']]['network']['data']['private_interfaces'] %}
       - {{ interface }}
       {% endfor %}
     - services:
@@ -143,28 +160,16 @@ Private data zone:
       {% for service in pillar['firewall']['data_private']['ports'].keys() %}
       - {{ service }}
       {% endfor %}
-
-Trusted zone for lo:
-  firewalld.present:
-    - name: trusted
-    - default: False
-    - masquerade: False
-    - prune_ports: False
-    - prune_services: False
-    - prune_interfaces: True
-    - interfaces:
-      - lo
-    - sources:
-      - 127.0.0.0/24
 {% else %}
 Private data zone:
   firewalld.present:
     - name: trusted
     - default: False
     - masquerade: False
-    - prune_ports: False
-    - prune_services: False
+    - prune_ports: True
+    - prune_services: True
     - prune_interfaces: True
+    - prune_rich_rules: True
     - interfaces:
       - lo
       {% for interface in pillar['cluster'][grains['id']]['network']['data']['private_interfaces'] %}

--- a/srv/components/system/firewall/teardown.sls
+++ b/srv/components/system/firewall/teardown.sls
@@ -20,21 +20,23 @@ Reset default zone:
   firewalld.present:
     - name: public
     - default: True
+    - prune_interfaces: True
     - prune_ports: True
-    - prune_services: False
-    - prune_interfaces: False
+    - prune_services: True
+    - prune_rich_rules: True
     - services:
+      - http
+      - salt-master
       - ssh
-    - ports:
-      # Ports added to ensure Salt services are not affected
-      - 4505/tcp
-      - 4506/tcp
 
 {% if 'management-zone' in salt['firewalld.get_zones']() %}
 Remove public management interfaces:
   firewalld.present:
     - name: management-zone
     - prune_interfaces: True
+    - prune_ports: True
+    - prune_services: True
+    - prune_rich_rules: True
 
 Remove management-zone:
   module.run:
@@ -49,6 +51,9 @@ Remove public data interfaces:
   firewalld.present:
     - name: public-data-zone
     - prune_interfaces: True
+    - prune_ports: True
+    - prune_services: True
+    - prune_rich_rules: True
 
 Remove public-data-zone:
   module.run:
@@ -63,6 +68,9 @@ Remove private data interfaces:
   firewalld.present:
     - name: private-data-zone
     - prune_interfaces: True
+    - prune_ports: True
+    - prune_services: True
+    - prune_rich_rules: True
 
 Remove private-data-zone:
   module.run:
@@ -72,11 +80,13 @@ Remove private-data-zone:
       - Reset default zone
 {% endif %}
 
-Remove lo interfaces:
+Reset trusted zone:
   firewalld.present:
     - name: trusted
     - prune_interfaces: True
+    - prune_ports: True
     - prune_sources: True
+    - prune_rich_rules: True
 
 Refresh firewalld:
   module.run:
@@ -86,4 +96,3 @@ Refresh firewalld:
 Delete firewall checkpoint flag:
   file.absent:
     - name: /opt/seagate/cortx_configs/provisioner_generated/{{ grains['id'] }}.firewall
-


### PR DESCRIPTION
Signed-off-by: Yashodhan Pise <yashodhan.pise@seagate.com>

--------------------------------------------------------------------------------
This PR adds control in firewall for private data network.
The whole section (data_private) in pillar sls file is optional. Same applies to input yaml to `lr_cli` command.

If added, it creates a dedicated zone: private-data-zone for the private data network NICs.
If skipped, it adds the private data network NICs to the trusted zone.