### PR TITLE
added few modifications for upgrade script for avoiding parrallel upgrade as well as few improvments

### DIFF
--- a/src/setup/cortx_deploy
+++ b/src/setup/cortx_deploy
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e;
+set -eu;
+
 # Log Levels:
 DEBUG=1
 INFO=2

--- a/test/deploy/kubernetes/provisioner-pods/deployment_control_node.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_control_node.yaml
@@ -37,15 +37,6 @@ spec:
     - /bin/sh
     - -c
     - set -x;
-      mkdir -p /opt/seagate/cortx/csm/bin;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/csm/bin/csm_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/motr/bin/motr_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-      chmod +x /opt/seagate/cortx/csm/bin/csm_setup;
-      chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-      chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
-      chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
       /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config

--- a/test/deploy/kubernetes/provisioner-pods/deployment_storage_node1.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_storage_node1.yaml
@@ -61,14 +61,6 @@ spec:
     - /bin/sh
     - -c
     - set -x;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/motr/bin/motr_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-      chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-      chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-      chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
-      chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
       /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config

--- a/test/deploy/kubernetes/provisioner-pods/deployment_storage_node2.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_storage_node2.yaml
@@ -61,14 +61,6 @@ spec:
     - /bin/sh
     - -c
     - set -x;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/motr/bin/motr_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-      chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-      chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-      chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
-      chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
       /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config

--- a/test/deploy/kubernetes/provisioner-pods/deployment_storage_node3.yaml
+++ b/test/deploy/kubernetes/provisioner-pods/deployment_storage_node3.yaml
@@ -61,14 +61,6 @@ spec:
     - /bin/sh
     - -c
     - set -x;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/motr/bin/motr_setup;
-      echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-      chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-      chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-      chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
-      chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
       /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config

--- a/test/deploy/kubernetes/reimage.sh
+++ b/test/deploy/kubernetes/reimage.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # Defaults
 IMAGE_NAME="ghcr.io/seagate/cortx-all"
-LATEST_TAG="2.0.0-latest-custom-ci"
 CUSTOM_TAG="2.0.0-latest-custom-ci"
-IMAGE_LIST="/tmp/cortx_images.log"
 LOCAL_PATH="/var/cortx"
 SHARE_PATH="/share"
 CONFIG_PATH="/etc/cortx"
@@ -51,10 +49,6 @@ sysctl -w vm.max_map_count=30000000;
 # Download latest new image
 echo -e "Pulling New Image: $IMAGE_NAME:$CUSTOM_TAG";
 docker pull $IMAGE_NAME:$CUSTOM_TAG;
-if [[ "$CUSTOM_TAG" != "$LATEST_TAG" ]]; then
-    echo -e "Updating Image: $IMAGE_NAME:$CUSTOM_TAG --> $IMAGE_NAME:$LATEST_TAG";
-    docker tag $IMAGE_NAME:$CUSTOM_TAG $IMAGE_NAME:$LATEST_TAG;
-fi
 
 # Pull 3rd party Docker images
 print_header "Updating 3rdParty Image: symas-openldap";

--- a/test/deploy/kubernetes/template-config/cluster_redefined.yaml
+++ b/test/deploy/kubernetes/template-config/cluster_redefined.yaml
@@ -2,7 +2,7 @@ cluster:
   name: cortx-cluster
   id: 0007ec45379e36d9fa089a3d615c32a3
   node_types:
-    - name: storage_node
+    - name: data_node
       components:
         - name: utils
         - name: motr
@@ -66,18 +66,18 @@ cluster:
           id: 1115f539f4f770e2a3fe9e2e615c32a8
           hostname: ha-node
           type: ha_node
-        - name: storage-node1
+        - name: data-node1
           id: aaa120a9e051d103c164f605615c32a4
-          hostname: storage-node1
-          type: storage_node
-        - name: storage-node2
+          hostname: data-node1
+          type: data_node
+        - name: data-node2
           id: bbb340f79047df9bb52fa460615c32a5
-          hostname: storage-node2
-          type: storage_node
-        - name: storage-node3
+          hostname: data-node2
+          type: data_node
+        - name: data-node3
           id: ccc8700fe6797ed532e311b0615c32a7
-          hostname: storage-node3
-          type: storage_node
+          hostname: data-node3
+          type: data_node
         - name: server-node1
           id: ddd120a9e051d103c164f605615c32a4
           hostname: server-node1

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_control_node.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_control_node.yaml
@@ -46,7 +46,7 @@ spec:
       chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
       chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_data_node1.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_data_node1.yaml
@@ -69,7 +69,7 @@ spec:
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_data_node2.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_data_node2.yaml
@@ -69,7 +69,7 @@ spec:
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_data_node3.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_data_node3.yaml
@@ -69,7 +69,7 @@ spec:
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_ha_node.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_ha_node.yaml
@@ -42,7 +42,7 @@ spec:
       echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
       chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
       chmod +x /opt/seagate/cortx/ha/bin/ha_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_server_node1.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_server_node1.yaml
@@ -43,7 +43,7 @@ spec:
       chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_server_node2.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_server_node2.yaml
@@ -43,7 +43,7 @@ spec:
       chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_server_node3.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_server_node3.yaml
@@ -43,7 +43,7 @@ spec:
       chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_storage_node1.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_storage_node1.yaml
@@ -69,7 +69,7 @@ spec:
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_storage_node2.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_storage_node2.yaml
@@ -69,7 +69,7 @@ spec:
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade-pods/upgrade_storage_node3.yaml
+++ b/test/deploy/kubernetes/upgrade-pods/upgrade_storage_node3.yaml
@@ -69,7 +69,7 @@ spec:
       chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
       chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
       chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
-      cortx_setup cluster upgrade -c yaml:///etc/cortx/cluster.conf;
+      /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
     volumeMounts:
     - name: solution-config
       mountPath: /etc/cortx/solution

--- a/test/deploy/kubernetes/upgrade.sh
+++ b/test/deploy/kubernetes/upgrade.sh
@@ -8,6 +8,17 @@ PASSED='\033[0;32m'       #GREEN
 INFO='\033[0;36m'        #CYAN
 NC='\033[0m'              #NO COLOUR
 REDEFPODS=false
+UPGRADEPIDFILE=/var/run/upgrade.sh.pid
+
+#check if file exits with pid in it. Throw error if PID is present
+if [ -s "$UPGRADEPIDFILE" ]; then
+   echo "Upgrade is already being performed on the cluster."
+   exit 1
+fi
+
+# Create a file with current PID to indicate that process is running.
+echo $$ > "$UPGRADEPIDFILE"
+
 function show_usage {
     echo -e "usage: $(basename $0) [-i UPGRADE-IMAGE]"
     echo -e "Where:"
@@ -244,3 +255,6 @@ fi
 
 # Wait for deletion of Upgrade nodes
 wait;
+
+# Ensure PID file is removed after upgrade is performed.
+trap "rm -f -- '$UPGRADEPIDFILE'"


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement

- remove mock for deployment pods
- call provisioner entry point in upgrade pods
- rename storage-node with data-node in redefined_cluster.yaml
- PID implementation for upgrade script to avoid parallel upgrade.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide