### PR TITLE
EOS-26800: Update data_node type as storage_node in redefined pods flow

### DIFF
--- a/test/deploy/kubernetes/template-config/cluster_redefined.yaml
+++ b/test/deploy/kubernetes/template-config/cluster_redefined.yaml
@@ -2,7 +2,7 @@ cluster:
   name: cortx-cluster
   id: 0007ec45379e36d9fa089a3d615c32a3
   node_types:
-    - name: data_node
+    - name: storage_node
       components:
         - name: utils
         - name: motr
@@ -69,15 +69,15 @@ cluster:
         - name: data-node1
           id: aaa120a9e051d103c164f605615c32a4
           hostname: data-node1
-          type: data_node
+          type: storage_node
         - name: data-node2
           id: bbb340f79047df9bb52fa460615c32a5
           hostname: data-node2
-          type: data_node
+          type: storage_node
         - name: data-node3
           id: ccc8700fe6797ed532e311b0615c32a7
           hostname: data-node3
-          type: data_node
+          type: storage_node
         - name: server-node1
           id: ddd120a9e051d103c164f605615c32a4
           hostname: server-node1


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- Update data_node type as storage_node in redefined pods flow

# Design
-  [For Bug, Describe the fix here.](https://jts.seagate.com/browse/EOS-26800)
- Hare mini provisioner failing for redefined pods flow because of node type has been changed to data_node from storage_node. Temporarily reverting node_type to storage_node.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide