### PR TITLE
EOS-21915: Provisioner: Discrepancy in systemd resources

### DIFF
--- a/srv/components/ha/haproxy/config.sls
+++ b/srv/components/ha/haproxy/config.sls
@@ -29,18 +29,6 @@ Setup HAProxy config:
     - keep_source: False
     - template: jinja
 
-Configure HAProxy service:
-  file.managed:
-    - name: /etc/systemd/system/haproxy.service.d/override.conf
-    - makedirs: True
-    - source: salt://components/ha/haproxy/files/haproxy_override.conf
-
-Reload service units:
-  cmd.run:
-    - name: systemctl daemon-reload
-    - onchanges:
-      - file: Configure HAProxy service
-
 Setup haproxy 503 error code to http file:
   file.managed:
     - name: /etc/haproxy/errors/503.http

--- a/srv/components/ha/haproxy/start.sls
+++ b/srv/components/ha/haproxy/start.sls
@@ -18,7 +18,6 @@
 Ensure HAProxy running:
   service.running:
     - name: haproxy.service
-    - enable: True
 
 include:
   - components.misc_pkgs.rsyslog.start

--- a/srv/components/ha/haproxy/teardown.sls
+++ b/srv/components/ha/haproxy/teardown.sls
@@ -48,10 +48,6 @@ Remove haproxy:
   pkg.purged:
     - name: haproxy
 
-Remove haproxy service:
-  file.absent:
-    - name: /etc/systemd/system/haproxy.service.d/override.conf
-
 Remove user haproxy:
   user.absent:
     - name: haproxy

--- a/srv/components/misc_pkgs/kibana/start.sls
+++ b/srv/components/misc_pkgs/kibana/start.sls
@@ -18,4 +18,3 @@
 Start Kibana:
   service.running:
     - name: kibana
-    - enable: True


### PR DESCRIPTION
Addressed:

- Do not update haproxy.service in provisioner. i.e remove override.conf 
- Do not enable haproxy.service
- Do not enable kibana.service

Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>