### PR TITLE
Eos 25409: Added error code check in the entry point script

### DIFF
--- a/src/setup/cortx_deploy
+++ b/src/setup/cortx_deploy
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e;
 # Log Levels:
 DEBUG=1
 INFO=2


### PR DESCRIPTION
Signed-off-by: Kailash Yadav <kailash.yadav@seagate.com>

# Problem Statement
 - While executing Provisioner deployment Pods in Kubernetes environment observed that Provisioner entry point script is not throwing error if any provisioner command fails:
# Design
-  added error throw and exit mechanism for entry point script so if any command fails Provisioner pod will go in error state and not completed state
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide