### PR TITLE
EOS-25065: Factory Reset: Use original salt master file to restore salt configuraion

### DIFF
--- a/srv/components/provisioner/scripts/salt.sh
+++ b/srv/components/provisioner/scripts/salt.sh
@@ -37,7 +37,7 @@ if ! rpm -qa | grep -iEwq "salt|salt-master|salt-minion|cortx-prvsnr"; then
 fi
 
 minion_file="${PRVSNR_ROOT}/srv/components/provisioner/salt_minion/files/minion_factory"
-master_file="${PRVSNR_ROOT}/srv/components/provisioner/salt_master/files/master"
+master_file="${PRVSNR_ROOT}/srv/components/provisioner/salt_master/files/master_factory"
 
 yes | cp -f "${master_file}" /etc/salt/master
 yes | cp -f "${minion_file}" /etc/salt/minion


### PR DESCRIPTION

Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

# Problem Statement
- Use original salt configuration file to restore the sale configuration during factory reset.
- The Updated file has Jinja template which needs to be rendered, during factory reset the render is not done, so need to use the original salt master file (one that comes with Salt Package)

# Design
-  Use the correct salt master file (original one) to restore the Salt configuration to default one.

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide