### PR TITLE
EOS-23586: Make role of all nodes as OpenLDAP servers in the cluster.

### DIFF
--- a/srv/components/provisioner/files/cluster_sls.template
+++ b/srv/components/provisioner/files/cluster_sls.template
@@ -36,16 +36,14 @@ cluster:
     hostname: {{ srvnode }}
     node_type: {{ "HW" if "physical" in grains["virtual"] else "VM" }}
     roles:
+      - openldap_server
       {% if 0 == node_num %}
       - primary
       {% else %}
       - secondary
       {% endif %}
       {%- if 0 == (node_num // 3) %}
-      - openldap_server
       - kafka_server
-      {%- else %}
-      - openldap_client
       {%- endif %}
     {%- if 0 == node_num %}
     is_primary: True


### PR DESCRIPTION
Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>
After the change, this is how the roles for each node in the configuration would look like:
cluster:
server_nodes:
  srvnode-1:

    roles:
      - openldap_server
      - primary
      - kafka_server
    is_primary:·True

  srvnode-2:
    roles:
      - openldap_server
      - secondary
      - kafka_server
    is_primary:·False

  srvnode-3:
    roles:
      - openldap_server
      - secondary
      - kafka_server
    is_primary:·False

  srvnode-4:
    roles:
      - openldap_server
      - secondary
    is_primary:·False

  srvnode-5:
    roles:
      - openldap_server
      - secondary
    is_primary:·False
