### PR TITLE
EOS-21183: Rename sspl-ll service to sspl

### DIFF
--- a/api/python/provisioner/commands/bootstrap_provisioner.py
+++ b/api/python/provisioner/commands/bootstrap_provisioner.py
@@ -148,14 +148,25 @@ class BootstrapProvisioner(SetupCmdBase, CommandParserFillerMixin):
 
         for node in nodes:
             pings = set()
+            targets = set()
             candidates = set(addrs[node.minion_id])
             for _node in nodes:
                 if _node is not node:
                     candidates -= addrs[_node.minion_id]
 
-            targets = '|'.join(
-                [_node.minion_id for _node in nodes if _node is not node]
-            )
+            _server_numbers = set()
+            for _node in nodes:
+                if _node is not node:
+                    _minion_id = _node.minion_id
+                    _server_number = _minion_id.split('-')[1]
+                    _server_numbers.add(_server_number)
+
+            # Convert server_numbers list to comma separated string
+            # e.g. Convert {'1', '2', '3', .., 'n'} to "1,2,3,..,n"
+            _target_server_numbers = ",".join(_num for _num in _server_numbers)
+
+            # Create targets glob as: "srvnode-[1,2,3,4,5,6,...,n]"
+            targets = "srvnode-[" + _target_server_numbers + "]"
 
             for addr in candidates:
                 try:

--- a/api/python/provisioner/commands/bootstrap_provisioner.py
+++ b/api/python/provisioner/commands/bootstrap_provisioner.py
@@ -202,8 +202,7 @@ class BootstrapProvisioner(SetupCmdBase, CommandParserFillerMixin):
         # TODO IMPROVE EOS-8473 hardcoded
         if len(run_args.nodes) == 1:
             res[run_args.nodes[0].minion_id] = [
-                run_args.salt_master if run_args.salt_master
-                else config.LOCALHOST_IP
+                run_args.salt_master
             ]
             return res
 
@@ -221,8 +220,7 @@ class BootstrapProvisioner(SetupCmdBase, CommandParserFillerMixin):
                     # note: any node may be a salt-master
                     if _node.minion_id in salt_masters:
                         res[node.minion_id].append(
-                            config.LOCALHOST_IP if _node is node
-                            else salt_masters[_node.minion_id]
+                            salt_masters[_node.minion_id]
                         )
         else:
             res = {

--- a/api/python/provisioner/srv/salt/provisioner/configure_salt_master.sls
+++ b/api/python/provisioner/srv/salt/provisioner/configure_salt_master.sls
@@ -25,6 +25,7 @@ salt_master_configured:
     - source: {{ install_dir }}/srv/components/provisioner/salt_master/files/master
     - keep_source: True
     - backup: minion
+    - template: jinja
 
 {% for id in salt['pillar.get']('updated_keys', []) %}
 salt_minion_{{ id }}_key_deleted:

--- a/pillar/components/firewall.sls
+++ b/pillar/components/firewall.sls
@@ -15,117 +15,74 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-# Check for default services under:
-# /usr/lib/firewalld/services/
 firewall:
-  # data_private:
-  # # Configuration for Data Public network
-  #   services:
-  #   # Specify standard firewalld supported services
-  #   # to be allowed through firewall on management network
-  #     # elasticsearch: 9200, 9300
-  #     - elasticsearch
-  #     # high-availability: 2224, 3121, 5403, 5404/udp, 5405-5412/udp, 9929, 9929/udp, 21064
-  #     - high-availability
-  #     # ldap: 389
-  #     - ldap
-  #     # ldaps: 636
-  #     - ldaps
-  #     - ssh
-  #   ports:
-  #   # Specify ports to be allowed through firewall
-  #   # on management network
-  #     consul:
-  #      - 8300/tcp
-  #       - 8301/tcp
-  #       - 8301/udp
-  #       - 8302/tcp
-  #       - 8302/udp
-  #       - 8500/tcp
-  #     csm_agent:
-  #       - 28101/tcp
-  #     haproxy_dummy:
-  #       - 28001/tcp
-  #       - 28002/tcp
-  #     hax:
-  #       - 8008/tcp
-  #     kafka:
-  #       - 9092/tcp
-  #     lnet:
-  #       - 988/tcp
-  #     s3server:
-  #       {%- for port in range(28071,28093) %}
-  #       - {{ port }}/tcp
-  #       {% endfor -%}
-  #       - 28049/tcp
-  #     s3authserver:
-  #       - 28050/tcp
-  #     statsd:
-  #       - 5601/tcp
-  #       - 8125/tcp
-  #     rest_server:
-  #       - 28300/tcp
-  #     rsyslog:
-  #       - 514/tcp
-  #     zookeeper:
-  #       - 2181/tcp
-  #       - 2888/tcp
-  #       - 3888/tcp
-  data_public:
-  # Configuration for Data Public network
-    services:
-    # Specify standard firewalld supported services
-    # to be allowed through firewall on management network
-      # http: 80
-      - http
-      # https: 443
-      - https
-      # salt-master: 4505, 4506
-      - salt-master
+  data_private:
     ports:
-    # Specify ports to be allowed through firewall
-    # on management network
+      consul:
+        - 8300/tcp
+        - 8301/tcp
+        - 8301/udp
+        - 8302/tcp
+        - 8302/udp
+        - 8500/tcp            
+      csm_agent:
+        - 28101/tcp
+      dhclient:
+        - 68/udp
+        - 68/tcp
+      haproxy_dummy:
+        - 28001/tcp
+        - 28002/tcp
+      hax:
+        - 8008/tcp
+      kafka:
+        - 9092/tcp
+      lnet:
+        - 988/tcp
+      rest_server:
+        - 28300/tcp
+      rsyslog:
+        - 514/tcp
+      s3authserver:
+        - 28050/tcp
+      s3server:
+        {%- for port in range(28071,28093) %}
+        - {{ port }}/tcp
+        {% endfor -%}
+        - 28049/tcp
+      statsd:
+        - 5601/tcp
+        - 8125/tcp
+      zookeeper:
+        - 2181/tcp
+        - 2888/tcp
+        - 3888/tcp
+    services:
+      - elasticsearch
+      - high-availability
+      - ldap
+      - ldaps
+      - ssh
+  data_public:
+    ports:
+      haproxy:
+        - 443/tcp
       s3:
         - 9080/tcp
         - 9443/tcp
-      uds:
-        - 5000/tcp
-  mgmt_public:
-  # Configuration for Management network
     services:
-    # Specify standard firewalld supported services
-    # to be allowed through firewall on management network
-      # - dns
-      # - dhcp
-      # http: 80
       - http
-      # http: 443
       - https
-      - ftp
-      # ntp: 123/udp
-      - ntp
-      # salt-master: 4505, 4506
-      - salt-master
-      # ssh: 22
       - ssh
-      {%- if salt['cmd.run']('rpm -qa glusterfs-server') %}
-      - glusterfs
-      {%- endif %}
+  mgmt_public:
     ports:
-    # Specify ports to be allowed through firewall
-    # on management network
       csm:
         - 28100/tcp
-      # dhclient:
-      #   - 68/udp
-      # chronyd:
-      #   - 123/tcp
-      #   - 123/udp
-      # redis:
-      #   - 6379/tcp
-      #   - 6379/udp
-      # smtp:
-      #   - 25/tcp
-      # saltmaster:
-      #   - 4505/tcp
-      #   - 4506/tcp
+    services:
+      - http
+      - https
+      - ftp
+      - ntp
+      - salt-master
+      - ssh
+      - glusterfs

--- a/srv/components/provisioner/salt_master/config.sls
+++ b/srv/components/provisioner/salt_master/config.sls
@@ -19,6 +19,7 @@ salt_master_config_updated:
   file.managed:
     - name: /etc/salt/master
     - source: salt://components/provisioner/salt_master/files/master
+    - template: jinja
 
 # Always start glusterfshsaredstorage before salt-master
 Update glusterfssharedstorage.service:

--- a/srv/components/provisioner/salt_master/files/master_factory
+++ b/srv/components/provisioner/salt_master/files/master_factory
@@ -12,11 +12,7 @@
 #default_include: master.d/*.conf
 
 # The address of the interface to bind to:
-{% if salt['cmd.shell']("nslookup $(hostname) | awk 'FNR==6 {print $2}'") %}
-interface: {{ salt['cmd.shell']("nslookup $(hostname) | awk 'FNR==6 {print $2}'") }}
-{% else %}
-interface: 0.0.0.0
-{% endif %}
+#interface: 0.0.0.0
 
 # Whether the master should listen for IPv6 connections. If this is set to True,
 # the interface option must be adjusted, too. (For example: "interface: '::'")
@@ -576,6 +572,36 @@ ssh_update_roster: True
 
 # The renderer to use on the minions to render the state data
 #renderer: yaml_jinja
+
+# Default Jinja environment options for all templates except sls templates
+#jinja_env:
+#  block_start_string: '{%'
+#  block_end_string: '%}'
+#  variable_start_string: '{{'
+#  variable_end_string: '}}'
+#  comment_start_string: '{#'
+#  comment_end_string: '#}'
+#  line_statement_prefix:
+#  line_comment_prefix:
+#  trim_blocks: False
+#  lstrip_blocks: False
+#  newline_sequence: '\n'
+#  keep_trailing_newline: False
+
+# Jinja environment options for sls templates
+#jinja_sls_env:
+#  block_start_string: '{%'
+#  block_end_string: '%}'
+#  variable_start_string: '{{'
+#  variable_end_string: '}}'
+#  comment_start_string: '{#'
+#  comment_end_string: '#}'
+#  line_statement_prefix:
+#  line_comment_prefix:
+#  trim_blocks: False
+#  lstrip_blocks: False
+#  newline_sequence: '\n'
+#  keep_trailing_newline: False
 
 # The failhard option tells the minions to stop immediately after the first
 # failure detected in the state execution, defaults to False

--- a/srv/components/provisioner/scripts/install.sh
+++ b/srv/components/provisioner/scripts/install.sh
@@ -200,7 +200,7 @@ config_local_salt()
     fi
 
     minion_file="${PRVSNR_ROOT}/srv/components/provisioner/salt_minion/files/minion_factory"
-    master_file="${PRVSNR_ROOT}/srv/components/provisioner/salt_master/files/master"
+    master_file="${PRVSNR_ROOT}/srv/components/provisioner/salt_master/files/master_factory"
 
     yes | cp -f "${master_file}" /etc/salt/master
     yes | cp -f "${minion_file}" /etc/salt/minion

--- a/srv/components/sanity_tests/sspl.sls
+++ b/srv/components/sanity_tests/sspl.sls
@@ -30,7 +30,7 @@ Create SSPL Sanity test script:
           #!/bin/bash
           echo "Runnign SSPL sanity"
           echo "state=active" > /var/cortx/sspl/data/state.txt
-          PID=$(/usr/bin/pgrep -d " " -f /usr/bin/sspl_ll_d)
+          PID=$(/usr/bin/pgrep -d " " -f /usr/bin/sspld)
             kill -s SIGHUP $PID
           sh /opt/seagate/cortx/sspl/sspl_test/run_tests.sh
 

--- a/srv/components/sspl/start.sls
+++ b/srv/components/sspl/start.sls
@@ -15,7 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-Start service sspl-ll:
+Start service sspl:
   service.running:
-    - name: sspl-ll
+    - name: sspl
     - enable: true

--- a/srv/components/sspl/stop.sls
+++ b/srv/components/sspl/stop.sls
@@ -15,6 +15,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-Stop service sspl-ll:
+Stop service sspl:
   service.dead:
-    - name: sspl-ll
+    - name: sspl

--- a/srv/components/system/firewall/files/firewall_config.yaml
+++ b/srv/components/system/firewall/files/firewall_config.yaml
@@ -1,9 +1,76 @@
 firewall:
+  data_private:
+    services:
+      - elasticsearch
+      - high-availability
+      - ldap
+      - ldaps
+      - ssh
+    ports:
+      consul:
+        - 8300/tcp
+        - 8301/tcp
+        - 8301/udp
+        - 8302/tcp
+        - 8302/udp
+        - 8500/tcp
+      csm_agent:
+        - 28101/tcp
+      haproxy_dummy:
+        - 28001/tcp
+        - 28002/tcp
+      hax:
+        - 8008/tcp
+      kafka:
+        - 9092/tcp
+      lnet:
+        - 988/tcp
+      s3server:
+        - 28071/tcp
+        - 28072/tcp
+        - 28073/tcp
+        - 28074/tcp
+        - 28075/tcp
+        - 28076/tcp
+        - 28077/tcp
+        - 28078/tcp
+        - 28079/tcp
+        - 28080/tcp
+        - 28081/tcp
+        - 28082/tcp
+        - 28083/tcp
+        - 28084/tcp
+        - 28085/tcp
+        - 28086/tcp
+        - 28087/tcp
+        - 28088/tcp
+        - 28089/tcp
+        - 28090/tcp
+        - 28091/tcp
+        - 29092/tcp
+        - 28049/tcp
+      s3authserver:
+        - 28050/tcp
+      statsd:
+        - 5601/tcp
+        - 8125/tcp
+      rest_server:
+        - 28300/tcp
+      rsyslog:
+        - 514/tcp
+      zookeeper:
+        - 2181/tcp
+        - 2888/tcp
+        - 3888/tcp
+      dhclient:
+        - 68/udp
+        - 68/tcp
+
   data_public:
     services:
       - http
       - https
-      - salt-master
+      - ssh
     ports:
       haproxy:
         - 443/tcp


### PR DESCRIPTION
# Problem Statement
- SSPL service has grown beyond its original design, and it doesn't need to limit to any internal domain name like low-level or high-level. So service needs to be renamed to sspl.

# Design
-  https://jts.seagate.com/browse/EOS-21183

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide