### PR TITLE
[EOS-22098][EOS-22032]: Fix get release version API for R2

### DIFF
--- a/api/python/provisioner/commands/release/get_release.py
+++ b/api/python/provisioner/commands/release/get_release.py
@@ -33,7 +33,8 @@ from provisioner.pillar import (
     PillarResolver
 )
 from provisioner.commands._basic import (
-    CommandParserFillerMixin
+    CommandParserFillerMixin,
+    RunArgsBase
 )
 
 from .release import CortxRelease
@@ -65,7 +66,7 @@ class GetRelease(CommandParserFillerMixin):
     @property
     def installed_rpms(self) -> List:
         if self._installed_rpms is None:
-            exclude_rpms = 'cortx-py|prvsnr-cli|cortx-sspl-test'
+            exclude_rpms = config.EXCLUDE_RPMS_RELEASE_VERSION
             res = cmd_run(
                 f"rpm -qa|grep '^cortx-'|grep -Ev '{exclude_rpms}'",
                 targets=local_minion_id()
@@ -130,16 +131,16 @@ class GetRelease(CommandParserFillerMixin):
 @attr.s(auto_attribs=True)
 class GetReleaseLegacy(CommandParserFillerMixin):
     input_type: Type[inputs.NoParams] = inputs.NoParams
-    _run_args_type = None
+    _run_args_type = RunArgsBase
 
-    def run(self):
+    def run(self, targets):
         return json.dumps(GetRelease().run(factory=False))
 
 
 @attr.s(auto_attribs=True)
 class GetFactoryLegacy(CommandParserFillerMixin):
     input_type: Type[inputs.NoParams] = inputs.NoParams
-    _run_args_type = None
+    _run_args_type = RunArgsBase
 
-    def run(self):
+    def run(self, targets):
         return json.dumps(GetRelease().run(factory=True))

--- a/api/python/provisioner/config.py
+++ b/api/python/provisioner/config.py
@@ -779,3 +779,5 @@ MiniAPIHooks = Enum(
     ),
     module=__name__
 )
+
+EXCLUDE_RPMS_RELEASE_VERSION = 'prvsnr-cli|cortx-sspl-test'


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

1. support target parameter in get_release_version API (EOS-22032)
2. Fix get_release_version API which causing issue's to get_iso_version API.