### PR TITLE
EOS-23534: use uuid as name of profile directory in setup_provisioner

### DIFF
--- a/api/python/provisioner/commands/setup_provisioner.py
+++ b/api/python/provisioner/commands/setup_provisioner.py
@@ -487,9 +487,7 @@ class SetupCmdBase:
             run_args.profile.name if run_args.profile else run_args.name
         )
         if not res:
-            res = '__'.join(
-                [str(node) for node in run_args.nodes]
-            ).replace(':', '_')
+            res = str(uuid.uuid4())
         return res
 
 # TODO TEST EOS-8473


### PR DESCRIPTION
EOS-23534: use uuid as name of profile directory in setup_provisioner
Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>