### PR TITLE
EOS-23507: Use current user for field deployment

### DIFF
--- a/api/python/provisioner/commands/bootstrap_provisioner.py
+++ b/api/python/provisioner/commands/bootstrap_provisioner.py
@@ -985,8 +985,7 @@ class BootstrapProvisioner(SetupCmdBase, CommandParserFillerMixin):
             ssh_client.cmd_run(
                 (
                     'provisioner pillar_set --fpath release.sls'
-                    ' release/type '
-                    f"\"{run_args.dist_type.value}\""
+                    f' release/type \'"{run_args.dist_type.value}"\''
                 ), targets=run_args.primary.minion_id
             )
 
@@ -996,7 +995,7 @@ class BootstrapProvisioner(SetupCmdBase, CommandParserFillerMixin):
                     (
                         'provisioner pillar_set --fpath release.sls'
                         ' release/deps_bundle_url '
-                        f"\"{run_args.url_cortx_deps}\""
+                        f'\'"{run_args.url_cortx_deps}"\''
                     ), targets=run_args.primary.minion_id
                 )
 
@@ -1005,8 +1004,7 @@ class BootstrapProvisioner(SetupCmdBase, CommandParserFillerMixin):
                 ssh_client.cmd_run(
                     (
                         'provisioner pillar_set --fpath release.sls'
-                        ' release/target_build '
-                        f"\"{run_args.target_build}\""
+                        f' release/target_build \'"{run_args.target_build}"\''
                     ), targets=run_args.primary.minion_id
                 )
 

--- a/api/python/provisioner/inputs.py
+++ b/api/python/provisioner/inputs.py
@@ -435,7 +435,10 @@ class PillarInputBase(PillarItemsAPI):
     value: Any = attr.ib(
         metadata={
             METADATA_ARGPARSER: {
-                'help': 'pillar value'
+                'help': 'pillar value',
+                'type': functools.partial(
+                    AttrParserArgs.value_from_str, v_type='json'
+                )
             }
         }
     )

--- a/lr-cli/cortx_setup/commands/cluster/encrypt.py
+++ b/lr-cli/cortx_setup/commands/cluster/encrypt.py
@@ -34,7 +34,8 @@ class EncryptSecrets(Command):
     def run(self, targets=ALL_MINIONS, **kwargs):
 
         self.provisioner = provisioner
-        self.provisioner.auth_init(kwargs['username'], kwargs['password'])
+        if 'username' in kwargs:
+            self.provisioner.auth_init(kwargs['username'], kwargs['password'])
 
         try:
             self.logger.debug("Encrypting config data")

--- a/lr-cli/cortx_setup/commands/cluster/generate.py
+++ b/lr-cli/cortx_setup/commands/cluster/generate.py
@@ -35,7 +35,8 @@ class GenerateCluster(Command):
     def run(self, **kwargs):
 
         self.provisioner = provisioner
-        self.provisioner.auth_init(kwargs['username'], kwargs['password'])
+        if 'username' in kwargs:
+            self.provisioner.auth_init(kwargs['username'], kwargs['password'])
 
         try:
             self.logger.debug("Generating cluster pillar")


### PR DESCRIPTION
Addressed:
1. Use current user for field deployment
2. setup_provisioner command failure

Signed-off-by: Anjali Somwanshi <anjali.somwanshi@seagate.com>