### PR TITLE
EOS-25357: pillar sync: Ignore error if backup directory doesn't exist.

### DIFF
--- a/lr-cli/cortx_setup/commands/pillar_sync.py
+++ b/lr-cli/cortx_setup/commands/pillar_sync.py
@@ -66,7 +66,7 @@ class PillarSync(Command):
         conf_copy = 'components.provisioner.confstore_copy'
         StatesApplier.apply([conf_copy])
         # backup local pillar data
-        cmd_run(f"rm -rf {PRVSNR_DATA_ROOT_DIR}/.backup ",  **kwargs)
+        cmd_run(f"rm -rf {PRVSNR_DATA_ROOT_DIR}/.backup || true",  **kwargs)
         cmd_run(f"mkdir -p {PRVSNR_DATA_ROOT_DIR}/.backup",  **kwargs)
         cmd_run(f"mv {PRVSNR_USER_LOCAL_PILLAR_DIR}/* "
-                f"{PRVSNR_DATA_ROOT_DIR}/.backup/",  **kwargs)
+                f"{PRVSNR_DATA_ROOT_DIR}/.backup/ || true",  **kwargs)


### PR DESCRIPTION
Signed-off-by: Pritam Bhavsar <pritam.bhavsar@seagate.com>

# Problem Statement
Rhe cluster create command is not idempotent after it cross certain point in the code. 
It calls pillar_sync to update the pillar across cluster nodes, in that it saves the current local pillar data to backup directory.
If the command fails for any reason after backup is taken and then it is run again then during backup creation it doesn't find the local pillar directory and fails.

# Design
Ignore the failure in "mv" command if the directory don't exist.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide