### PR TITLE
fix network configuration issues with prefix

### DIFF
--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -686,6 +686,14 @@ class PrivateDataNetwork(ParamGroupInputBase):
         _param_group, descr="node data network mtu",
         default=1500
     )
+    data_gateway: str = ParamGroupInputBase._attr_ib(
+        _param_group, descr="node data gateway IP",
+        validator=Validation.check_ip4
+    )
+    data_netmask: str = ParamGroupInputBase._attr_ib(
+        _param_group, descr="node data interface netmask",
+        validator=Validation.check_ip4
+    )
 
 
 class ReleaseParams():

--- a/api/python/provisioner/params_spec.yaml
+++ b/api/python/provisioner/params_spec.yaml
@@ -73,6 +73,8 @@ public_data_network:
 private_data_network:
   _path: cluster.sls
   data_private_ip: cluster/srvnode-0/network/data/private_ip
+  data_netmask: cluster/srvnode-0/network/data/netmask
+  data_gateway: cluster/srvnode-0/network/data/gateway
   data_private_interfaces: cluster/srvnode-0/network/data/private_interfaces
   data_mtu: cluster/srvnode-0/network/data/mtu
 

--- a/lr-cli/cortx_setup/commands/node/prepare/network.py
+++ b/lr-cli/cortx_setup/commands/node/prepare/network.py
@@ -134,7 +134,7 @@ class NodePrepareNetwork(Command):
             if not server_type:
                 raise Exception("server_type missing in grains")
             mtu = '1500' if server_type == 'virtual' or network_type == 'management' else '9000'
-            
+
             config_method = 'Static' if ip_address else 'DHCP'
             self.logger.debug(
                 f"Configuring {network_type} network using {config_method} method"

--- a/lr-cli/cortx_setup/commands/node/prepare/network.py
+++ b/lr-cli/cortx_setup/commands/node/prepare/network.py
@@ -133,8 +133,8 @@ class NodePrepareNetwork(Command):
                                 targets=node_id)[f'{node_id}']
             if not server_type:
                 raise Exception("server_type missing in grains")
-            mtu = '9000' if server_type == 'physical' else '1500'
-
+            mtu = '1500' if server_type == 'virtual' or network_type == 'management' else '9000'
+            
             config_method = 'Static' if ip_address else 'DHCP'
             self.logger.debug(
                 f"Configuring {network_type} network using {config_method} method"

--- a/lr-cli/cortx_setup/commands/node/prepare/network.py
+++ b/lr-cli/cortx_setup/commands/node/prepare/network.py
@@ -64,12 +64,6 @@ class NodePrepareNetwork(Command):
             'optional': True,
             'default': "",
             'help': 'IP address'
-        },
-        'mtu': {
-            'type': str,
-            'optional': True,
-            'default': "",
-            'help': 'mtu'
         }
     }
 
@@ -146,7 +140,6 @@ class NodePrepareNetwork(Command):
                         mgmt_public_ip=ip_address,
                         mgmt_netmask=netmask,
                         mgmt_gateway=gateway,
-                        mgmt_mtu=mtu,
                         local=True
                     )
                 elif network_type == 'data':
@@ -154,13 +147,11 @@ class NodePrepareNetwork(Command):
                         data_public_ip=ip_address,
                         data_netmask=netmask,
                         data_gateway=gateway,
-                        data_mtu=mtu,
                         local=True
                     )
                 elif network_type == 'private':
                     set_private_data_network(
                         data_private_ip=ip_address,
-                        data_mtu=mtu,
                         local=True
                     )
             except Exception as ex:

--- a/lr-cli/cortx_setup/commands/node/prepare/network.py
+++ b/lr-cli/cortx_setup/commands/node/prepare/network.py
@@ -64,6 +64,12 @@ class NodePrepareNetwork(Command):
             'optional': True,
             'default': "",
             'help': 'IP address'
+        },
+        'mtu': {
+            'type': str,
+            'optional': True,
+            'default': "",
+            'help': 'mtu'
         }
     }
 
@@ -140,6 +146,7 @@ class NodePrepareNetwork(Command):
                         mgmt_public_ip=ip_address,
                         mgmt_netmask=netmask,
                         mgmt_gateway=gateway,
+                        mgmt_mtu=mtu,
                         local=True
                     )
                 elif network_type == 'data':
@@ -147,11 +154,13 @@ class NodePrepareNetwork(Command):
                         data_public_ip=ip_address,
                         data_netmask=netmask,
                         data_gateway=gateway,
+                        data_mtu=mtu,
                         local=True
                     )
                 elif network_type == 'private':
                     set_private_data_network(
                         data_private_ip=ip_address,
+                        data_mtu=mtu,
                         local=True
                     )
             except Exception as ex:

--- a/srv/components/system/network/data/direct/init.sls
+++ b/srv/components/system/network/data/direct/init.sls
@@ -43,7 +43,7 @@ Private data network configuration:
     - netmask: {{ pillar['cluster'][node]['network']['data']['netmask'] }}
 {%- endif %}
 {% if pillar['cluster'][node]['network']['data']['gateway'] %}
-    - gateway: {{ pillar['cluster'][grains['id']]['network']['data']['gateway'] }}
+    - gateway: {{ pillar['cluster'][node]['network']['data']['gateway'] }}
 {% endif %}
 {%- else %}
     - proto: dhcp

--- a/srv/components/system/network/data/direct/init.sls
+++ b/srv/components/system/network/data/direct/init.sls
@@ -35,11 +35,16 @@ Private data network configuration:
     - nm_controlled: no
     - peerdns: no
     - userctl: no
-    - prefix: 24
 {% if pillar['cluster'][node]['network']['data']['private_ip'] %}
     - proto: none
     - ipaddr: {{ pillar['cluster'][node]['network']['data']['private_ip'] }}
     - mtu: {{ pillar['cluster'][node]['network']['data']['mtu'] }}
+{% if pillar['cluster'][node]['network']['data']['netmask'] %}
+    - netmask: {{ pillar['cluster'][node]['network']['data']['netmask'] }}
+{%- endif %}
+{% if pillar['cluster'][node]['network']['data']['gateway'] %}
+    - gateway: {{ pillar['cluster'][grains['id']]['network']['data']['gateway'] }}
+{% endif %}
 {%- else %}
     - proto: dhcp
 {%- endif %}


### PR DESCRIPTION
Fixed below network configurations:
1. Remove statically added prefix value from srv/components/system/network/data/direct.sls
2. Update `netmask` and `gateway` for private_data network.


Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>