### PR TITLE
[EOS-19899] : Node cli framework for captive CLI

### DIFF
--- a/node_cli/__init__.py
+++ b/node_cli/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#

--- a/node_cli/client.py
+++ b/node_cli/client.py
@@ -1,0 +1,50 @@
+# CORTX-Py-Utils: CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from importlib import import_module
+
+
+class Client:
+    """ Base class for invoking business logic functionality """
+
+    def __init__(self, url):
+        self._url = url
+
+    def call(self, command):
+        pass
+
+
+class CliClient(Client):
+    """Class Handles Direct Calls for CLI"""
+    def __init__(self):
+        super(CliClient, self).__init__(None)
+
+    def call(self, command):
+        module_obj = import_module(command.comm.get("target"))
+        command_args = list(command.options.keys())
+        exclude_args = ['format', 'comm', 'output',
+                        'need_confirmation', 'sub_command_name']
+        command_args = {arg: command.options.get(arg)
+                        for arg in command.options.keys()
+                        if arg not in exclude_args}
+
+        if command.comm.get("class", None):
+            if command.comm.get("is_static", False):
+                target = getattr(module_obj, command.comm.get("class"))
+            else:
+                target = getattr(module_obj, command.comm.get("class"))()
+        else:
+            target = module_obj
+        return getattr(target, command.comm.get("method"))(**command_args)

--- a/node_cli/config.py
+++ b/node_cli/config.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+PROMPT_DESC = 'Node cli interface'
+TERMINAL = 'nodecli>> '
+
+# Log file configuration
+LOG_PATH = '/var/log/seagate/provisioner/'
+BACKUP_FILE_COUNT = 10
+FILE_SIZE = 10
+LOG_LEVEL = 'INFO'
+
+
+# permissions
+permissions = {
+                  'node': {'bypass': True},
+                  'cluster': {'bypass': True},
+                  'storageset': {'bypass': True}
+              }

--- a/node_cli/nodecli.py
+++ b/node_cli/nodecli.py
@@ -86,7 +86,7 @@ class NodeCli(Cmd):
             channel_name = f"""process_{command.comm.get("type", "")}_command"""
             if not hasattr(self, channel_name):
                 err_str = f"Invalid communication protocol {command.comm.get('type','')} selected."
-                sys.stderr(err_str)
+                raise Exception(err_str)
             getattr(self, channel_name)(command)
             Log.debug(f"{cmd}: Command executed")
         except SystemExit:
@@ -96,6 +96,7 @@ class NodeCli(Cmd):
             self.do_exit()
         except Exception as e:
             Log.critical(f"{e}")
+            print(str(e))
 
     def do_exit(self, args=""):
         sys.exit()

--- a/node_cli/nodecli.py
+++ b/node_cli/nodecli.py
@@ -20,7 +20,6 @@ import os
 import shlex
 from cmd import Cmd
 import pathlib
-from node_cli import config
 from pathlib import Path
 
 
@@ -100,9 +99,10 @@ class NodeCli(Cmd):
 
 
 if __name__ == '__main__':
-    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..'))
-    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(os.path.realpath(__file__))), '..', '..'))
+    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..'))
+    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(os.path.realpath(__file__))), '..'))
     from cortx.utils.cli_framework.command_factory import CommandFactory
+    from node_cli import config
     from node_cli.client import CliClient
     from cortx.utils.log import Log
     try:

--- a/node_cli/nodecli.py
+++ b/node_cli/nodecli.py
@@ -59,11 +59,6 @@ class NodeCli(Cmd):
     def emptyline(self):
         pass
 
-    def precmd(self, command):
-        if command.strip():
-            self.args = shlex.split(command)
-        return command
-
     def process_direct_command(self, command):
         obj = CliClient()
         response = obj.call(command)
@@ -76,6 +71,8 @@ class NodeCli(Cmd):
 
     def default(self, cmd):
         try:
+            if cmd.strip():
+                self.args = shlex.split(cmd)
             parent = Path(__file__).resolve().parent
             cmd_dir = str(Path(parent / 'schema'))
             # permission to fit in cli framework

--- a/node_cli/nodecli.py
+++ b/node_cli/nodecli.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import sys
+import os
+import shlex
+from cmd import Cmd
+import pathlib
+from node_cli import config
+from pathlib import Path
+
+
+class Response(object):
+    def __init__(self, rc=0, output=''):
+        self._rc = int(rc)
+        self._output = output
+
+    def output(self):
+        return self._output
+
+    def rc(self):
+        return self._rc
+
+    def __str__(self):
+        return '%d: %s' % (self._rc, self._output)
+
+
+class NodeCli(Cmd):
+    def __init__(self, args):
+        super(NodeCli, self).__init__()
+        self.intro = config.PROMPT_DESC
+        self.prompt = config.TERMINAL
+        if len(args) > 1:
+            self.args = args[1:]
+        else:
+            self.args = "help"
+
+    def preloop(self):
+        Log.init("nodecli",
+                 backup_count=config.BACKUP_FILE_COUNT,
+                 file_size_in_mb=config.FILE_SIZE,
+                 log_path=config.LOG_PATH,
+                 level=config.LOG_LEVEL)
+
+    def emptyline(self):
+        pass
+
+    def precmd(self, command):
+        if command.strip():
+            self.args = shlex.split(command)
+        return command
+
+    def process_direct_command(self, command):
+        obj = CliClient()
+        response = obj.call(command)
+        if response:
+            # convert dict response in Response object
+            # to fit in cli framework format.
+            response = Response(output=response)
+            command.process_response(out=sys.stdout, err=sys.stderr,
+                                     response=response)
+
+    def default(self, cmd):
+        try:
+            parent = Path(__file__).resolve().parent
+            cmd_dir = str(Path(parent / 'schema'))
+            # permission to fit in cli framework
+            permissions = config.permissions
+            command = CommandFactory.get_command(self.args,
+                                                 component_cmd_dir=cmd_dir,
+                                                 permissions=permissions)
+            channel_name = f"""process_{command.comm.get("type", "")}_command"""
+            if not hasattr(self, channel_name):
+                err_str = f"Invalid communication protocol {command.comm.get('type','')} selected."
+                sys.stderr(err_str)
+            getattr(self, channel_name)(command)
+            Log.debug(f"{cmd}: Command executed")
+        except SystemExit:
+            Log.debug(f" Command executed system exit")
+        except KeyboardInterrupt:
+            Log.debug(f"Stopped via keyboard interrupt.")
+            self.do_exit()
+        except Exception as e:
+            Log.critical(f"{e}")
+
+    def do_exit(self, args=""):
+        sys.exit()
+
+
+if __name__ == '__main__':
+    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..'))
+    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(os.path.realpath(__file__))), '..', '..'))
+    from cortx.utils.cli_framework.command_factory import CommandFactory
+    from node_cli.client import CliClient
+    from cortx.utils.log import Log
+    try:
+        NodeCli(sys.argv).cmdloop()
+    except KeyboardInterrupt:
+        Log.debug(f"Stopped via keyboard interrupt.")
+        sys.stdout.write("\n")
+    except Exception as e:
+        Log.critical(f"{e}")
+        sys.stderr.write('Some error occurred.\nPlease try login again.\n')

--- a/node_cli/nodecli.py
+++ b/node_cli/nodecli.py
@@ -69,10 +69,10 @@ class NodeCli(Cmd):
             command.process_response(out=sys.stdout, err=sys.stderr,
                                      response=response)
 
-    def default(self, cmd):
+    def default(self, line):
         try:
-            if cmd.strip():
-                self.args = shlex.split(cmd)
+            if line.strip():
+                self.args = shlex.split(line)
             parent = Path(__file__).resolve().parent
             cmd_dir = str(Path(parent / 'schema'))
             # permission to fit in cli framework
@@ -85,7 +85,7 @@ class NodeCli(Cmd):
                 err_str = f"Invalid communication protocol {command.comm.get('type','')} selected."
                 raise Exception(err_str)
             getattr(self, channel_name)(command)
-            Log.debug(f"{cmd}: Command executed")
+            Log.debug(f"{line}: Command executed")
         except SystemExit:
             Log.debug(f" Command executed system exit")
         except KeyboardInterrupt:

--- a/node_cli/schema/cluster.json
+++ b/node_cli/schema/cluster.json
@@ -1,0 +1,48 @@
+{
+  "name": "cluster",
+  "description": "Cluster commands",
+  "sub_commands": [
+    {
+      "name": "show",
+      "description": "CLuster show command",
+      "permissions_tag": "bypass",
+      "args": [
+           {
+              "flag": "args",
+              "default": [],
+              "suppress_help": true,
+              "nargs": "?",
+              "help": ""
+           },
+           {
+              "flag": "-f",
+              "dest": "format",
+              "help": "Format of Output",
+              "default": "table",
+              "type": "str",
+              "choices": [
+              "table",
+              "xml",
+              "json"
+              ]
+            }
+      ],
+      "comm": {
+              "type": "direct",
+              "target": "cortx_setup.commands",
+              "method": "run",
+              "class": "ClusterShow"
+           },
+      "output": {
+        "table": {
+          "headers": {
+            "cluster_nodes": "cluster nodes",
+            "non_cluster_nodes": "non cluster nodes"
+          }
+        }
+      }
+
+
+   }
+ ]
+}

--- a/node_cli/schema/cluster.json
+++ b/node_cli/schema/cluster.json
@@ -4,7 +4,7 @@
   "sub_commands": [
     {
       "name": "show",
-      "description": "CLuster show command",
+      "description": "Cluster show command",
       "permissions_tag": "bypass",
       "args": [
            {

--- a/node_cli/schema/node.json
+++ b/node_cli/schema/node.json
@@ -1,0 +1,39 @@
+{
+  "name": "node",
+  "description": "Node commands",
+  "sub_commands": [
+    {
+      "name": "prepare",
+      "description": "Node preparation",
+      "permissions_tag": "bypass",
+      "sub_commands": [
+         {
+           "name": "network",
+           "description": "Node network configuration",
+           "permissions_tag": "bypass",
+           "args": [
+           {
+             "flag": "--hostname",
+             "type": "str",
+             "help": "Specify the hostname for system"
+           },
+           {
+              "flag": "args",
+              "default": [],
+              "suppress_help": true,
+              "nargs": "?",
+              "help": ""
+           }
+           ],
+           "comm": {
+              "type": "direct",
+              "target": "cortx_setup.commands",
+              "method": "run",
+              "class": "NodePrepareNetwork"
+           }
+
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: mazinamdar <mazhar.inamdar@seagate.com>

To run nodecli in dev mode:
``` 
checkout cortx-prvsnr code
cp -r node_cli  /opt/seagate/cortx/provisioner/
export PYTHONPATH='/opt/seagate/cortx/provisioner/' 
python3 /opt/seagate/cortx/provisioner/node_cli/nodecli.py
```

Sample nodecli commands:
```
node prepare network --hostname ssc-vm-rhev4-0315.colo.seagate.com
cluster show
```
 