### PR TITLE
Adding new consul endpoint into config.yaml

### DIFF
--- a/conf/config.yaml.sample
+++ b/conf/config.yaml.sample
@@ -17,6 +17,7 @@ cortx:
     consul:
       endpoints:
         - tcp://consul-server.default.svc.cluster.local:8301
+        - http://consul-server.default.svc.cluster.local:8500
       admin: admin
       secret: consul_admin_secret
   common:

--- a/test/deploy/kubernetes/solution-config/config.yaml
+++ b/test/deploy/kubernetes/solution-config/config.yaml
@@ -17,6 +17,7 @@ cortx:
     consul:
       endpoints:
         - tcp://consul-server.default.svc.cluster.local:8301
+        - http://consul-server.default.svc.cluster.local:8500
       admin: admin
       secret: consul_admin_secret
   common:


### PR DESCRIPTION
# Problem Statement
Adding new consul endpoint into config.yaml

# Design
https://jts.seagate.com/browse/EOS-26741
Add another endpoint into list of endpoints for consul, as consul is not reachable for 8301 port.
New endpoint will be pointing to 8500 and with http protocol

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide