### PR TITLE
EOS-22119: Use cluster_manager start api instead of unstandby

### DIFF
--- a/api/python/provisioner/commands/upgrade/sw_upgrade.py
+++ b/api/python/provisioner/commands/upgrade/sw_upgrade.py
@@ -57,7 +57,6 @@ from provisioner.cortx_ha import (
     cluster_stop,
     cluster_standby,
     cluster_start,
-    cluster_unstandby,
     is_cluster_healthy
 )
 

--- a/api/python/provisioner/commands/upgrade/sw_upgrade.py
+++ b/api/python/provisioner/commands/upgrade/sw_upgrade.py
@@ -271,7 +271,7 @@ class SWUpgrade(CommandParserFillerMixin):
         )
 
         logger.info("Starting the Cortx cluster")
-        cluster_unstandby()
+        cluster_start()
         # cluster_start(unstandby=False)
 
         # TODO make the folllowing a part of migration

--- a/api/python/provisioner/cortx_ha.py
+++ b/api/python/provisioner/cortx_ha.py
@@ -280,6 +280,10 @@ class ClusterManagerCortxAPI(ClusterManagerCortxBase):
     def cluster_unstandby(self):
         super().cluster_unstandby()
 
+    @_call_ha_api_carefully
+    def cluster_start(self):
+        super().cluster_start()
+
 
 class ClusterManagerBroker(ClusterManagerBase):
     _pcs = None


### PR DESCRIPTION
Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>