### PR TITLE
EOS-23606: Add support to add more than 3 nodes in storage set (#6086)

### DIFF
--- a/lr-cli/cortx_setup/commands/storageset/config/durability.py
+++ b/lr-cli/cortx_setup/commands/storageset/config/durability.py
@@ -109,6 +109,8 @@ class DurabilityConfig(Command):
                 )
 
             confstore_durability_key = f'cluster>{cluster_id}>storage_set[{storage_set_index}]>durability'
+            #TODO: Get node list for storage_set_name provided and update
+            # durability dict to only those nodes.
             pillar_durability_key = 'cluster/srvnode-1/storage/durability'
 
             PillarSet().run(

--- a/lr-cli/cortx_setup/commands/storageset/create.py
+++ b/lr-cli/cortx_setup/commands/storageset/create.py
@@ -65,15 +65,28 @@ class CreateStorageSet(Command):
                 name
             )
 
-            # Not updating node count to Confstore
+            #Not updating node count to Confstore
+            #TODO: Handle scenario for multiple storagesets
             PillarSet().run(
                 'cluster/storage_set/count',
                 count
             )
 
+            try:
+                tot_storageset = Conf.get (
+                    'storage_create_index',
+                    f'cluster>{cluster_id}>storage_set'
+                )
+                storage_set_index = len(tot_storageset)
+            except Exception:
+                self.logger.debug(
+                    "No storage_set in confstore, setting storage_set_index to 0"
+                    )
+                storage_set_index = 0
+
             Conf.set(
                 index,
-                f'cluster>{cluster_id}>storage_set[0]>name',
+                f'cluster>{cluster_id}>storage_set[{storage_set_index}]>name',
                 name
             )
 

--- a/srv/components/provisioner/files/cluster_sls.template
+++ b/srv/components/provisioner/files/cluster_sls.template
@@ -21,15 +21,6 @@ cluster:
   mgmt_vip: 
   search_domains:                     # Do not update
   dns_servers:                        # Do not update
-  storage_sets:
-    {%- for node_num in range(num_of_nodes) %}
-    {%- if (node_num + 1) % 3 == 1 %}
-    {%- set storage_set_id = "storage-set-" + ((node_num // 3) + 1)| string %}
-    {{  storage_set_id }}:
-    {%- endif %}
-      {%- set srvnode = "srvnode-" + ((node_num + 1) | string) %}
-      - {{ srvnode }}
-    {%- endfor %}
   server_nodes:
     {%- for node_num in range(num_of_nodes) %}
     {%- set node = "srvnode-" + ((node_num + 1) | string) %}
@@ -37,11 +28,9 @@ cluster:
     {%- endfor %}
   {%- for node_num in range(num_of_nodes) %}
   {%- set srvnode = "srvnode-" + ((node_num + 1) | string) %}
-  {%- set storage_set_id = "storage-set-" + ((node_num // 3) + 1)| string %}
   {{ srvnode }}:
     rack_id: 1
     site_id: 1
-    storage_set_id: {{ storage_set_id }}
     node_id: {{ node_num }}
     machine_id: {{ salt['mine.get'](srvnode , 'node_machine_id')[srvnode] }}
     hostname: {{ srvnode }}

--- a/srv/components/system/files/confstore_template.j2
+++ b/srv/components/system/files/confstore_template.j2
@@ -29,7 +29,6 @@ cluster>{{ cluster_id }}>name=>{{ pillar['cluster']['name'] }}
 cluster>{{ cluster_id }}>name=>{{ pillar['corosync-pacemaker']['cluster_name'] }}
 {% endif %}
 cluster>{{ cluster_id }}>site_count=>1
-cluster>{{ cluster_id }}>site>storage_set_count=>{{ pillar['cluster']['storage_sets'].keys() | length }}
 {% set mgmt_vip = salt['mine.get']('srvnode-1', 'node_ip_addrs') | dictsort() %}
 cluster>{{ cluster_id }}>network>management>virtual_host=>{{ pillar['cluster']['mgmt_vip'] if pillar['cluster']['mgmt_vip'] else mgmt_vip[0][1][pillar['cluster']['srvnode-1']['network']['mgmt']['interfaces'][0]][0] }}
 {%- if pillar['cluster']['search_domains'] %}
@@ -46,19 +45,6 @@ cluster>{{ cluster_id }}>network>dns_servers[{{ loop.index - 1 }}]=>{{ dns }}
 {%- else %}
 cluster>{{ cluster_id }}>network>dns_servers=>{{ pillar['cluster']['dns_servers'] }}
 {%- endif %}
-{%- for storage_set in pillar['cluster']['storage_sets'].keys() %}
-{%- set outer_loop = loop %}
-cluster>{{ cluster_id }}>storage_set[{{ outer_loop.index - 1 }}]>name=>{{ storage_set }}
-{%- for node in pillar['cluster']['storage_sets'][storage_set] %}
-cluster>{{ cluster_id }}>storage_set[{{ outer_loop.index - 1 }}]>server_nodes[{{ loop.index - 1 }}]=>{{ pillar['cluster'][node]['machine_id'] }}
-cluster>{{ cluster_id }}>storage_set[{{ outer_loop.index - 1 }}]>storage_enclosures[{{ loop.index - 1 }}]=>{{ pillar['storage'][pillar['cluster'][node]['storage']['enclosure']]['enclosure_id'] }}
-{%- endfor %}
-{%- for durability_type in pillar['cluster']['srvnode-1']['storage']['durability'] %}
-cluster>{{ cluster_id }}>storage_set[{{ outer_loop.index - 1 }}]>durability>{{ durability_type }}>data=>{{ pillar['cluster']['srvnode-1']['storage']['durability'][durability_type]['data'] }}
-cluster>{{ cluster_id }}>storage_set[{{ outer_loop.index - 1 }}]>durability>{{ durability_type }}>parity=>{{ pillar['cluster']['srvnode-1']['storage']['durability'][durability_type]['parity'] }}
-cluster>{{ cluster_id }}>storage_set[{{ outer_loop.index - 1 }}]>durability>{{ durability_type }}>spare=>{{ pillar['cluster']['srvnode-1']['storage']['durability'][durability_type]['spare'] }}
-{%- endfor %}
-{%- endfor %}
 {%- for machine_id, node in pillar['cluster']['server_nodes'].items() %}
 server_node>{{ machine_id }}>name=>{{ node }}
 server_node>{{ machine_id }}>hostname=>{{ pillar['cluster'][node]['hostname'] }}
@@ -112,7 +98,6 @@ server_node>{{ machine_id }}>storage>enclosure_id=>{{ pillar['storage'][pillar['
 server_node>{{ machine_id }}>site_id=>{{ pillar['cluster'][node]['site_id'] }}
 server_node>{{ machine_id }}>rack_id=>{{ pillar['cluster'][node]['rack_id'] }}
 server_node>{{ machine_id }}>node_id=>{{ pillar['cluster'][node]['node_id'] }}
-server_node>{{ machine_id }}>storage_set_id=>{{ pillar['cluster'][node]['storage_set_id'] }}
 server_node>{{ machine_id }}>cluster_id=>{{ cluster_id }}
 server_node>{{ machine_id }}>s3_instances=>{{ pillar['cluster'][node]['s3_instances'] }}
 {%- endfor %}
@@ -123,7 +108,6 @@ storage_enclosure>{{ pillar['storage'][enclosure]['enclosure_id'] }}>cluster_id=
 {%- for _,node in pillar['cluster']['server_nodes'].items() %}
 {%- if pillar['cluster'][node]['storage']['enclosure'] == enclosure %}
 storage_enclosure>{{ pillar['storage'][enclosure]['enclosure_id'] }}>site_id=>{{ pillar['cluster'][node]['site_id'] }}
-storage_enclosure>{{ pillar['storage'][enclosure]['enclosure_id'] }}>storage_set_id=>{{ pillar['cluster'][node]['storage_set_id'] }}
 {%- endif %}
 {%- endfor %}
 storage_enclosure>{{ pillar['storage'][enclosure]['enclosure_id'] }}>controller>type=>{{ pillar['storage'][enclosure]['controller']['type'] }}


### PR DESCRIPTION
* EOS-23606: Support to add more than 3 nodes in one storage set

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

* EOS-23606: add storage set details in confstore, remove hardcoding.

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

* EOS-23606: fix bugs found in testing.

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

* EOS-23606: Fix bugs

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

* EOS-23606: Address Codacy issues.

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

* EOS-23606: address review comment

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

* EOS-23606: Handle exception gracefully

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

* EOS-23606: Addressed code reivew changes.

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>