### PR TITLE
Changed validation for 'in-progress' provisioning state.

### DIFF
--- a/test/deploy/kubernetes/upgrade.sh
+++ b/test/deploy/kubernetes/upgrade.sh
@@ -257,4 +257,4 @@ fi
 wait;
 
 # Ensure PID file is removed after upgrade is performed.
-trap "rm -f -- '$UPGRADEPIDFILE'"
+rm -f $UPGRADEPIDFILE


### PR DESCRIPTION
# Problem Statement
- In case of system crash/pod restarts, Provisioning phase status will be in 'progress'. 
- If status=progress detected, reset status to default and start upgrade/deployment again.
- Before calling upgrading interface for component, added component version check.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide