### PR TITLE
EOS-24455: changed confstore file URL argument for cortx_setup command to -c

### DIFF
--- a/src/setup/cortx_deploy
+++ b/src/setup/cortx_deploy
@@ -94,13 +94,13 @@ export PATH=$PATH:/opt/seagate/provisioner/bin
 echo $NODE_ID > "/etc/machine-id";
 log $DEBUG node_id=$NODE_ID
 # Apply Cluster Config
-log $INFO "cortx_setup config apply -f $(yaml_config $CLUSTER_INFO) -o '$CORTX_CONFSTORE'"
-cortx_setup config apply -f $(yaml_config $CLUSTER_INFO) -o "$CORTX_CONFSTORE";
+log $INFO "cortx_setup config apply -f $(yaml_config $CLUSTER_INFO) -c '$CORTX_CONFSTORE'"
+cortx_setup config apply -f $(yaml_config $CLUSTER_INFO) -c "$CORTX_CONFSTORE";
 
 # Apply Common Config
-log $INFO "cortx_setup config apply -f $(yaml_config $CONFIG_INFO) -o '$CORTX_CONFSTORE'"
-cortx_setup config apply -f $(yaml_config $CONFIG_INFO) -o "$CORTX_CONFSTORE"
+log $INFO "cortx_setup config apply -f $(yaml_config $CONFIG_INFO) -c '$CORTX_CONFSTORE'"
+cortx_setup config apply -f $(yaml_config $CONFIG_INFO) -c "$CORTX_CONFSTORE"
 
 # Bootstrap Cluster
-log $INFO "cortx_setup cluster bootstrap -f "$CORTX_CONFSTORE" $SETUP_ARGS"
-cortx_setup cluster bootstrap -f "$CORTX_CONFSTORE" $SETUP_ARGS;
+log $INFO "cortx_setup cluster bootstrap -c "$CORTX_CONFSTORE" $SETUP_ARGS"
+cortx_setup cluster bootstrap -c "$CORTX_CONFSTORE" $SETUP_ARGS;

--- a/src/setup/cortx_setup.py
+++ b/src/setup/cortx_setup.py
@@ -42,7 +42,7 @@ class ConfigCmd(Cmd):
         parser.add_argument('action', help='apply')
         parser.add_argument('-f', dest='solution_conf', \
             help='Solution Config URL')
-        parser.add_argument('-o', dest='cortx_conf', nargs='?', \
+        parser.add_argument('-c', dest='cortx_conf', nargs='?', \
             help='CORTX Config URL')
         parser.add_argument('-l', dest='log_level', help='Log level')
 
@@ -80,7 +80,7 @@ class ClusterCmd(Cmd):
         """ Add Command args for parsing """
 
         parser.add_argument('action', help='bootstrap')
-        parser.add_argument('-f', dest='cortx_conf', help='Cortx Config URL')
+        parser.add_argument('-c', dest='cortx_conf', help='Cortx Config URL')
         parser.add_argument('-l', dest='log_level', help='Log level')
         parser.add_argument('-m', dest='mock', action="store_true",
             help='Boolean - Enable Mocking.')


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- Change Confstore URL Argument to -c to make it consistent accross the workflow.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide