### PR TITLE
EOS-28599: Update version for each component in bootstrap phase

### DIFF
--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -95,10 +95,8 @@ class CortxCluster:
         for index, component in enumerate(component_list):
             key_prefix = f'node>{node_id}>components[{index}]'
             component_name = component['name']
-            component_version = self._cortx_release.get_component_version(component_name)
-            component_kv_list.extend((
-                (f'{key_prefix}>name', component_name),
-                (f'{key_prefix}>version', component_version)))
+            component_kv_list.append((
+                (f'{key_prefix}>name', component_name)))
 
             service_list = component.get('services')
             if service_list:

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -33,13 +33,13 @@ class PROVISIONING_STAGES(Enum):
     DEPLOYMENT = "deployment"
     UPGRADE = "upgrade"
 
-class DEPLOYMENTINTERFACES(Enum):
+class DEPLOYMENT_STAGES(Enum):
     POST_INSTALL= "post_install"
     PREAPRE= "prepare"
     CONFIG= "config"
     INIT= "init"
 
-class UPGRADEINTERFACES(Enum):
+class UPGRADE_STAGES(Enum):
     UPGRADE = "upgrade"
 
 class PROVISIONING_STATUS(Enum):
@@ -268,7 +268,7 @@ class CortxProvisioner:
         Log.info(f"Starting cluster bootstrap on {node_id}:{node_name}")
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase)
-        CortxProvisioner._provision_components(cortx_conf, DEPLOYMENTINTERFACES, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf, DEPLOYMENT_STAGES, apply_phase)
         CortxProvisioner._add_version_info(cortx_conf, node_id)
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase, PROVISIONING_STATUS.SUCCESS.value)
@@ -301,7 +301,7 @@ class CortxProvisioner:
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase)
 
-        CortxProvisioner._provision_components(cortx_conf, UPGRADEINTERFACES, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf, UPGRADE_STAGES, apply_phase)
         # Update CORTX version, once the upgrade is successful
         CortxProvisioner._add_version_info(cortx_conf, node_id)
         CortxProvisioner._update_provisioning_status(

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -33,13 +33,13 @@ class PROVISIONING_STAGES(Enum):
     DEPLOYMENT = "deployment"
     UPGRADE = "upgrade"
 
-class MINIPROVISIONING_STAGES(Enum):
+class DEPLOYMENTINTERFACES(Enum):
     POST_INSTALL= "post_install"
     PREAPRE= "prepare"
     CONFIG= "config"
     INIT= "init"
 
-class UPGRADEPROVISIONING_STAGES(Enum):
+class UPGRADEINTERFACES(Enum):
     UPGRADE = "upgrade"
 
 class PROVISIONING_STATUS(Enum):
@@ -200,11 +200,11 @@ class CortxProvisioner:
         return node_id, node_name
 
     @staticmethod
-    def _provision_components(cortx_conf: MappedConf, MINIPROVISIONING_STAGES: enum, apply_phase: str):
+    def _provision_components(cortx_conf: MappedConf, INTERFACES: enum, apply_phase: str):
         """Invoke Mini Provisioners of cluster components."""
         node_id, node_name = CortxProvisioner._get_node_info(cortx_conf)
         num_components = int(cortx_conf.get(f'node>{node_id}>num_components'))
-        for interface in MINIPROVISIONING_STAGES:
+        for interface in INTERFACES:
             for comp_idx in range(0, num_components):
                 key_prefix = f'node>{node_id}>components[{comp_idx}]'
                 component_name = cortx_conf.get(f'{key_prefix}>name')
@@ -268,7 +268,7 @@ class CortxProvisioner:
         Log.info(f"Starting cluster bootstrap on {node_id}:{node_name}")
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase)
-        CortxProvisioner._provision_components(cortx_conf, MINIPROVISIONING_STAGES, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf, DEPLOYMENTINTERFACES, apply_phase)
         CortxProvisioner._add_version_info(cortx_conf, node_id)
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase, PROVISIONING_STATUS.SUCCESS.value)
@@ -301,7 +301,7 @@ class CortxProvisioner:
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase)
 
-        CortxProvisioner._provision_components(cortx_conf, UPGRADEPROVISIONING_STAGES, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf, UPGRADEINTERFACES, apply_phase)
         # Update CORTX version, once the upgrade is successful
         CortxProvisioner._add_version_info(cortx_conf, node_id)
         CortxProvisioner._update_provisioning_status(

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -237,7 +237,7 @@ class CortxProvisioner:
                         rc, "%s phase of %s, failed. %s", interface.value,
                         component_name, err)
                 
-                if interface.value == MINIPROVISIONING_STAGES.INIT.value:
+                if interface.value == DEPLOYMENT_INTERFACES.INIT.value or interface.value == UPGRADE_INTERFACES.UPGRADE.VALUE :
                     # Update version for each component if Provisioning successful.
                     component_version = CortxProvisioner.cortx_release.get_component_version(
                         component_name)

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -33,13 +33,13 @@ class PROVISIONING_STAGES(Enum):
     DEPLOYMENT = "deployment"
     UPGRADE = "upgrade"
 
-class DEPLOYMENT_STAGES(Enum):
+class DEPLOYMENT_INTERFACES(Enum):
     POST_INSTALL= "post_install"
     PREAPRE= "prepare"
     CONFIG= "config"
     INIT= "init"
 
-class UPGRADE_STAGES(Enum):
+class UPGRADE_INTERFACES(Enum):
     UPGRADE = "upgrade"
 
 class PROVISIONING_STATUS(Enum):
@@ -268,7 +268,7 @@ class CortxProvisioner:
         Log.info(f"Starting cluster bootstrap on {node_id}:{node_name}")
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase)
-        CortxProvisioner._provision_components(cortx_conf, DEPLOYMENT_STAGES, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf, DEPLOYMENT_INTERFACES, apply_phase)
         CortxProvisioner._add_version_info(cortx_conf, node_id)
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase, PROVISIONING_STATUS.SUCCESS.value)
@@ -301,7 +301,7 @@ class CortxProvisioner:
         CortxProvisioner._update_provisioning_status(
             cortx_conf, node_id, apply_phase)
 
-        CortxProvisioner._provision_components(cortx_conf, UPGRADE_STAGES, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf, UPGRADE_INTERFACES, apply_phase)
         # Update CORTX version, once the upgrade is successful
         CortxProvisioner._add_version_info(cortx_conf, node_id)
         CortxProvisioner._update_provisioning_status(

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -237,7 +237,7 @@ class CortxProvisioner:
                         rc, "%s phase of %s, failed. %s", interface.value,
                         component_name, err)
                 
-                if interface.value == DEPLOYMENT_INTERFACES.INIT.value or interface.value == UPGRADE_INTERFACES.UPGRADE.VALUE :
+                if interface.value == DEPLOYMENT_INTERFACES.INIT.value or interface.value == UPGRADE_INTERFACES.UPGRADE.value :
                     # Update version for each component if Provisioning successful.
                     component_version = CortxProvisioner.cortx_release.get_component_version(
                         component_name)

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -227,11 +227,10 @@ class CortxProvisioner:
                     raise CortxProvisionerError(
                         rc, "%s phase of %s, failed. %s", interface,
                         component_name, err)
-                # Update version for each component if upgrade successful.
-                if apply_phase == PROVISIONING_STAGES.UPGRADE.value:
-                    component_version = CortxProvisioner.cortx_release.get_component_version(
-                        component_name)
-                    cortx_conf.set(f'{key_prefix}>version', component_version)
+                # Update version for each component if Provisioning successful.
+                component_version = CortxProvisioner.cortx_release.get_component_version(
+                    component_name)
+                cortx_conf.set(f'{key_prefix}>version', component_version)
 
     @staticmethod
     def cluster_bootstrap(cortx_conf_url: str, force_override: bool = False):


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- In the config apply stage of the provisioner , we add a version field for all components by searching all component rpms in the RELEASE.INFO file. so even if it's a data pod or any other pod, we search all components to add versions in it and not only data pod components. so for granular images, if other component RPMs are missing, the provisioner throws an error saying "rpm for csm not found".

# Design
-  Fix For above solution would be:
1. Remove add version for component from config apply state.
2. add version only after mini provisioning for the component is successful. This way only for that particular component utils will return version.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide