### PR TITLE
EOS-26598: Remove mocking for data and server pod from provisioner te…

### DIFF
--- a/test/deploy/kubernetes/runtime-pods/components_data_node1.yaml
+++ b/test/deploy/kubernetes/runtime-pods/components_data_node1.yaml
@@ -72,14 +72,6 @@ spec:
         - /bin/sh
         - -c
         - set -x;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/motr/bin/motr_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-          chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-          chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-          chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
-          chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
           /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
         volumeMounts:
         - name: solution-config

--- a/test/deploy/kubernetes/runtime-pods/components_data_node2.yaml
+++ b/test/deploy/kubernetes/runtime-pods/components_data_node2.yaml
@@ -72,14 +72,6 @@ spec:
         - /bin/sh
         - -c
         - set -x;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/motr/bin/motr_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-          chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-          chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-          chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
-          chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
           /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
         volumeMounts:
         - name: solution-config

--- a/test/deploy/kubernetes/runtime-pods/components_data_node3.yaml
+++ b/test/deploy/kubernetes/runtime-pods/components_data_node3.yaml
@@ -72,14 +72,6 @@ spec:
         - /bin/sh
         - -c
         - set -x;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/motr/bin/motr_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-          chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-          chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-          chmod +x /opt/seagate/cortx/motr/bin/motr_setup;
-          chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
           /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
         volumeMounts:
         - name: solution-config

--- a/test/deploy/kubernetes/runtime-pods/components_server_node1.yaml
+++ b/test/deploy/kubernetes/runtime-pods/components_server_node1.yaml
@@ -48,12 +48,6 @@ spec:
         - /bin/sh
         - -c
         - set -x;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-          chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-          chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-          chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
           /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
         volumeMounts:
         - name: solution-config

--- a/test/deploy/kubernetes/runtime-pods/components_server_node2.yaml
+++ b/test/deploy/kubernetes/runtime-pods/components_server_node2.yaml
@@ -48,12 +48,6 @@ spec:
         - /bin/sh
         - -c
         - set -x;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-          chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-          chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-          chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
           /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
         volumeMounts:
         - name: solution-config

--- a/test/deploy/kubernetes/runtime-pods/components_server_node3.yaml
+++ b/test/deploy/kubernetes/runtime-pods/components_server_node3.yaml
@@ -48,12 +48,6 @@ spec:
         - /bin/sh
         - -c
         - set -x;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/utils/bin/utils_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/hare/bin/hare_setup;
-          echo -e "#!/bin/bash\necho $*" > /opt/seagate/cortx/s3/bin/s3_setup;
-          chmod +x /opt/seagate/cortx/utils/bin/utils_setup;
-          chmod +x /opt/seagate/cortx/hare/bin/hare_setup;
-          chmod +x /opt/seagate/cortx/s3/bin/s3_setup;
           /opt/seagate/cortx/provisioner/bin/cortx_deploy -f /etc/cortx/solution -c yaml:///etc/cortx/cluster.conf;
         volumeMounts:
         - name: solution-config


### PR DESCRIPTION
…st framework

Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- EOS-26598: Remove mocking for data and server pod from provisioner test framework

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide