### PR TITLE
EOS-26800: revert storage_node to data_node in cluster redefined pods

### DIFF
--- a/test/deploy/kubernetes/template-config/cluster_redefined.yaml
+++ b/test/deploy/kubernetes/template-config/cluster_redefined.yaml
@@ -2,7 +2,7 @@ cluster:
   name: cortx-cluster
   id: 0007ec45379e36d9fa089a3d615c32a3
   node_types:
-    - name: storage_node
+    - name: data_node
       components:
         - name: utils
         - name: motr
@@ -69,15 +69,15 @@ cluster:
         - name: data-node1
           id: aaa120a9e051d103c164f605615c32a4
           hostname: data-node1
-          type: storage_node
+          type: data_node
         - name: data-node2
           id: bbb340f79047df9bb52fa460615c32a5
           hostname: data-node2
-          type: storage_node
+          type: data_node
         - name: data-node3
           id: ccc8700fe6797ed532e311b0615c32a7
           hostname: data-node3
-          type: storage_node
+          type: data_node
         - name: server-node1
           id: ddd120a9e051d103c164f605615c32a4
           hostname: server-node1

--- a/test/deploy/kubernetes/template-config/cluster_redefined.yaml
+++ b/test/deploy/kubernetes/template-config/cluster_redefined.yaml
@@ -2,7 +2,7 @@ cluster:
   name: cortx-cluster
   id: 0007ec45379e36d9fa089a3d615c32a3
   node_types:
-    - name: data_node
+    - name: storage_node
       components:
         - name: utils
         - name: motr
@@ -69,15 +69,15 @@ cluster:
         - name: data-node1
           id: aaa120a9e051d103c164f605615c32a4
           hostname: data-node1
-          type: data_node
+          type: storage_node
         - name: data-node2
           id: bbb340f79047df9bb52fa460615c32a5
           hostname: data-node2
-          type: data_node
+          type: storage_node
         - name: data-node3
           id: ccc8700fe6797ed532e311b0615c32a7
           hostname: data-node3
-          type: data_node
+          type: storage_node
         - name: server-node1
           id: ddd120a9e051d103c164f605615c32a4
           hostname: server-node1


### PR DESCRIPTION
# Problem Statement
-EOS-26800: revert storage_node to data_node in cluster redefined pods

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide