### PR TITLE
EOS-24981: Test component logging - Provisioner

### DIFF
--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -1,5 +1,5 @@
 # CORTX Python common library.
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -15,6 +15,7 @@
 
 TMP_LOG_PATH = "/tmp/"
 SERVICE_NAME = "cortx_setup"
-DEFAULT_LOG_PATH = "/var/log/cortx"
 APP_NAME = "provisioner"
+DEFAULT_LOG_PATH = "/var/log/cortx"
+DEFAULT_LOG_LEVEL = "INFO"
 SUPPORTED_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -1,0 +1,17 @@
+# CORTX Python common library.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+TMP_LOG_PATH = "/tmp/"
+SERVICE_NAME = "cortx_setup"

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -15,3 +15,6 @@
 
 TMP_LOG_PATH = "/tmp/"
 SERVICE_NAME = "cortx_setup"
+DEFAULT_LOG_PATH = "/var/log/cortx"
+APP_NAME = "provisioner"
+SUPPORTED_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/src/provisioner/log.py
+++ b/src/provisioner/log.py
@@ -24,49 +24,39 @@ from cortx.provisioner import const
 class CortxProvisionerLog(Log):
     """ Redirect log message to log file and console using cortx utils logger """
 
-    default_log_path = '/var/log/cortx'
-    app_name = 'provisioner'
     logger = None
 
     @staticmethod
-    def initialize(service_name, log_path=None, level='INFO', console_output=False):
+    def initialize(service_name, log_path=const.DEFAULT_LOG_PATH, level='INFO', console_output=True):
         """
         Initialize and use cortx-utils logger to log message in file and console.
         If console_output is True, log message will be displayed in console.
         """
         if not CortxProvisionerLog.logger:
-            log_path = log_path if log_path else CortxProvisionerLog.default_log_path
-            log_path = os.path.join(log_path, CortxProvisionerLog.app_name)
-
-            if level not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
-                level = 'INFO'
-
+            log_path = os.path.join(log_path, const.APP_NAME)
+            level = level if level in const.SUPPORTED_LOG_LEVELS else 'INFO'
             Log.init(service_name, log_path, level=level, console_output=console_output)
             CortxProvisionerLog.logger = Log.logger
 
 
     @staticmethod
-    def reinitialize(service_name, log_path=None, level='INFO', console_output=False):
+    def reinitialize(service_name, log_path=const.DEFAULT_LOG_PATH, level='INFO', console_output=True):
         """
-        Reinitialize cortx-utils logger with given log path
+        Reinitialize existing logger.
 
-        Add captured log message from temporary log file to log file in
-        configured log path
+        This removes logging handler from existing logger and moves captured
+        logs from temporary log file to target log path file.
         """
         if Log.logger:
-
-            log_path = log_path if log_path else CortxProvisionerLog.default_log_path
-            log_path = os.path.join(log_path, CortxProvisionerLog.app_name)
-
-            if level not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
-                level = 'INFO'
+            log_path = os.path.join(log_path, const.APP_NAME)
+            level = level if level in const.SUPPORTED_LOG_LEVELS else 'INFO'
 
             # Remove current logging handlers before truncating
             for handler in Log.logger.handlers[:]:
                 Log.logger.removeHandler(handler)
 
             temp_log_file = '%s/%s/%s.log' % (
-                const.TMP_LOG_PATH, CortxProvisionerLog.app_name, const.SERVICE_NAME)
+                const.TMP_LOG_PATH, const.APP_NAME, const.SERVICE_NAME)
 
             if os.path.exists(temp_log_file):
                 with open(temp_log_file, 'r') as f:

--- a/src/provisioner/log.py
+++ b/src/provisioner/log.py
@@ -27,7 +27,8 @@ class CortxProvisionerLog(Log):
     logger = None
 
     @staticmethod
-    def initialize(service_name, log_path=const.DEFAULT_LOG_PATH, level='INFO', console_output=True):
+    def initialize(service_name, log_path=const.DEFAULT_LOG_PATH,
+                   level=const.DEFAULT_LOG_LEVEL, console_output=True):
         """
         Initialize and use cortx-utils logger to log message in file and console.
         If console_output is True, log message will be displayed in console.
@@ -40,7 +41,8 @@ class CortxProvisionerLog(Log):
 
 
     @staticmethod
-    def reinitialize(service_name, log_path=const.DEFAULT_LOG_PATH, level='INFO', console_output=True):
+    def reinitialize(service_name, log_path=const.DEFAULT_LOG_PATH,
+                     level=const.DEFAULT_LOG_LEVEL, console_output=True):
         """
         Reinitialize existing logger.
 

--- a/src/provisioner/log.py
+++ b/src/provisioner/log.py
@@ -35,7 +35,8 @@ class CortxProvisionerLog(Log):
         """
         if not CortxProvisionerLog.logger:
             log_path = os.path.join(log_path, const.APP_NAME)
-            level = level if level in const.SUPPORTED_LOG_LEVELS else 'INFO'
+            if level not in const.SUPPORTED_LOG_LEVELS:
+                level = const.DEFAULT_LOG_LEVEL
             Log.init(service_name, log_path, level=level, console_output=console_output)
             CortxProvisionerLog.logger = Log.logger
 
@@ -51,7 +52,8 @@ class CortxProvisionerLog(Log):
         """
         if Log.logger:
             log_path = os.path.join(log_path, const.APP_NAME)
-            level = level if level in const.SUPPORTED_LOG_LEVELS else 'INFO'
+            if level not in const.SUPPORTED_LOG_LEVELS:
+                level = const.DEFAULT_LOG_LEVEL
 
             # Remove current logging handlers before truncating
             for handler in Log.logger.handlers[:]:

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -48,7 +48,7 @@ class CortxProvisioner:
         """
         if Log.logger is None:
             CortxProvisionerLog.initialize(const.SERVICE_NAME, const.TMP_LOG_PATH,
-                level='INFO', console_output=True)
+                level='INFO')
         Log.info('Applying config %s' % solution_conf_url)
         Conf.load(CortxProvisioner._solution_index, solution_conf_url)
 
@@ -164,7 +164,7 @@ class CortxProvisioner:
             cortx_config_store.get('cortx>common>storage>log'), node_id)
         log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
         CortxProvisionerLog.reinitialize(
-            const.SERVICE_NAME, log_path, level=log_level, console_output=True)
+            const.SERVICE_NAME, log_path, level=log_level)
 
         if cortx_config_store.get(f'node>{node_id}') is None:
             raise CortxProvisionerError(

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -154,16 +154,17 @@ class CortxProvisioner:
             cortx_conf_url = CortxProvisioner._cortx_conf_url
         cortx_config_store = ConfigStore(cortx_conf_url)
 
-        # Reinitialize logging with configured log path
-        log_path = cortx_config_store.get('cortx>common>storage>log')
-        log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
-        CortxProvisionerLog.reinitialize(
-            const.SERVICE_NAME, log_path, level=log_level, console_output=True)
-
         node_id = Conf.machine_id
         if node_id is None:
             raise CortxProvisionerError(errno.EINVAL, 'Invalid node_id: %s', \
                 node_id)
+
+        # Reinitialize logging with configured log path
+        log_path = os.path.join(
+            cortx_config_store.get('cortx>common>storage>log'), node_id)
+        log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
+        CortxProvisionerLog.reinitialize(
+            const.SERVICE_NAME, log_path, level=log_level, console_output=True)
 
         if cortx_config_store.get(f'node>{node_id}') is None:
             raise CortxProvisionerError(

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -18,7 +18,8 @@ import os
 from cortx.utils.process import SimpleProcess
 from cortx.utils.conf_store import Conf
 from cortx.utils.security.cipher import Cipher
-from cortx.utils.log import Log
+from cortx.provisioner import const
+from cortx.provisioner.log import CortxProvisionerLog, Log
 from cortx.provisioner.error import CortxProvisionerError
 from cortx.provisioner.config_store import ConfigStore
 from cortx.provisioner.config import CortxConfig
@@ -45,6 +46,9 @@ class CortxProvisioner:
         [IN]  Solution Config URL
         [OUT] CORTX Config URL
         """
+        if Log.logger is None:
+            CortxProvisionerLog.initialize(const.SERVICE_NAME, const.TMP_LOG_PATH,
+                level='INFO', console_output=True)
         Log.info('Applying config %s' % solution_conf_url)
         Conf.load(CortxProvisioner._solution_index, solution_conf_url)
 
@@ -149,6 +153,12 @@ class CortxProvisioner:
         if cortx_conf_url is None:
             cortx_conf_url = CortxProvisioner._cortx_conf_url
         cortx_config_store = ConfigStore(cortx_conf_url)
+
+        # Reinitialize logging with configured log path
+        log_path = cortx_config_store.get('cortx>common>storage>log')
+        log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
+        CortxProvisionerLog.reinitialize(
+            const.SERVICE_NAME, log_path, level=log_level, console_output=True)
 
         node_id = Conf.machine_id
         if node_id is None:

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -47,8 +47,7 @@ class CortxProvisioner:
         [OUT] CORTX Config URL
         """
         if Log.logger is None:
-            CortxProvisionerLog.initialize(const.SERVICE_NAME, const.TMP_LOG_PATH,
-                level='INFO')
+            CortxProvisionerLog.initialize(const.SERVICE_NAME, const.TMP_LOG_PATH)
         Log.info('Applying config %s' % solution_conf_url)
         Conf.load(CortxProvisioner._solution_index, solution_conf_url)
 
@@ -162,7 +161,7 @@ class CortxProvisioner:
         # Reinitialize logging with configured log path
         log_path = os.path.join(
             cortx_config_store.get('cortx>common>storage>log'), node_id)
-        log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
+        log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', const.DEFAULT_LOG_LEVEL)
         CortxProvisionerLog.reinitialize(
             const.SERVICE_NAME, log_path, level=log_level)
 

--- a/src/setup/cortx_setup.py
+++ b/src/setup/cortx_setup.py
@@ -53,12 +53,12 @@ class ConfigCmd(Cmd):
         if self._args.action not in ['apply']:
             raise CortxProvisionerError(errno.EINVAL, 'Invalid action type')
 
-        if self._args.log_level:
-            if self._args.log_level not in \
-                ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
-                    raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
-            else:
-                Log.logger.setLevel(self._args.log_level)
+        log_level = self._args.log_level
+        if not log_level:
+            log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
+        if log_level not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
+            raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
+        Log.logger.setLevel(log_level)
 
     def process(self):
         """ Apply Config """
@@ -93,12 +93,12 @@ class ClusterCmd(Cmd):
         if self._args.action not in ['bootstrap']:
             raise CortxProvisionerError(errno.EINVAL, 'Invalid action type')
 
-        if self._args.log_level:
-            if self._args.log_level not in \
-                ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
-                    raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
-            else:
-                os.environ['CORTX_PROVISIONER_DEBUG_LEVEL'] = self._args.log_level
+        log_level = self._args.log_level
+        if not log_level:
+            log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
+        if log_level not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
+            raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
+        os.environ['CORTX_PROVISIONER_DEBUG_LEVEL'] = log_level
 
     def process(self, *args, **kwargs):
         """ Bootsrap Cluster """

--- a/src/setup/cortx_setup.py
+++ b/src/setup/cortx_setup.py
@@ -55,7 +55,7 @@ class ConfigCmd(Cmd):
 
         log_level = self._args.log_level
         if not log_level:
-            log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
+            log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', const.DEFAULT_LOG_LEVEL)
         if log_level not in const.SUPPORTED_LOG_LEVELS:
             raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
         Log.logger.setLevel(log_level)
@@ -95,7 +95,7 @@ class ClusterCmd(Cmd):
 
         log_level = self._args.log_level
         if not log_level:
-            log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
+            log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', const.DEFAULT_LOG_LEVEL)
         if log_level not in const.SUPPORTED_LOG_LEVELS:
             raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
         os.environ['CORTX_PROVISIONER_DEBUG_LEVEL'] = log_level
@@ -110,8 +110,7 @@ class ClusterCmd(Cmd):
 
 
 def main():
-    CortxProvisionerLog.initialize(
-        const.SERVICE_NAME, const.TMP_LOG_PATH, level='INFO')
+    CortxProvisionerLog.initialize(const.SERVICE_NAME, const.TMP_LOG_PATH)
     try:
         # Parse and Process Arguments
         command = Cmd.get_command(sys.modules[__name__], 'cortx_setup', \

--- a/src/setup/cortx_setup.py
+++ b/src/setup/cortx_setup.py
@@ -56,7 +56,7 @@ class ConfigCmd(Cmd):
         log_level = self._args.log_level
         if not log_level:
             log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
-        if log_level not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
+        if log_level not in const.SUPPORTED_LOG_LEVELS:
             raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
         Log.logger.setLevel(log_level)
 
@@ -96,7 +96,7 @@ class ClusterCmd(Cmd):
         log_level = self._args.log_level
         if not log_level:
             log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', 'INFO')
-        if log_level not in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
+        if log_level not in const.SUPPORTED_LOG_LEVELS:
             raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
         os.environ['CORTX_PROVISIONER_DEBUG_LEVEL'] = log_level
 
@@ -111,7 +111,7 @@ class ClusterCmd(Cmd):
 
 def main():
     CortxProvisionerLog.initialize(
-        const.SERVICE_NAME, const.TMP_LOG_PATH, level='INFO', console_output=True)
+        const.SERVICE_NAME, const.TMP_LOG_PATH, level='INFO')
     try:
         # Parse and Process Arguments
         command = Cmd.get_command(sys.modules[__name__], 'cortx_setup', \

--- a/src/setup/cortx_setup.py
+++ b/src/setup/cortx_setup.py
@@ -20,10 +20,11 @@ import traceback
 import errno
 import os
 
-from cortx.provisioner.log import Log
+from cortx.provisioner.log import CortxProvisionerLog, Log
 from cortx.provisioner.provisioner import CortxProvisioner
 from cortx.provisioner.error import CortxProvisionerError
 from cortx.utils.cmd_framework import Cmd
+from cortx.provisioner import const
 
 
 class ConfigCmd(Cmd):
@@ -97,7 +98,7 @@ class ClusterCmd(Cmd):
                 ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
                     raise CortxProvisionerError(errno.EINVAL, 'Invalid log level')
             else:
-                Log.logger.setLevel(self._args.log_level)
+                os.environ['CORTX_PROVISIONER_DEBUG_LEVEL'] = self._args.log_level
 
     def process(self, *args, **kwargs):
         """ Bootsrap Cluster """
@@ -109,6 +110,8 @@ class ClusterCmd(Cmd):
 
 
 def main():
+    CortxProvisionerLog.initialize(
+        const.SERVICE_NAME, const.TMP_LOG_PATH, level='INFO', console_output=True)
     try:
         # Parse and Process Arguments
         command = Cmd.get_command(sys.modules[__name__], 'cortx_setup', \


### PR DESCRIPTION
# Problem Statement
Ensure provisioner logs are writing in configured log path (Kubernete, local VM env)
As part of this, we identified that ConfigStore will not be available to provisioner config apply command. To overcome this, let write the config apply log information in tmp file. Once ConfigStore is ready with log location, initialize the logger and append tmp logs to required log path file.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide