### PR TITLE
[INVALID] EOS-21183: Rename sspl-ll service to sspl

### DIFF
--- a/srv/components/sanity_tests/sspl.sls
+++ b/srv/components/sanity_tests/sspl.sls
@@ -30,7 +30,7 @@ Create SSPL Sanity test script:
           #!/bin/bash
           echo "Runnign SSPL sanity"
           echo "state=active" > /var/cortx/sspl/data/state.txt
-          PID=$(/usr/bin/pgrep -d " " -f /usr/bin/sspl_ll_d)
+          PID=$(/usr/bin/pgrep -d " " -f /usr/bin/sspld)
             kill -s SIGHUP $PID
           sh /opt/seagate/cortx/sspl/sspl_test/run_tests.sh
 

--- a/srv/components/sspl/start.sls
+++ b/srv/components/sspl/start.sls
@@ -15,7 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-Start service sspl-ll:
+Start service sspl:
   service.running:
-    - name: sspl-ll
+    - name: sspl
     - enable: true

--- a/srv/components/sspl/stop.sls
+++ b/srv/components/sspl/stop.sls
@@ -15,6 +15,6 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 #
 
-Stop service sspl-ll:
+Stop service sspl:
   service.dead:
-    - name: sspl-ll
+    - name: sspl


### PR DESCRIPTION
# Problem Statement
- SSPL service has grown beyond its original design, and it doesnt need to limit to any internal domain name like low-level or high-level. So service needs to be renamed to sspl.

# Design
-  https://jts.seagate.com/browse/EOS-21183

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide