### PR TITLE
EOS-23002: Node Health - Resource health status is coming as 'NA' for 'inactive' services and other resources

### DIFF
--- a/lr-cli/cortx_setup/commands/resource/show.py
+++ b/lr-cli/cortx_setup/commands/resource/show.py
@@ -81,8 +81,7 @@ class ResourceShow(Command):
             'type': str,
             'default': None,
             'optional': True,
-            'choices': ['OK', 'FAULT', 'DEGRADED'],
-            'help': 'The current state of the resources'
+            'help': "The current state of the resources  like 'OK', 'FAULT', 'DEGRADED', 'NA', 'INACTIVE', 'UNKNOWN'"
         },
     }
 


### PR DESCRIPTION
Signed-off-by: sradhanandpati <sradhanand.pati@seagate.com>