### PR TITLE
Fixes related to resource discover and show api

### DIFF
--- a/lr-cli/cortx_setup/commands/resource/discover.py
+++ b/lr-cli/cortx_setup/commands/resource/discover.py
@@ -31,7 +31,7 @@ class ResourceDiscover(Command):
         self.logger.debug("Running resource discover command")
         # Currently since this is a bug once fixed (EOS-20937)
         # we wont be needing to provide any parameter
-        request_id = int(Discovery.generate_node_health(rpath=resource_type))
+        request_id = Discovery.generate_node_health(rpath=resource_type)
         self.logger.debug(f"Requestid for resource map - {request_id}")
 
         while retries > 0:

--- a/lr-cli/cortx_setup/commands/resource/show.py
+++ b/lr-cli/cortx_setup/commands/resource/show.py
@@ -75,7 +75,7 @@ class ResourceShow(Command):
             'type': str,
             'default': None,
             'optional': True,
-            'help': 'Resource type for which resource map is to be fetched e.g node>compute[0]>hw>disks or node>compute[0]'
+            'help': "Resource type for which resource map is to be fetched e.g 'node>compute[0]>hw>disks' or 'node>compute[0]' or 'node>storage[0]>hw>controllers'"
         },
         'resource_state': {
             'type': str,

--- a/lr-cli/cortx_setup/commands/storage/config.py
+++ b/lr-cli/cortx_setup/commands/storage/config.py
@@ -19,9 +19,12 @@ from pathlib import Path
 from ..command import Command
 from cortx.utils.conf_store import Conf
 from cortx.utils.security.cipher import Cipher
-from cortx_setup.commands.common_utils import get_machine_id
+from cortx_setup.commands.common_utils import (
+    get_machine_id,
+    get_pillar_data,
+    encrypt_secret
+)
 from cortx_setup.validate import ipv4
-from cortx_setup.commands.common_utils import get_pillar_data
 from collections import OrderedDict
 from provisioner.commands import PillarSet
 from provisioner.salt import cmd_run, local_minion_id
@@ -187,7 +190,7 @@ class StorageEnclosureConfig(Command):
         )
 
         if(key=='password'):
-            value = self.encrypt_password(value)
+            value = encrypt_secret(value, "storage_enclosure", self.enclosure_id)
 
         if key == "cvg":
             value = str(value)
@@ -206,17 +209,6 @@ class StorageEnclosureConfig(Command):
         file = open(enc_file_path, "w")
         file.write(self.enclosure_id)
         file.close()
-
-    def encrypt_password(self, password):
-        """Returns encrypted password as string"""
-
-        cipher_key = Cipher.generate_key(self.enclosure_id, "storage")
-        return str(
-            Cipher.encrypt(
-                cipher_key, bytes(password, 'utf-8')
-            ),
-            'utf-8'
-        )
 
     def run(self, **kwargs):
         # valid combinations for cortx_setup storage config

--- a/srv/components/system/config/hosts.sls
+++ b/srv/components/system/config/hosts.sls
@@ -59,7 +59,7 @@ Hostsfile update for data interfaces:
         {{ grains['ip4_interfaces']['data0'][0] }}    {{ srvnode }}    {{ srvnode }}.data.public
         {%- else %}
           {%- if pillar['cluster'][srvnode]['network']['data']['public_ip'] %}
-        {{ pillar['cluster'][srvnode]['network']['data']['public_ip'] }}    {{ srvnode }}    {{ srvnode }}.data.public
+        {{ pillar['cluster'][srvnode]['network']['data']['public_ip'] }}    {{ srvnode }}.data.public
           {%- else %}
         {{ ip_data[pillar['cluster'][srvnode]['network']['data']['public_interfaces'][0]][0] }}    {{ srvnode }}.data.public
           {%- endif %}


### PR DESCRIPTION
This PR has fixes for -
1. enclosure password encryption into confstore was using wrong key. should have been 'storage_enclosure' instead of 'storage'
2. not parsing request id received from resource discovery
3. removing srvnode-1 mapping in etc hosts with public data ip
Signed-off-by: sradhanandpati <sradhanand.pati@seagate.com>