### PR TITLE
CORTX-28927 - upgrade package numpy from 1.19.XX to 1.19.5

### DIFF
--- a/jenkins/docker/python_requirements.ext.txt
+++ b/jenkins/docker/python_requirements.ext.txt
@@ -3,6 +3,6 @@
 # depdendencies of cryptography
 cffi==1.14.5
 # depdendencies of python==3.6
-numpy==1.19.2
+numpy==1.19.5
 # dependency of cifi
 pycparser==2.20


### PR DESCRIPTION
Signed-off-by: Swanand S Gadre <swanand.s.gadre@seagate.com>

# Problem Statement
- Problem statement

Current python version in all cortx pods is at python 3.6.8. All the versions of numpy above 1.19.X (i.e. 1.20.X, 1.21.X, 1.22.X) are not available for python 3.6.8.
Infact they are available from python 3.7.X ot 3.8.X onwards. So unless python version is not upgraded, numpy cannot be upgraded to the next version.

So plan is to upgrade numpy to latest minor version of 1.19.5. This upgrade will not fix any existing vulnerabilities, but from compliance perspective, it will take numpy to latest minor version compatible with cortx – python version.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design
https://jts.seagate.com/browse/CORTX-28927

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [X] Unit and System Tests are added
- [X] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [X] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

https://jts.seagate.com/browse/CORTX-28927

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

Not Applicable