### PR TITLE
Eos 25409: Added error code check functionality

### DIFF
--- a/src/setup/cortx_deploy
+++ b/src/setup/cortx_deploy
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e;
 # Log Levels:
 DEBUG=1
 INFO=2

--- a/src/setup/cortx_deploy
+++ b/src/setup/cortx_deploy
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e;
+
 # Log Levels:
 DEBUG=1
 INFO=2
@@ -37,6 +37,14 @@ function validate_config {
     local config=$1
     if [ ! -f $config ]; then
         echo -e "ERROR: Config $config not found"
+    fi
+}
+
+function validate_success {
+    local retcode=$1
+    if [ $retcode != 0 ]; then
+        echo -e "ERROR: cortx_setup command failed";
+        exit 1;
     fi
 }
 
@@ -103,10 +111,12 @@ export PATH=$PATH:/opt/seagate/provisioner/bin
 # Apply Cluster Config
 log $INFO "cortx_setup config apply -f $(yaml_config $CLUSTER_INFO) -c '$CORTX_CONFSTORE'"
 cortx_setup config apply -f $(yaml_config $CLUSTER_INFO) -c "$CORTX_CONFSTORE";
+validate_success $?;
 
 # Apply Common Config
 log $INFO "cortx_setup config apply -f $(yaml_config $CONFIG_INFO) -c '$CORTX_CONFSTORE'"
 cortx_setup config apply -f $(yaml_config $CONFIG_INFO) -c "$CORTX_CONFSTORE";
+validate_success $?;
 
 # Check if mocking is enabled
 if [ $MOCK_FLAG = true ]; then
@@ -126,6 +136,7 @@ fi
 # Bootstrap Cluster
 log $INFO "cortx_setup cluster bootstrap -c "$CORTX_CONFSTORE" $SETUP_ARGS"
 cortx_setup cluster bootstrap -c "$CORTX_CONFSTORE" $SETUP_ARGS;
+validate_success $?;
 
 # Check if debugging is enabled
 if [ $DEBUG_FLAG = true ]; then


### PR DESCRIPTION
# Problem Statement
- While executing Provisioner deployment Pods in Kubernetes environment observed that Provisioner entry point script is not throwing error if any provisioner command fails:

# Design
-   added error throw and exit mechanism for entry point script so if any command fails Provisioner pod will go in error state and not completed state
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide