### PR TITLE
Fix: cluster config and prepare commands

### DIFF
--- a/lr-cli/cortx_setup/api_spec.yaml
+++ b/lr-cli/cortx_setup/api_spec.yaml
@@ -50,8 +50,6 @@ node:
       NodePrepareNetwork
     storage:
       NodePrepareStorage
-    software:
-      NodePrepare
 
 cluster:
   create:
@@ -62,6 +60,8 @@ cluster:
     EncryptSecrets
   generate:
     GenerateCluster 
+  prepare:
+    ClusterPrepare
   config:
     network:
       ClusterNetworkConfig

--- a/lr-cli/cortx_setup/commands/__init__.py
+++ b/lr-cli/cortx_setup/commands/__init__.py
@@ -28,11 +28,11 @@ from .cluster.encrypt import EncryptSecrets
 from .cluster.generate import GenerateCluster
 from .cluster.show import ClusterShow
 from .cluster.config.network import ClusterNetworkConfig
+from .cluster.prepare import ClusterPrepare
 from .cluster.config.component import ClusterConfigComponent
 from .security.config import SecurityConfig
 from .resource.show import ResourceShow
 from .resource.discover import ResourceDiscover
-from .node.prepare.software import NodePrepare
 from .node.prepare.firewall import NodePrepareFirewall
 from .node.prepare.network import NodePrepareNetwork
 from .node.prepare.time import NodePrepareTime
@@ -55,6 +55,7 @@ __all__ = [
     'Commons',
     'ClusterCreate',
     'ClusterNetworkConfig',
+    'ClusterPrepare',
     'ClusterConfigComponent',
     'ClusterShow',
     'CreateStorageSet',
@@ -66,7 +67,6 @@ __all__ = [
     'NetworkConfig',
     'NodeInitialize',
     'NodeFinalize',
-    'NodePrepare',
     'NodePrepareFirewall',
     'NodePrepareNetwork',
     'NodePrepareServer',

--- a/lr-cli/cortx_setup/commands/cluster/config/component.py
+++ b/lr-cli/cortx_setup/commands/cluster/config/component.py
@@ -90,7 +90,7 @@ class ClusterConfigComponent(Command):
                 self.logger.debug(f"Deploying prerequisites components on nodes")
                 self._configure(
                     noncortx_components['prerequisites']
-                )                        
+                )
             elif component_group in cortx_components:
                 self.logger.debug(f"Deploying {component_group} components on nodes")
                 self._configure(
@@ -98,14 +98,14 @@ class ClusterConfigComponent(Command):
                     stages=['config.config', 'config.init_mod']
                 )
             elif component_group == 'ha':
-                self.logger.debug(f"Deploying prerequisites components on nodes")
+                self.logger.debug(f"Deploying cortx ha components on nodes")
                 self._configure(
                     ['ha.cortx-ha'],
                     stages=[
                         'config.post_install','config.prepare',
                         'config.config', 'config.init_mod']
-                )          
-            self.logger.debug(f"Deployment done")  
+                )
+            self.logger.debug(f"Deployment done")
         except ValueError as exc:
             raise ValueError(
               f"Cluster Config Failed. Reason: {str(exc)}"

--- a/lr-cli/cortx_setup/commands/cluster/prepare.py
+++ b/lr-cli/cortx_setup/commands/cluster/prepare.py
@@ -31,7 +31,7 @@ from cortx_setup.commands.common_utils import (
 node_id = local_minion_id()
 
 
-class NodePrepare(Command):
+class ClusterPrepare(Command):
     """Cortx Setup API for preparing node"""
     _args = {}
 
@@ -56,15 +56,15 @@ class NodePrepare(Command):
         It would deploy platform states and prepare cortx components.
 
         Execution:
-        `cortx_setup node prepare software`
+        `cortx_setup cluster prepare`
         """
 
-        # provisioner_components = get_provisioner_states()
+        provisioner_components = get_provisioner_states()
         cortx_components = get_cortx_states()
 
-        # self.logger.debug("Deploying platform components")
-        # self._deploy(
-        #     {'noncortx_component': provisioner_components['platform']}, stage=None)
+        self.logger.debug("Deploying platform components")
+        self._deploy(
+            {'noncortx_component': provisioner_components['platform']}, stage=None)
 
         self.logger.debug("Deploying cortx components")
         self._deploy(cortx_components, stage=["config.prepare"])

--- a/pillar/components/execution.sls
+++ b/pillar/components/execution.sls
@@ -23,7 +23,7 @@ execution:
       - system.storage
       - misc_pkgs.rsyslog
       - system.logrotate
-    3rd_party:
+    prerequisites:
       - misc_pkgs.sos
       - misc_pkgs.ipmi.bmc_watchdog
       - misc_pkgs.ssl_certs
@@ -50,6 +50,3 @@ execution:
       - sspl
       - uds
       - csm
-    ha:
-      - ha.cortx-ha
-


### PR DESCRIPTION
Addressed:
1. Rename `cortx_setup node prepare` to `cortx_setup cluster prepare`
2. Remove `ha`  component from `cortx_setup node initialize` and `cortx_setup cluster prepare` and apply in `cortx_setup cluster config`

Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>