### PR TITLE
EOS-24770: Add machne-id to each POD in kubernetes cluster

### DIFF
--- a/test/deploy/k8s/cluster.yaml
+++ b/test/deploy/k8s/cluster.yaml
@@ -43,16 +43,16 @@ cluster:
         sns: 8+7+0
         dix: 1+7+0
       nodes:
-        - name: pod-1
-          id: 1
+        - name: podnode-0
+          id: 1111
           hostname: pod-1.colo.seagate.com
           type: storage_node
-        - name: pod-2
-          id: 2
+        - name: podnode-1
+          id: 2222
           hostname: pod-2.colo.seagate.com
           type: control_node
-        - name: pod-*          # TBD: Future Optimization
-          id: 3
+        - name: podnode-2          # TBD: Future Optimization
+          id: 3333
           hostname: pod-*.colo.seagate.com
           type: storage_node
           index: 0-14

--- a/test/deploy/k8s/cortx-statefulset.yml
+++ b/test/deploy/k8s/cortx-statefulset.yml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: cortx-provisioner
+  name: podnode
   labels:
     app: cortx-provisioner
 spec:
+  serviceName: "cortx-provisioner"
   replicas: 1
   selector:
     matchLabels:
@@ -24,6 +25,12 @@ spec:
       - name: cortx-secret
         secret:
           secretName: cortx-secret
+      - name: podinfo
+        downwardAPI:
+          items:
+          - path: "name"
+            fieldRef:
+              fieldPath: metadata.name
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -41,6 +48,7 @@ spec:
         - set -x;
           export PATH=$PATH:/opt/seagate/cortx/provisioner/bin;
           CORTX_CONF=yaml:/etc/cortx/cluster.conf;
+          cat /etc/cortx/solution/cluster.yaml | grep -A 1 `cat /etc/podinfo/name` | grep id | awk {'print $2'} > /etc/machine-id;
           cortx_setup config apply -f yaml:///etc/cortx/solution/config.yaml -o $CORTX_CONF;
           cortx_setup config apply -f yaml:///etc/cortx/solution/cluster.yaml -o $CORTX_CONF;
           cortx_setup cluster bootstrap '1111' $CORTX_CONF;
@@ -53,5 +61,5 @@ spec:
           mountPath: /etc/cortx/solution
         - name: cortx-config
           mountPath: /etc/cortx
-        - name: cortx-secret
-          mountPath: /etc/cortx/secret
+        - name: podinfo
+          mountPath: /etc/podinfo

--- a/test/deploy/k8s/deploy.sh
+++ b/test/deploy/k8s/deploy.sh
@@ -4,14 +4,15 @@ SCRIPT_DIR=$(dirname $0)
 kubectl create namespace cortx
 kubectl create cm solution-config --from-file="$SCRIPT_DIR"/cluster.yaml \
     --from-file="$SCRIPT_DIR"/config.yaml --namespace cortx
-#kubectl apply -f "$SCRIPT_DIR"/cortx-cm-machine-id.yml --namespace cortx
+
 kubectl apply -f "$SCRIPT_DIR"/cortx-secret.yml --namespace cortx
 kubectl apply -f "$SCRIPT_DIR"/cortx-pv-config.yml --namespace cortx
 kubectl apply -f "$SCRIPT_DIR"/cortx-pvc-config.yml --namespace cortx
-kubectl apply -f "$SCRIPT_DIR"/cortx-deployment.yml --namespace cortx
+kubectl apply -f "$SCRIPT_DIR"/cortx-statefulset.yml --namespace cortx
 echo "Waiting for the containers to start up..."
 sleep 5
-kubectl describe deployment cortx-provisioner --namespace cortx
+
+kubectl get statefulset podnode --namespace cortx
 kubectl get pods --namespace cortx
-pod=$(kubectl get pods --namespace cortx | grep cortx | awk '{print $1;}')
+pod=$(kubectl get pods --namespace cortx | grep podnode | awk '{print $1;}')
 kubectl logs $pod --namespace cortx

--- a/test/deploy/k8s/destroy.sh
+++ b/test/deploy/k8s/destroy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
-kubectl delete deployment cortx-provisioner --namespace cortx
+kubectl delete -f ./cortx-statefulset.yml --namespace cortx
 kubectl delete pvc cortx-config-pvc --namespace cortx
 kubectl delete pv cortx-config-pv --namespace cortx
 kubectl delete cm solution-config --namespace cortx
 kubectl delete secret cortx-secret --namespace cortx
+kubectl delete namespace cortx


### PR DESCRIPTION
# Problem Statement
- Add machine-id to each POD in Kubernetes cluster

# Design
- as part of the config-map we provide a cluster.yaml file to POD's which has all pod's data. In this PR, using statefulset we are creating pods to have unique names (podnode-0,podnode-1..podnode-n) . and this unique name will be mapped to the pod name from cluster.yaml file and from cluster.yaml will fetch the id and place it inside etc/machine-id file.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide