### PR TITLE
Eos 27645 num array improvements to gconf 

### DIFF
--- a/conf/solution/cluster.yaml.sample
+++ b/conf/solution/cluster.yaml.sample
@@ -7,7 +7,7 @@ cluster:
     - name: utils
     - name: motr
       services:
-      - cclient_service      # motr_setup --services=cclient_service
+      - motr_client          # motr_setup --services=motr_client
     - name: hare
   - name: data_node/1        # For multiple pods per node, there will another type "data_node/2"
     components:

--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -91,6 +91,7 @@ class CortxCluster:
         """Return list of confstore key-values for components."""
         # Create confstore keys, from given component list(config from config.yaml).
         component_kv_list = []
+        # TODO: Need to remove num_components key later
         component_kv_list.append((f'node>{node_id}>num_components', len(component_list)))
         for index, component in enumerate(component_list):
             key_prefix = f'node>{node_id}>components[{index}]'
@@ -112,6 +113,8 @@ class CortxCluster:
         # Create confstore keys,from storage_spec(config from config.yaml).
         storage_kv_list = []
         key_prefix = f'node>{node_id}>storage'
+        # TODO: Need to remove num cvg_count key later
+        storage_kv_list.append((f'{key_prefix}>cvg_count', len(storage_spec)))
         for index, group in enumerate(storage_spec):
             for key, val in group.items():
                 if key == 'devices':

--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -112,7 +112,6 @@ class CortxCluster:
         # Create confstore keys,from storage_spec(config from config.yaml).
         storage_kv_list = []
         key_prefix = f'node>{node_id}>storage'
-        storage_kv_list.append((f'{key_prefix}>cvg_count', len(storage_spec)))
         for index, group in enumerate(storage_spec):
             for key, val in group.items():
                 if key == 'devices':

--- a/src/provisioner/config.py
+++ b/src/provisioner/config.py
@@ -18,6 +18,7 @@ from cortx.provisioner.error import CortxProvisionerError
 from cortx.utils.validator.error import VError
 from cortx.utils.conf_store import Conf
 from cortx.provisioner.log import Log
+from cortx.provisioner import const
 
 class CortxConfig:
     """ CORTX Configuration """
@@ -44,7 +45,7 @@ class CortxConfig:
                     errno.EINVAL, f"'{k}' property is unspecified in cortx_config.")
 
             if k == 'external':
-                required_external_keys = ['kafka', 'consul']
+                required_external_keys = const.REQUIRED_EXTERNAL_SW
                 for e_key in required_external_keys:
                     try:
                         if cortx_solution_config[k][e_key]['endpoints'] is None:

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -20,3 +20,4 @@ DEFAULT_LOG_PATH = "/var/log/cortx/%s" % APP_NAME
 DEFAULT_LOG_LEVEL = "INFO"
 SUPPORTED_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 RELEASE_INFO_URL = "yaml:///opt/seagate/cortx/RELEASE.INFO"
+REQUIRED_EXTERNAL_SW = ['kafka', 'consul']

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -145,9 +145,10 @@ class CortxProvisioner:
 
             for node_type in node_types:
                 node_map[node_type['name']] = node_type
-
+            # TODO: Need to remove storgae_set_count key
             cluster_keys = [('cluster>id', cluster_id),
-                ('cluster>name', cluster_name)]
+                ('cluster>name', cluster_name),
+                ('cluster>storage_set_count', len(storage_sets))]
             cortx_conf.set_kvs(cluster_keys)
 
             nodes = []

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -118,6 +118,8 @@ class CortxProvisioner:
                     # decoding the byte string in val variable
                     Conf.set(CortxProvisioner._solution_index, key, val.decode('utf-8'))
             CortxProvisioner.apply_cortx_config(cortx_conf, CortxProvisioner.cortx_release)
+            # Adding array count key in conf
+            cortx_conf.add_num_keys()
 
     @staticmethod
     def apply_cortx_config(cortx_conf, cortx_release):
@@ -145,8 +147,7 @@ class CortxProvisioner:
                 node_map[node_type['name']] = node_type
 
             cluster_keys = [('cluster>id', cluster_id),
-                ('cluster>name', cluster_name),
-                ('cluster>storage_set_count', len(storage_sets))]
+                ('cluster>name', cluster_name)]
             cortx_conf.set_kvs(cluster_keys)
 
             nodes = []


### PR DESCRIPTION
# Problem Statement
- Add code for setting num keys to the gconf arrays
- remove code for previous counter keys

# Design
-  For Bug, Describe the fix here.
-  https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/651132980/CORTX+GConf+Config+Store+Keys

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide