### PR TITLE
EOS-25416: Convert metadata device to list.

### DIFF
--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -121,6 +121,11 @@ class CortxProvisioner:
                     node = dict(node_map[node_type], **node)
                     if node['type'] == 'storage_node':
                         cvg_list = node.pop('storage')
+                        for cvg in cvg_list:
+                            metadata_device = cvg['devices']['metadata']
+                            # Convert metadata value to list.
+                            if isinstance(metadata_device, str):
+                                cvg['devices']['metadata'] = metadata_device.split(',')
                         node['storage'] = {
                             'cvg_count': len(cvg_list),
                             'cvg': cvg_list


### PR DESCRIPTION
Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>

# Problem Statement
EOS-25416: Metadata device field in confstore should be type 'list'
- Add metadata value in list format.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide