### PR TITLE
EOS-24455: Remove Privilaged mode from Provisioner kubernetes test framework

### DIFF
--- a/test/deploy/kubernetes/provisioner-pods/deployment_control_node.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_control_node.yaml
@@ -33,8 +33,6 @@ spec:
   - name: cortx-control-node
     image: ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci
     imagePullPolicy: IfNotPresent
-    securityContext:
-      privileged: true
     env:
     - name: NODE_ID
       valueFrom:

--- a/test/deploy/kubernetes/provisioner-pods/deployment_storage_node1.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_storage_node1.yaml
@@ -57,8 +57,6 @@ spec:
   - name: cortx-data
     image: ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci
     imagePullPolicy: IfNotPresent
-    securityContext:
-      privileged: true
     env:
     - name: NODE_ID
       valueFrom:

--- a/test/deploy/kubernetes/provisioner-pods/deployment_storage_node2.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_storage_node2.yaml
@@ -57,8 +57,6 @@ spec:
   - name: cortx-data
     image: ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci
     imagePullPolicy: IfNotPresent
-    securityContext:
-      privileged: true
     env:
     - name: NODE_ID
       valueFrom:

--- a/test/deploy/kubernetes/provisioner-pods/deployment_storage_node3.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_storage_node3.yaml
@@ -57,8 +57,6 @@ spec:
   - name: cortx-data
     image: ghcr.io/seagate/cortx-all:2.0.0-latest-custom-ci
     imagePullPolicy: IfNotPresent
-    securityContext:
-      privileged: true
     env:
     - name: NODE_ID
       valueFrom:


### PR DESCRIPTION
…amework

Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- EOS-24455: Remove Privilaged mode from Provisioner kubernetes test framework

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide