### PR TITLE
EOS-27084: added check in version comaptibility in entrypoint provisi…

### DIFF
--- a/src/setup/cortx_deploy
+++ b/src/setup/cortx_deploy
@@ -154,7 +154,9 @@ release_version=$(conf_get $RELEASE_INFO "VERSION")
 #update_prim_version=$(awk -F- '{print $1}' <<<  $release_version )
 image_version=$(awk -F- '{print $2}' <<<  $release_version)
 
-[[ $current_version -eq $image_version && -z $FORCE_PROVISIONING ]] &&
+#  [[ $image_version != '0' ]] Is a temprory patch for community deployment for build number 0 condition and 
+#   needs to be removed as part of [EOS-27087]
+[[ $current_version -eq $image_version && -z $FORCE_PROVISIONING ]] && [[ $image_version != '0' ]] &&
     log $INFO "current_version ($installed_version) = image_version ($release_version)" &&
     exit 0
 [[ $current_version -gt $image_version ]] &&

--- a/test/deploy/kubernetes/reimage.sh
+++ b/test/deploy/kubernetes/reimage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Defaults
 IMAGE_NAME="ghcr.io/seagate/cortx-all"
-CUSTOM_TAG="2.0.0-latest-custom-ci"
+CUSTOM_TAG=
 LOCAL_PATH="/var/cortx"
 SHARE_PATH="/share"
 CONFIG_PATH="/etc/cortx"
@@ -46,9 +46,11 @@ chmod 700 get_helm.sh;
 print_header "Increasing virtual memory limit";
 sysctl -w vm.max_map_count=30000000;
 
-# Download latest new image
-echo -e "Pulling New Image: $IMAGE_NAME:$CUSTOM_TAG";
-docker pull $IMAGE_NAME:$CUSTOM_TAG;
+if [ -n "$CUSTOM_TAG" ]; then
+    # Download latest new image
+    echo -e "Pulling New Image: $IMAGE_NAME:$CUSTOM_TAG";
+    docker pull $IMAGE_NAME:$CUSTOM_TAG;
+fi
 
 # Pull 3rd party Docker images
 print_header "Updating 3rdParty Image: symas-openldap";


### PR DESCRIPTION
…oner for community build deployment patch

Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- added check in version comaptibility in entrypoint provisioner for community build deployment patch

# Design
-  For community build deployment version is used as "2.0.0-0", which was causing version compatibility check error as provisioner code returns 0 if installed version= image version. In this case, null=0 was casing return 0 condition and deployment was not happening on community build. hence adding this patch for temporary fix and have created story ticket : https://jts.seagate.com/browse/EOS-27087 for improvement on this so that we can check complete version instead of only build number.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide