### PR TITLE
EOS-22276 default values removed for dns_servers and search_domains (…

### DIFF
--- a/lr-cli/cortx_setup/commands/node/prepare/network.py
+++ b/lr-cli/cortx_setup/commands/node/prepare/network.py
@@ -70,15 +70,13 @@ class NodePrepareNetwork(Command):
             'type': str,
             'nargs': '+',
             'optional': True,
-            'default': "",
-            'help': 'DNS server'
+            'help': 'List of DNS servers for the provided network, given space-separated'
         },
         'search_domains': {
             'type': host,
             'nargs': '+',
             'optional': True,
-            'default': "",
-            'help': 'Search domain list'
+            'help': 'List of Search domains for the provided network, given space-separated'
         },
     }
 


### PR DESCRIPTION
…#1497)

* EOS-22276 default values removed for dns_servers and search_domains

Signed-off-by: zahid.shaikh <zahid.shaikh@seagate.com>

* EOS-22276 comments incorporated

Signed-off-by: zahid.shaikh <zahid.shaikh@seagate.com>