### PR TITLE
[WIP] Docs Generation

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -25,6 +25,7 @@ from setuptools import setup, find_packages
 INSTALL_REQ_F_NAME = 'install.txt'
 TESTS_REQ_F_NAME = 'tests.txt'
 CODACY_REQ_F_NAME = 'codacy.txt'
+DOCS_REQ_F_NAME = 'docs.txt'
 
 try:
     here = os.path.abspath(os.path.dirname(__file__))
@@ -53,6 +54,7 @@ def parse_requirements_f(req_f_name):
 
 tests_require = parse_requirements_f(TESTS_REQ_F_NAME)
 codacy_require = parse_requirements_f(CODACY_REQ_F_NAME)
+docs_require = parse_requirements_f(DOCS_REQ_F_NAME)
 
 
 # requiring pytest-runner only when pytest is invoked
@@ -102,6 +104,7 @@ setup(
         'test': tests_require,
         'tests': tests_require,
         'codacy': codacy_require,
+        'docs': docs_require,
     },
     tests_require=tests_require
 )

--- a/docs/Architecture/Architectural-Overview.md
+++ b/docs/Architecture/Architectural-Overview.md
@@ -1,76 +1,81 @@
+# Architectural Overview
 
-Table of Contents
+## Table of Contents
 
-- [Use of SaltStack](#use-of-saltstack)
-- [High Level Repository Structure](#high-level-repository-structure)
-  - [Repo Structure](#repo-structure)
-    - [`files`](#files)
-    - [`pillar`](#pillar)
-    - [`srv`](#srv)
-      - [`top.sls`](#topsls)
-      - [`_grains`](#_grains)
-      - [`_modules`](#_modules)
-      - [`components`](#components)
+*   [Use of SaltStack](#use-of-saltstack)
 
+*   [High Level Repository Structure](#high-level-repository-structure)
 
-# Use of SaltStack
+    *   [Repo Structure](#repo-structure)
+
+        *   [`files`](#files)
+
+        *   [`pillar`](#pillar)
+
+        *   [`srv`](#srv)
+
+            *   [`top.sls`](#topsls)
+            *   [`_grains`](#\_grains)
+            *   [`_modules`](#\_modules)
+            *   [`components`](#components)
+
+## Use of SaltStack
 
 SaltStack has 3 possible modes of operation that were tried out before arriving on the final approach:
 
-* SSH: This mechanism is similar to Ansible, which primarily performs remote executions over SSH protocol. Salt-SSH requires each node to be configured in roster file and thus the execution is limited to the number of entries in Roster file.
+*   SSH: This mechanism is similar to Ansible, which primarily performs remote executions over SSH protocol. Salt-SSH requires each node to be configured in roster file and thus the execution is limited to the number of entries in Roster file.
 
-  cortx-prvsnr uses Salt-SSH for initial provisioner bootstrap. This installs and configures Salt in master-minion configuration along with cortx-prvsnr itself.
+    cortx-prvsnr uses Salt-SSH for initial provisioner bootstrap. This installs and configures Salt in master-minion configuration along with cortx-prvsnr itself.
 
-  The cortx-prvsnr API (`provisioner --help`) provides various commands to perform this bootstrap on various environments and is also capable of remotely performing bootstrap on a system from a jump server/host.
+    The cortx-prvsnr API (`provisioner --help`) provides various commands to perform this bootstrap on various environments and is also capable of remotely performing bootstrap on a system from a jump server/host.
 
-* Masterless: Salt formulae would be executed on each minion independently in absence of Salt master (using salt-call --local). This has lower overhead and works fine with single node configuration.
+*   Masterless: Salt formulae would be executed on each minion independently in absence of Salt master (using salt-call --local). This has lower overhead and works fine with single node configuration.
 
-  With multi-node configuration, the setup still was workable, however, the source of Salt formulae (cortx-prvsnr repo) requires replication on each node. Also, assigning role to each node independently becomes challenging.
+    With multi-node configuration, the setup still was workable, however, the source of Salt formulae (cortx-prvsnr repo) requires replication on each node. Also, assigning role to each node independently becomes challenging.
 
-  This mechanism is preferred to make local calls to fetch data (grains/pillar) from Salt.
+    This mechanism is preferred to make local calls to fetch data (grains/pillar) from Salt.
 
-* Master-Minion: Primary node is elected as Salt master and minions installed on primary and non-primary nodes are connected to the master. This configuration allows better source code management, centralized control and possibility to remotely trigger execution using delegation (salt-syndic).
-  
-  Master-Minion configuration is the backbone of cortx-prvsnr. Deployment, updates, Northbound API execution (and monitoring in future) are all designed around the capability of salt-minions to communicate with salt-master. This configuration allows for scalability and asynchronous mode of operations.
+*   Master-Minion: Primary node is elected as Salt master and minions installed on primary and non-primary nodes are connected to the master. This configuration allows better source code management, centralized control and possibility to remotely trigger execution using delegation (salt-syndic).
 
+    Master-Minion configuration is the backbone of cortx-prvsnr. Deployment, updates, Northbound API execution (and monitoring in future) are all designed around the capability of salt-minions to communicate with salt-master. This configuration allows for scalability and asynchronous mode of operations.
 
-# High Level Repository Structure
+## High Level Repository Structure
 
 The provisioner code is broken down into 3 essential parts:
 
-* State files (`./srv`)
-* Static configuration data (`./pillar`)
-* Application Programming Interface (`./api`)
-* Command Line Interface (`./cli`)
+*   State files (`./srv`)
+*   Static configuration data (`./pillar`)
+*   Application Programming Interface (`./api`)
+*   Command Line Interface (`./cli`)
 
-## Repo Structure
+### Repo Structure
 
 An overview of folder structure in cortx-prvsnr repo:
 
-### `files`
+#### `files`
 
-Generic files used by Vagrantfile for Vagrant provisioning.  
+Generic files used by Vagrantfile for Vagrant provisioning.
 
-### `pillar`
+#### `pillar`
 
 Pillar is an interface for Salt designed to offer global values that can be distributed to minions.  See [Salt Docs](https://docs.saltstack.com/en/latest/topics/pillar/) for more details.
 
 For EOS and supported components the pillar data is maintained under:
 
-* Repo path: `./pillar/components`
-* Installed path: `/opt/seagate/cortx/provisioner/pillar/components`
+*   Repo path: `./pillar/components`
+*   Installed path: `/opt/seagate/cortx/provisioner/pillar/components`
 
 NOTE: User modified pillars are not stored at above location as their data would be replaced during updates.
 
 It's recommended that the Pillar data should be updated using `provisioner pillar_set`, although currently it's possible to update these files manually.
 
-### `srv`
+#### `srv`
 
-#### `top.sls`
+##### `top.sls`
 
-This is the top level state file referred to by highstate when executing SaltStack state(s).  
+This is the top level state file referred to by highstate when executing SaltStack state(s).
 
-#### `_grains`
+##### `_grains`
 
 See also [Salt Docs on Grains](https://docs.saltstack.com/en/latest/topics/grains/index.html#writing-grains).
 
@@ -78,7 +83,7 @@ This directory consists of custom grains.
 
 It has a module to fetch MAC address and IP address data over IPMI and present it as `bmc_network` grain item.
 
-#### `_modules`
+##### `_modules`
 
 See also [Salt Docs on Modules](https://docs.saltstack.com/en/latest/ref/states/writing.html#using-custom-state-modules).
 
@@ -86,7 +91,7 @@ This directory consists of custom modules.
 
 The `stx_disks.py` is available as a sample module for reference.
 
-#### `components`
+##### `components`
 
 These are the Salt state formulae. They are categorized into components and sub-components under `./src/components`.
 
@@ -96,53 +101,55 @@ Sub-components are sub-directories under `./srv/components/<component>`.
 
 As of writing the components directory looks like:
 
-```
-├───srv  
-│   ├───components  
-│   │   ├───csm  
-│   │   ├───motr  
-│   │   ├───ha  
-│   │   │   ├───corosync-pacemaker  
-│   │   │   ├───haproxy  
-│   │   │   └───keepalived  
-│   │   ├───hare  
-│   │   ├───misc  
-│   │   │   ├───build_ssl_cert_rpms  
-│   │   │   ├───elasticsearch  
-│   │   │   ├───kibana  
-│   │   │   ├───lustre  
-│   │   │   ├───nodejs  
-│   │   │   ├───openldap  
-│   │   │   └───rabbitmq  
-│   │   ├───performance_testing  
-│   │   │   └───cosbench  
-│   │   ├───post_setup  
-│   │   ├───s3client  
-│   │   │   ├───awscli  
-│   │   │   └───s3cmd  
-│   │   ├───s3server  
-│   │   ├───sspl  
-│   │   └───system  
-│   │       ├───logrotate  
-│   │       ├───network  
-│   │       ├───ntp  
-│   │       └───storage  
+```bash
+
+    ├───srv  
+    │   ├───components  
+    │   │   ├───csm  
+    │   │   ├───motr  
+    │   │   ├───ha  
+    │   │   │   ├───corosync-pacemaker  
+    │   │   │   ├───haproxy  
+    │   │   │   └───keepalived  
+    │   │   ├───hare  
+    │   │   ├───misc  
+    │   │   │   ├───build_ssl_cert_rpms  
+    │   │   │   ├───elasticsearch  
+    │   │   │   ├───kibana  
+    │   │   │   ├───lustre  
+    │   │   │   ├───nodejs  
+    │   │   │   ├───openldap  
+    │   │   │   └───rabbitmq  
+    │   │   ├───performance_testing  
+    │   │   │   └───cosbench  
+    │   │   ├───post_setup  
+    │   │   ├───s3client  
+    │   │   │   ├───awscli  
+    │   │   │   └───s3cmd  
+    │   │   ├───s3server  
+    │   │   ├───sspl  
+    │   │   └───system  
+    │   │       ├───logrotate  
+    │   │       ├───network  
+    │   │       ├───ntp  
+    │   │       └───storage  
 ```
 
 Each component/sub-component directory should consist of an `.sls` (Salt state) file or directory with collection of state files each addressing execution steps in entirety (attempting to following single responsibility principle).  Supported states are listed below:
 
-* `init`: Represents highstate of the component module and defines the execution sequence of the state files.
+*   `init`: Represents highstate of the component module and defines the execution sequence of the state files.
 
-* `install`: Installation of component and its requisite packages. It is expected that the component package to include all the required dependencies. However, in absence of component package's ability to have all requisites installed, provisioner would address such installation from this file/directory.
+*   `install`: Installation of component and its requisite packages. It is expected that the component package to include all the required dependencies. However, in absence of component package's ability to have all requisites installed, provisioner would address such installation from this file/directory.
 
-  Packages types to be installed include:
+    Packages types to be installed include:
 
-  * RPM/DEB
-  * PIP
-  * Custom build requirements from source tar
+    *   RPM/DEB
+    *   PIP
+    *   Custom build requirements from source tar
 
-* `config`: Any configurations required for base (factory/field) setup of the component shall be covered in this file/directory. In ideal world, this would be a simple call to component provided `init` file. This state file should also allow for correcting any deviations caused by user over-rides.  
-A representative config directory structure shall be:  
+*   `config`: Any configurations required for base (factory/field) setup of the component shall be covered in this file/directory. In ideal world, this would be a simple call to component provided `init` file. This state file should also allow for correcting any deviations caused by user over-rides.\
+    A representative config directory structure shall be:
+
 ```
 ├───component
 │   ├───config
@@ -154,21 +161,21 @@ A representative config directory structure shall be:
 
 ```
 
-Each sub-level file would consist of calls to respective southbound API as:  
-    * `init`: Represent states of the configuration and defines the execution sequence of the state files within config.  
-    * `post_install` : After installing the component , post_install call will be made through `/opt/seagate/cortx/csm/conf/setup.yaml` and it will call `[component]:post_install` command.  
-    * `prepare` : This is a preparatory step that sets up the platform before initiating the setup. Pre-checks before the   components installation, configuration is attempted through prepare.    
-    * `config` : Copying configuration files to target directories and Modifying the Configuration to suit the target node environment will be covered from config , and these steps will be invoked from config command respective to the component.  
-    * `init_mod` : Execute initialization and configuration scripts of component will get covered with init_mod.  
+Each sub-level file would consist of calls to respective southbound API as:\
+\* `init`: Represent states of the configuration and defines the execution sequence of the state files within config.\
+\* `post_install` : After installing the component , post_install call will be made through `/opt/seagate/cortx/csm/conf/setup.yaml` and it will call `[component]:post_install` command.\
+\* `prepare` : This is a preparatory step that sets up the platform before initiating the setup. Pre-checks before the   components installation, configuration is attempted through prepare.\
+\* `config` : Copying configuration files to target directories and Modifying the Configuration to suit the target node environment will be covered from config , and these steps will be invoked from config command respective to the component.\
+\* `init_mod` : Execute initialization and configuration scripts of component will get covered with init_mod.
 
+*   `start`: Start component services.
 
-* `start`: Start component services.
-* `stop`: Stop component services.
+*   `stop`: Stop component services.
 
-* `housekeeping`: Any expected clean-up activities for junk files created during setup and if required, during operation phase.
+*   `housekeeping`: Any expected clean-up activities for junk files created during setup and if required, during operation phase.
 
-* `sanity_check`: This is a crucial stage as its outcome would determine and confirm the healthy state of the component in operation (post setup). This should be an independently reusable component.
+*   `sanity_check`: This is a crucial stage as its outcome would determine and confirm the healthy state of the component in operation (post setup). This should be an independently reusable component.
 
-* `teardown.sls`: This is a special case that would be triggered only on demand and not as part of normal setup procedure. The purpose of this stage would be to undo all the changes made by all above stages (esp. Install and Config). Ideally after a teardown stage the system would be back to a state as before the start of respective component provisioning.
+*   `teardown.sls`: This is a special case that would be triggered only on demand and not as part of normal setup procedure. The purpose of this stage would be to undo all the changes made by all above stages (esp. Install and Config). Ideally after a teardown stage the system would be back to a state as before the start of respective component provisioning.
 
 **Note**: It is not always essential to populate/implement each state file mentioned above.

--- a/docs/Architecture/SW-Upgrade.md
+++ b/docs/Architecture/SW-Upgrade.md
@@ -135,4 +135,4 @@ yum repolist
 
 ## References
 
-#### [Passing crdedentials to CLI](../../api/python/README.md#passing-crdedentials-to-cli)
+### [Passing crdedentials to CLI](../../api/python/README.md#passing-crdedentials-to-cli)

--- a/docs/Architecture/SW-Upgrade.md
+++ b/docs/Architecture/SW-Upgrade.md
@@ -1,14 +1,20 @@
 # SW Upgrade
 
-Table of contents:
+## Table of Contents
 
-- [High Level SW Upgrade logic](#high-level-sw-upgrade-logic)
-- [Setup SW upgrade repository](#setup-sw-upgrade-repository)
-- [Apply SW upgrade](#apply-sw-upgrade)
-- [SW upgrade single ISO bundle structure](#sw-upgrade-single-iso-bundle-structure)
-- [Delete SW upgrade repository](#delete-sw-upgrade-repository)
-- [References](#references)
+*   [High Level SW Upgrade logic](#high-level-sw-upgrade-logic)
 
+*   [Setup SW upgrade repository](#setup-sw-upgrade-repository)
+
+*   [SW upgrade single ISO bundle structure](#sw-upgrade-single-iso-bundle-structure)
+
+*   [Apply SW upgrade](#apply-sw-upgrade)
+
+*   [Delete SW upgrade repository](#delete-sw-upgrade-repository)
+
+*   [References](#references)
+
+    *   [Passing crdedentials to CLI](#passing-crdedentials-to-cli)
 
 ## High Level SW Upgrade logic
 
@@ -28,6 +34,7 @@ The high level logic of SW upgrade is:
 ## Setup SW upgrade repository
 
 The common structure of the `set_swupgrade_repo` command:
+
 ```bash
 provisioner set_swupgrade_repo </path/to/single/iso/bundle> --hash="<hash_type>:<hash> <filename>"  --hash-type="<hash_type>"
 ```
@@ -40,18 +47,18 @@ where
 Can be either string with hash data or path to the file with that data.
 Supported formats of checksum string
 
-1. <hash_type>:<check_sum> <file_name>
-2. <hash_type>:<check_sum>
-3. <check_sum> <file_name>
-4. <check_sum>
+1.  \<hash_type>:\<check_sum> \<file_name>
+2.  \<hash_type>:\<check_sum>
+3.  \<check_sum> \<file_name>
+4.  \<check_sum>
 
 where
 
-- `<hash_type>`: one of the values from `config.HashType` enumeration. Supported values: `md5`, `sha256`, `sha512`.
-- `<check_sum>`: hexadecimal representation of hash checksum
-- `<file_name>`: a file name to which <hash_type> and <hash_sum> belongs to
+*   `<hash_type>`: one of the values from `config.HashType` enumeration. Supported values: `md5`, `sha256`, `sha512`.
+*   `<check_sum>`: hexadecimal representation of hash checksum
+*   `<file_name>`: a file name to which \<hash_type> and \<hash_sum> belongs to
 
- `--hash-type="<hash_type>"` **Optional**. Type of hash value. Supported values: `md5`, `sha256`, `sha512`. See `config.HashType` for all possible values.
+`--hash-type="<hash_type>"` **Optional**. Type of hash value. Supported values: `md5`, `sha256`, `sha512`. See `config.HashType` for all possible values.
 
 :warning: **NOTE**: The `md5` is the default hash type. So you can omit hash type in `--hash` and in `--hash-type` options.
 Hash type in `--hash` option has the higher priority than `--hash-type`.
@@ -62,6 +69,7 @@ See [Passing crdedentials to CLI](#passing-crdedentials-to-cli) how to pass
 credential for command authorization.
 
 Examples:
+
 ```bash
 provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="fefa1db67588d2783b83f07f4f5beb5c"
 provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="sha256:ff01da01d4304729bfbad3aeca53b705c1d1d2132e94e4303c1ea210288de12b"
@@ -71,15 +79,14 @@ provisioner set_swupgrade_repo /opt/iso/single_cortx.iso --hash="md5:fefa1db6758
 ## SW upgrade single ISO bundle structure
 
 Expected minimum structure of single SW upgrade ISO bundle:
-```
-sw_upgrade_bundle.iso
-    - 3rd_party/
-        - THIRD_PARTY_RELEASE.INFO
-    - cortx_iso/
-        - RELEASE.INFO
-    - python_deps/
-    - os/
-```
+
+    sw_upgrade_bundle.iso
+        - 3rd_party/
+            - THIRD_PARTY_RELEASE.INFO
+        - cortx_iso/
+            - RELEASE.INFO
+        - python_deps/
+        - os/
 
 The following basic and minimum necessary structure of `RELEASE.INFO`
 
@@ -94,7 +101,6 @@ RELEASE.INFO:
 ```
 
 All fields above except `RELEASE` are mandatory fields for the `RELEASE.INFO` file
-
 
 ## Apply SW upgrade
 
@@ -114,6 +120,7 @@ credential for command authorization.
 ## Delete SW upgrade repository
 
 To remove installed SW upgrade repository run the command:
+
 ```bash
 provisioner remove_swupgrade_repo <release>
 ```
@@ -128,10 +135,10 @@ credential for command authorization.
 :warning: **NOTE**:
 
 To see the list of SW upgrade repositories:
+
 ```bash
 yum repolist
 ```
-
 
 ## References
 

--- a/docs/Architecture/Southbound-Interface.md
+++ b/docs/Architecture/Southbound-Interface.md
@@ -1,11 +1,6 @@
 # Framework of Southbound API
 
-Table of contents:
-
-- [Framework of Southbound API](#framework-of-southbound-api)
-  - [Summary of Southbound API](#summary-of-southbound-api)
-  - [`setup.yaml` File Sections Explained](#setupyaml-file-sections-explained)
-
+## Table of Contents
 
 ## Summary of Southbound API
 

--- a/docs/Architecture/Validation.md
+++ b/docs/Architecture/Validation.md
@@ -1,42 +1,53 @@
 # Validation Framework
 
-Table of Contents:
+## Table of Contents
 
-- [Validation Framework](#validation-framework)
-  - [General Guidelines](#general-guidelines)
-  - [Input/Output Checks](#inputoutput-checks)
-    - [Input Format](#input-format)
-    - [Output Format](#output-format)
-  - [Proposed directory structure](#proposed-directory-structure)
-  - [`scripts`](#scripts)
-    - [`utils`](#utils)
-    - [`factory`](#factory)
-    - [`field`](#field)
-  - [Salt Modules](#salt-modules)
-- [Checks](#checks)
-  - [Hardware check](#hardware-check)
-  - [Software Check](#software-check)
-- [Provisioner Validations](#provisioner-validations)
-  - [Check API](#check-api)
+*   [General Guidelines](#general-guidelines)
 
+*   [Input/Output Checks](#inputoutput-checks)
+
+    *   [Input Format](#input-format)
+    *   [Output Format](#output-format)
+
+*   [Proposed directory structure](#proposed-directory-structure)
+
+*   [`scripts`](#scripts)
+
+    *   [`utils`](#utils)
+    *   [`factory`](#factory)
+    *   [`field`](#field)
+
+*   [Salt Modules](#salt-modules)
+
+*   [Checks](#checks)
+
+    *   [Hardware check](#hardware-check)
+
+    *   [Software Check](#software-check)
+
+    *   [Provisioner Validations](#provisioner-validations)
+
+    *   [Check API](#check-api)
+
+        *   [Singular Checks](#singular-checks)
+        *   [Group Checks](#group-checks)
 
 ## General Guidelines
 
-* As a high-level guideline, the entire framework would be built and managed in Python 3.x+.
+*   As a high-level guideline, the entire framework would be built and managed in Python 3.x+.
 
-  Python helps us in 2 ways:
+    Python helps us in 2 ways:
 
-  1. Better control over `stdout` and `stderr`.
-  2. Possibility of easily converting Python module to Salt module.
+    1.  Better control over `stdout` and `stderr`.
+    2.  Possibility of easily converting Python module to Salt module.
 
-  If you have concerns regarding Python code or lack confidence in Python, it is absolutely ok to capture the logic in a bash script and place it under `_cortx-prvsnr/validation/scripts/utils/uncategorized_`.
+    If you have concerns regarding Python code or lack confidence in Python, it is absolutely ok to capture the logic in a bash script and place it under `_cortx-prvsnr/validation/scripts/utils/uncategorized_`.
 
-* Another general rule of thumb would be to modularize the checks as much as possible. Avoid long script files. Each script file should contain only checks related to the theme of the file -- **_Single-Responsibility principle_**.  E.g. a network check file should have only `ping` test and no checks related to storage connectivity like `iperf`, which also happens over network.
+*   Another general rule of thumb would be to modularize the checks as much as possible. Avoid long script files. Each script file should contain only checks related to the theme of the file -- ***Single-Responsibility principle***.  E.g. a network check file should have only `ping` test and no checks related to storage connectivity like `iperf`, which also happens over network.
 
-* Before you start implementing a new check, make sure you have scanned the `utils` directory for any existing modules -- **_Open-Closed principle_**.  If you find something similar, but doesn't fit your purpose, consider generalizing the existing module and extend it to scope in the new possible.
+*   Before you start implementing a new check, make sure you have scanned the `utils` directory for any existing modules -- ***Open-Closed principle***.  If you find something similar, but doesn't fit your purpose, consider generalizing the existing module and extend it to scope in the new possible.
 
-* Any script not in `validation/scripts/utils` should serve the only purpose of making calls to the `util` scripts (**should serve as an orchestrator**). Any specific code logic should be avoided as much as possible. (**Centralization** to avoid regression bugs and enable maintainable code.)
-
+*   Any script not in `validation/scripts/utils` should serve the only purpose of making calls to the `util` scripts (**should serve as an orchestrator**). Any specific code logic should be avoided as much as possible. (**Centralization** to avoid regression bugs and enable maintainable code.)
 
 ## Input/Output Checks
 
@@ -60,7 +71,6 @@ def foo(
     pass
 ```
 
-
 ### Output Format
 
 Output shall always be a single JSON format string:
@@ -72,86 +82,84 @@ Output shall always be a single JSON format string:
   "stdout": "",  
   "stderr": "",  
 }
-```  
+```
 
 Legend:
 
-* `check`: This is the check that has been performed by the called. It could be the command executed or a short string describing check performed.
+*   `check`: This is the check that has been performed by the called. It could be the command executed or a short string describing check performed.
 
-* `retcode`: Return code either from shell for an executed command or a preferable code decided by the called module to help understand the area of failure.
+*   `retcode`: Return code either from shell for an executed command or a preferable code decided by the called module to help understand the area of failure.
 
-* `stdout`: The `stdout` from shell command or a string that describes a success scenario.
+*   `stdout`: The `stdout` from shell command or a string that describes a success scenario.
 
-* `stderr`: The `stderr` from shell command or a string that describes a failure scenario.
-
+*   `stderr`: The `stderr` from shell command or a string that describes a failure scenario.
 
 ## Proposed directory structure
 
 At a high level the directory structure would consist of:
 
-* `messages`: Directory for messages. It would consist of:
-  * `user_messages`: Translations for known standard cryptic messages from system (command output/logs).
-  * `log_messages`: Messages that guide the user studying logs. This is essentially required if we plan to do localization in future.
-* `scripts`: The validation scripts performing granular level checks of system processes/components. This directory structure would be discussed in detail in later parts of this document.
+*   `messages`: Directory for messages. It would consist of:
+    *   `user_messages`: Translations for known standard cryptic messages from system (command output/logs).
+    *   `log_messages`: Messages that guide the user studying logs. This is essentially required if we plan to do localization in future.
+*   `scripts`: The validation scripts performing granular level checks of system processes/components. This directory structure would be discussed in detail in later parts of this document.
 
 A sample tree of directory structure for validation would be:
 
+```bash
+    ├───validation
+    │   ├───messages
+    │   │   ├───user_messages (future_scope: localization)
+    │   │   │   ├───error
+    │   │   │   └───instructions
+    │   │   ├───log_messages (future_scope: localization)
+    │   ├───scripts
+    │   │   ├───utils
+    │   │   │   ├───network_connectivity_check
+    │   │   │   ├───internal_storage_connectivity_check
+    │   │   │   ├───external_storage_connectivity_check
+    │   │   │   ├───raw_io_check_over_sas
+    │   │   │   ├───raw_io_check_over_nw
+    │   │   │   ├───uncategorized
+    |   │   │   |   └───my_custom_check
+    │   │   │   └───system_check
+    |   │   │       ├───hw_check
+    |   │   │       ├───hostname_check
+    |   │   │       ├───critical_dir_access_check
+    |   │   │       ├───repo_source_check
+    |   │   │       ├───gluster_replication_check
+    |   │   │       ├───lvm_check
+    |   │   │       └───salt_health_check
+    │   │   ├───factory
+    │   │   │   ├───pre_flight_check
+    │   │   │   ├───bootstarp_readiness_check
+    │   │   │   ├───deployment_readiness_check
+    │   │   │   ├───boxing_readiness_check
+    │   │   │   └───system_info
+    │   │   └───field
+    │   │       ├───hw_check
+    │   │       ├───unboxing_readiness_check
+    │   │       ├───unboxing_sanity
+    │   │       ├───onboarding_readiness_check
+    │   │       ├───onboarding_sanity
+    │   │       ├───update_readiness_check
+    │   │       └───replacement_checks
+    |   │           ├───system_check
+    |   │           ├───bootstrap_readiness_check
+    |   │           ├───bootstrap_success
+    |   │           ├───stage_1_readiness_check
+    |   │           ├───stage_1_success
+    |   │           ├───stage_2_readiness_check
+    |   │           ├───stage_2_success
+    |   │           └───post_replacement_check
 ```
-├───validation
-│   ├───messages
-│   │   ├───user_messages (future_scope: localization)
-│   │   │   ├───error
-│   │   │   └───instructions
-│   │   ├───log_messages (future_scope: localization)
-│   ├───scripts
-│   │   ├───utils
-│   │   │   ├───network_connectivity_check
-│   │   │   ├───internal_storage_connectivity_check
-│   │   │   ├───external_storage_connectivity_check
-│   │   │   ├───raw_io_check_over_sas
-│   │   │   ├───raw_io_check_over_nw
-│   │   │   ├───uncategorized
-|   │   │   |   └───my_custom_check
-│   │   │   └───system_check
-|   │   │       ├───hw_check
-|   │   │       ├───hostname_check
-|   │   │       ├───critical_dir_access_check
-|   │   │       ├───repo_source_check
-|   │   │       ├───gluster_replication_check
-|   │   │       ├───lvm_check
-|   │   │       └───salt_health_check
-│   │   ├───factory
-│   │   │   ├───pre_flight_check
-│   │   │   ├───bootstarp_readiness_check
-│   │   │   ├───deployment_readiness_check
-│   │   │   ├───boxing_readiness_check
-│   │   │   └───system_info
-│   │   └───field
-│   │       ├───hw_check
-│   │       ├───unboxing_readiness_check
-│   │       ├───unboxing_sanity
-│   │       ├───onboarding_readiness_check
-│   │       ├───onboarding_sanity
-│   │       ├───update_readiness_check
-│   │       └───replacement_checks
-|   │           ├───system_check
-|   │           ├───bootstrap_readiness_check
-|   │           ├───bootstrap_success
-|   │           ├───stage_1_readiness_check
-|   │           ├───stage_1_success
-|   │           ├───stage_2_readiness_check
-|   │           ├───stage_2_success
-|   │           └───post_replacement_check
-```
-
 
 ## `scripts`
 
 The scripts directory shall be logically segregated into:
 
-* `utils`
-* `factory`
-* `field`
+*   `utils`
+*   `factory`
+*   `field`
 
 ### `utils`
 
@@ -159,23 +167,23 @@ This would be a common library of reusable modules that would be reused with spe
 
 Example of scripts under `utils` would be:
 
-* `logger`
-* `exit_trap`
-* `network_connectivity_check`: Tools to test network connectivity
-  * `ping_test`
-  * `port_check`
-* `internal_storage_connectivity_check`: Check storage sanity on server node
-* `external_storage_connectivity_check`: Check storage sanity on storage enclosure
-* `raw_io_check_over_sas`: FIO kind of utility to test IO on SAS channels
-* `raw_io_check_over_nw`: `iperf` kind of utility over IB/TCP channels
-* `system_check`: Various sanity checks for system components (SW/HW):
-    * `hw_check`
-    * `hostname_check`
-    * `critical_dir_access_check`
-    * `repo_source_check`
-    * `gluster_replication_check`
-    * `lvm_check`
-    * `salt_health_check`
+*   `logger`
+*   `exit_trap`
+*   `network_connectivity_check`: Tools to test network connectivity
+    *   `ping_test`
+    *   `port_check`
+*   `internal_storage_connectivity_check`: Check storage sanity on server node
+*   `external_storage_connectivity_check`: Check storage sanity on storage enclosure
+*   `raw_io_check_over_sas`: FIO kind of utility to test IO on SAS channels
+*   `raw_io_check_over_nw`: `iperf` kind of utility over IB/TCP channels
+*   `system_check`: Various sanity checks for system components (SW/HW):
+    *   `hw_check`
+    *   `hostname_check`
+    *   `critical_dir_access_check`
+    *   `repo_source_check`
+    *   `gluster_replication_check`
+    *   `lvm_check`
+    *   `salt_health_check`
 
 ### `factory`
 
@@ -193,209 +201,180 @@ Our salt formula under `srv` directory follows a strict discipline of structure.
 
 In-place validations for each components modules can and shall be performed using:
 
-* `prepare.sls`: For check prior to starting installation and configuration of a component.
-* `sanity_check.sls`: For check post installation and configuration of a component.
+*   `prepare.sls`: For check prior to starting installation and configuration of a component.
+*   `sanity_check.sls`: For check post installation and configuration of a component.
 
+## Checks
 
-# Checks
+### Hardware check
 
-## Hardware check
+*   Mellanox OFED in installed:
 
-* Mellanox OFED in installed:
+        yum list yum list mlnx-ofed-all
 
-  ```
-  yum list yum list mlnx-ofed-all
-  ```
+    Ideally pick list of installed packages from
 
-  Ideally pick list of installed packages from
+        yum list *mlnx*
 
-  ```
-  yum list *mlnx*
-  ```
+    and cross-check against a standard reference list.
 
-  and cross-check against a standard reference list.
+*   Mellanox HCA present and has number of ports:
 
-* Mellanox HCA present and has number of ports:
+    https://www.mellanox.com/support/firmware/identification
 
-  https://www.mellanox.com/support/firmware/identification
+        [root@localhost ~]# lspci -nn | grep "Mellanox Technologies"
+        af:00.0 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
+        af:00.1 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
+        d8:00.0 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
+        d8:00.1 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
 
-  ```
-  [root@localhost ~]# lspci -nn | grep "Mellanox Technologies"
-  af:00.0 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
-  af:00.1 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
-  d8:00.0 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
-  d8:00.1 Ethernet controller [0200]: Mellanox Technologies MT27800 Family [ConnectX-5] [15b3:1017]
-  ```
+*   LSI HBA is present:
 
-* LSI HBA is present:
+        [root@localhost ~]# lspci -nn | grep "SCSI"
+        86:00.0 Serial Attached SCSI controller [0107]: Broadcom / LSI SAS3216 PCI-Express Fusion-MPT SAS-3 [1000:00c9] (rev 01)
 
-  ```
-  [root@localhost ~]# lspci -nn | grep "SCSI"
-  86:00.0 Serial Attached SCSI controller [0107]: Broadcom / LSI SAS3216 PCI-Express Fusion-MPT SAS-3 [1000:00c9] (rev 01)
-  ```
+*   LSI HBA has required number of ports:
+    *   https://www.thegeekdiary.com/how-to-identify-the-hba-cardsports-and-wwn-in-rheloel/
+    *   Enclosure volumes are accessible from both servers
+        *   `lsblk -S`
+        *   `ls -1 /dev/disk/by-id/scsi-*`
 
-* LSI HBA has required number of ports:
-	* https://www.thegeekdiary.com/how-to-identify-the-hba-cardsports-and-wwn-in-rheloel/
-  * Enclosure volumes are accessible from both servers
-    * `lsblk -S`
-    * `ls -1 /dev/disk/by-id/scsi-*`
+*   Enclosure volumes are mapped to both controller:
 
-* Enclosure volumes are mapped to both controller:
+    (Should be 16 for cross-connect setup with 8 volumes per storage mapping.)
 
-  (Should be 16 for cross-connect setup with 8 volumes per storage mapping.)
+        $ multipath -ll | grep prio=50 | wc -l
+          16
+        $ multipath -ll | grep prio=10 | wc -l
+          16
 
-  ```
-  $ multipath -ll | grep prio=50 | wc -l
-    16
-  $ multipath -ll | grep prio=10 | wc -l
-    16
-  ```
+    If not found, instruct user to run `rescan_scsi_bus.sh`.
 
-  If not found, instruct user to run `rescan_scsi_bus.sh`.
+*   LVM check:
 
-* LVM check:
+        $ lvscan | grep metadata | grep ACTIVE | wc -l
+        4
 
-  ```
-  $ lvscan | grep metadata | grep ACTIVE | wc -l
-  4
-  ```
+    2 for SWAP (one from each node) and 2 for metadata (one for each node).
 
-  2 for SWAP (one from each node) and 2 for metadata (one for each node).
+*   Network interface check:
 
-* Network interface check:
+        $ ip a | grep inet | egrep -v 'inet6|127.0.0.1'
+        inet 192.168.10.10/20 brd 10.230.255.255 scope global noprefixroute dynamic eth0
+        inet 192.168.20.10/20 brd 192.168.15.255 scope global noprefixroute dynamic eth1
+        inet 192.168.30.10/20 brd 192.168.31.255 scope global noprefixroute dynamic eth2
 
-  ```
-  $ ip a | grep inet | egrep -v 'inet6|127.0.0.1'
-  inet 192.168.10.10/20 brd 10.230.255.255 scope global noprefixroute dynamic eth0
-  inet 192.168.20.10/20 brd 192.168.15.255 scope global noprefixroute dynamic eth1
-  inet 192.168.30.10/20 brd 192.168.31.255 scope global noprefixroute dynamic eth2
-  ```
+### Software Check
 
-## Software Check
+*   Verify rpm:
 
-* Verify rpm:
+        yum verify-rpm *cortx*
 
-  ```
-  yum verify-rpm *cortx*
-  ```
+*   Cluster resource status:
 
-* Cluster resource status:
+        $ hctl node status --full|jq .
+        {
+          "resources": {
+            "statistics": {
+              "started": 71,
+              "stopped": 0,
+              "starting": 2
+            }
+          },
+          "nodes": [
+            {
+              "name": "srvnode-1",
+              "online": true,
+              "standby": false,
+              "unclean": false,
+              "resources_running": 39
+            },
+            {
+              "name": "srvnode-2",
+              "online": true,
+              "standby": false,
+              "unclean": false,
+              "resources_running": 34
+            }
+          ]
+        }
 
-  ```
-  $ hctl node status --full|jq .
-  {
-    "resources": {
-      "statistics": {
-        "started": 71,
-        "stopped": 0,
-        "starting": 2
-      }
-    },
-    "nodes": [
-      {
-        "name": "srvnode-1",
-        "online": true,
-        "standby": false,
-        "unclean": false,
-        "resources_running": 39
-      },
-      {
-        "name": "srvnode-2",
-        "online": true,
-        "standby": false,
-        "unclean": false,
-        "resources_running": 34
-      }
-    ]
-  }
-  ```
+*   Virtual IP:
+    *   Cluster VIP on public data network
 
-* Virtual IP:
-  * Cluster VIP on public data network
+            $ pcs status | grep kibana-vip
+             kibana-vip (ocf::heartbeat:IPaddr2):       Started srvnode-1
 
-    ```
-    $ pcs status | grep kibana-vip
-     kibana-vip (ocf::heartbeat:IPaddr2):       Started srvnode-1
+            $ salt-call pillar.get cluster:cluster_ip --output=newline_values_only
+            172.16.200.11
 
-    $ salt-call pillar.get cluster:cluster_ip --output=newline_values_only
-    172.16.200.11
-    ```
+    *   Management VIP on management network:
 
-  * Management VIP on management network:
+            $ pcs status | grep ClusterIP:
+             ClusterIP:0        (ocf::heartbeat:IPaddr2):       Started srvnode-1
+             ClusterIP:1        (ocf::heartbeat:IPaddr2):       Started srvnode-2
+            $ salt-call pillar.get cluster:mgmt_vip --output=newline_values_only
+             10.100.200.11
 
-    ```
-    $ pcs status | grep ClusterIP:
-     ClusterIP:0        (ocf::heartbeat:IPaddr2):       Started srvnode-1
-     ClusterIP:1        (ocf::heartbeat:IPaddr2):       Started srvnode-2
-    $ salt-call pillar.get cluster:mgmt_vip --output=newline_values_only
-     10.100.200.11
-    ```
+### Provisioner Validations
 
-
-# Provisioner Validations
-
-Certain requirements are mandatory to be available in the setup before and after major processes in Provisioner.  
+Certain requirements are mandatory to be available in the setup before and after major processes in Provisioner.\
 These verifications have been implemented as part in Provisioner **Validations Framework** to ensure all the mandatory checkpoints are covered and works without any glitches.
 
-## Check API
+### Check API
 
-A new API (**_provisioner check_**) has been created for this purpose and it can be run on CLI.
+A new API (***provisioner check***) has been created for this purpose and it can be run on CLI.
 
 `check` api has been created for the below processes:
 
-1. Before Deployment
-2. After Deployment
-3. Before Unboxing
-4. After Unboxing
-5. Before Node Replacement
-6. Before SW Upgrade
+1.  Before Deployment
+2.  After Deployment
+3.  Before Unboxing
+4.  After Unboxing
+5.  Before Node Replacement
+6.  Before SW Upgrade
 
 These six categories form the six groups of validations and individual checks will be grouped under either one the above group.
 
 In case of any failure in validations, based on the severity or the significance of the check in the above processes, the flow will either be stopped or the user will be warned of the error and proceeded next.
 
-For example, any error in Pre-Deployment or Pre-Unboxing checks will raise Exception and **the proccess will be stopped right at that step**.  
+For example, any error in Pre-Deployment or Pre-Unboxing checks will raise Exception and **the proccess will be stopped right at that step**.\
 Whereas, an error in Post-Deployment or Post-Unboxing checks will only raise a Warning with the error details to the user and **the process will continue without any break**.
 
 Though these validations have been seamlessly integrated into the code and are handled as part of the process, they can still be invoked directly on the CLI as,
 
 `provisioner check <check_name>`
 
-### Singular Checks
+#### Singular Checks
 
-```
-provisioner check network_drivers
-provisioner check network_hca
-provisioner check storage_hba
-provisioner check storage_luns
-provisioner check luns_mapped
-provisioner check storage_lvms
-provisioner check network
-provisioner check connectivity
-provisioner check bmc_accessibility
-provisioner check bmc_stonith
-provisioner check communicability
-provisioner check cluster_status
-provisioner check passwordless_ssh_access
-provisioner check mgmt_vip
-provisioner check hostnames
-provisioner check public_data_ip
-provisioner check controller_ip
-provisioner check logs_are_good
-```
+    provisioner check network_drivers
+    provisioner check network_hca
+    provisioner check storage_hba
+    provisioner check storage_luns
+    provisioner check luns_mapped
+    provisioner check storage_lvms
+    provisioner check network
+    provisioner check connectivity
+    provisioner check bmc_accessibility
+    provisioner check bmc_stonith
+    provisioner check communicability
+    provisioner check cluster_status
+    provisioner check passwordless_ssh_access
+    provisioner check mgmt_vip
+    provisioner check hostnames
+    provisioner check public_data_ip
+    provisioner check controller_ip
+    provisioner check logs_are_good
 
-### Group Checks
+#### Group Checks
 
-```
-provisioner check deploy_pre_checks
-provisioner check deploy_post_checks
-provisioner check replacenode_checks
-provisioner check swupdate_checks
-provisioner check unboxing_pre_checks
-provisioner check unboxing_post_checks
-```
+    provisioner check deploy_pre_checks
+    provisioner check deploy_post_checks
+    provisioner check replacenode_checks
+    provisioner check swupdate_checks
+    provisioner check unboxing_pre_checks
+    provisioner check unboxing_post_checks
 
 To execute ALL of the above validations, the below command works,
 
-`provisioner check all`  
-
+`provisioner check all`

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_arch_links.md
+++ b/docs/_arch_links.md
@@ -1,0 +1,38 @@
+```{include} ./Architecture/Architectural-Overview.md
+:relative-docs: docs/
+:relative-images:
+```
+
+
+```{include} ./Architecture/CLI.md
+:relative-docs: docs/
+:relative-images:
+```
+
+```{include} ./Architecture/Northbound-Interface.md
+:relative-docs: docs/
+:relative-images:
+```
+
+```{include} ./Architecture/Southbound-Interface.md
+:relative-docs: docs/
+:relative-images:
+```
+
+
+```{include} ./Architecture/SW-Upgrade.md
+:relative-docs: docs/
+:relative-images:
+```
+
+
+```{include} ./Architecture/Validation.md
+:relative-docs: docs/
+:relative-images:
+```
+
+
+```{include} ./Architecture/Test-Guidelines.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/_dev_links.md
+++ b/docs/_dev_links.md
@@ -1,0 +1,19 @@
+```{include} ./mocks.md
+:relative-docs: docs/
+:relative-images:
+```
+
+```{include} ./Development/resources.md
+:relative-docs: docs/
+:relative-images:
+```
+
+```{include} ./Development/testing.md
+:relative-docs: docs/
+:relative-images:
+```
+
+```{include} ./Development/saltstack.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/_user_links.md
+++ b/docs/_user_links.md
@@ -1,0 +1,10 @@
+```{include} ./User-Guides/Deploy VM Hosted Repo.md
+:relative-docs: docs/
+:relative-images:
+```
+
+
+```{include} ./User-Guides/Deploy VM ISO Repo.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,22 @@
+.. _api:
+
+Developer Interface
+===================
+
+.. module:: provisioner
+
+
+Main Interface
+--------------
+
+.. autofunction:: set_api
+.. autofunction:: auth_init
+.. autofunction:: set_ntp
+.. autofunction:: set_network
+.. autofunction:: set_swupdate_repo
+.. autofunction:: sw_update
+
+Exceptions
+----------
+
+.. autoexception:: provisioner.errors.ProvisionerError

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'cortx-prvsnr'
+copyright = '2021, support@seagate.com'
+author = 'support@seagate.com'
+
+# The full version, including alpha/beta/rc tags
+release = '2.0.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'myst_parser'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+#html_static_path = ['_static']
+html_static_path = []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,50 @@
+.. cortx-prvsnr documentation master file, created by
+   sphinx-quickstart on Mon Jun 28 11:08:08 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to cortx-prvsnr's documentation!
+========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   Provisioner-Introduction
+   mini_prvsnr_api
+   design_updates
+
+
+The Architecture
+---------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   _arch_links
+
+
+The User Guide
+---------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   _user_links
+
+The Developer Guide
+---------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   api
+   _dev_links
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/mini_prvsnr_api.md
+++ b/docs/mini_prvsnr_api.md
@@ -1,4 +1,4 @@
-# Provisioner Testing Approaches
+# Provisioner Support for Mini Provisioner API
 
 ## Table of Contents
 
@@ -21,7 +21,7 @@
 
 ## Overview
 
-Provisioner support mini-provisioner interfaces exposed by CORTX componnents
+Provisioner supports mini-provisioner interfaces exposed by CORTX componnents
 (including Provisioner itself).
 
 These interfaces are defined using specification files located in

--- a/docs/mocks.md
+++ b/docs/mocks.md
@@ -14,7 +14,7 @@ For that cases mocked deployment should help. It comes with the following mocks 
   - singlerepo bundle that might be used for a deployment
   - upgrade bundle that might be used for an upgrade routine verification
 
-# SaltStack states
+## SaltStack states
 
 There is a set of SaltStack states that can be applied to:
 - mock a system
@@ -48,7 +48,7 @@ salt "srvnode-1" state.apply components.misc_pkgs.mocks.cortx.build_upgrade \
     pillar='{"inline": {"upgrade_repo_dir": "/tmp/cortx-upgrade"}}'
 ```
 
-# CLI
+## CLI
 
 Under the hood the states above use [buildbundle.sh](srv/components/misc_pkgs/mocks/cortx/files/scripts/buildbundle.sh) script.
 


### PR DESCRIPTION
The change introduces better approach of dosc handling in the repo:

- [sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html)  auotmates docs generation
- usage:
  - enable python3 venv and install provisioner with docs extra: `pip install -e api/python[docs]`
  - generate docs `make -C docs clean html`
  - docs index page would be available at `docs/_build/index.html`
- PR also improves existent docs