### PR TITLE
EOS-25205: Change in provisioner log path structure

### DIFF
--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -13,9 +13,9 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-TMP_LOG_PATH = "/tmp/"
 SERVICE_NAME = "cortx_setup"
 APP_NAME = "provisioner"
-DEFAULT_LOG_PATH = "/var/log/cortx"
+TMP_LOG_PATH = "/tmp/%s" % APP_NAME
+DEFAULT_LOG_PATH = "/var/log/cortx/%s" % APP_NAME
 DEFAULT_LOG_LEVEL = "INFO"
 SUPPORTED_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/src/provisioner/log.py
+++ b/src/provisioner/log.py
@@ -34,7 +34,6 @@ class CortxProvisionerLog(Log):
         If console_output is True, log message will be displayed in console.
         """
         if not CortxProvisionerLog.logger:
-            log_path = os.path.join(log_path, const.APP_NAME)
             if level not in const.SUPPORTED_LOG_LEVELS:
                 level = const.DEFAULT_LOG_LEVEL
             Log.init(service_name, log_path, level=level, console_output=console_output)
@@ -51,7 +50,6 @@ class CortxProvisionerLog(Log):
         logs from temporary log file to target log path file.
         """
         if Log.logger:
-            log_path = os.path.join(log_path, const.APP_NAME)
             if level not in const.SUPPORTED_LOG_LEVELS:
                 level = const.DEFAULT_LOG_LEVEL
 
@@ -59,8 +57,8 @@ class CortxProvisionerLog(Log):
             for handler in Log.logger.handlers[:]:
                 Log.logger.removeHandler(handler)
 
-            temp_log_file = '%s/%s/%s.log' % (
-                const.TMP_LOG_PATH, const.APP_NAME, const.SERVICE_NAME)
+            temp_log_file = '%s/%s.log' % (
+                const.TMP_LOG_PATH, const.SERVICE_NAME)
 
             if os.path.exists(temp_log_file):
                 with open(temp_log_file, 'r') as f:

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -160,7 +160,7 @@ class CortxProvisioner:
 
         # Reinitialize logging with configured log path
         log_path = os.path.join(
-            cortx_config_store.get('cortx>common>storage>log'), node_id)
+            cortx_config_store.get('cortx>common>storage>log'), const.APP_NAME, node_id)
         log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', const.DEFAULT_LOG_LEVEL)
         CortxProvisionerLog.reinitialize(
             const.SERVICE_NAME, log_path, level=log_level)


### PR DESCRIPTION
# Problem Statement
Provisioner writes cortx_setup.log under,
/share/var/log/cortx/<machine-id>/provisioner/

All other components are following like,
/share/var/log/cortx/<component>/<machine-id>/

So provisioner also has to follow the same.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide