### PR TITLE
CORTX-29052: fix: added function call for num_array keys

### DIFF
--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -126,6 +126,8 @@ class CortxProvisioner:
                     # decoding the byte string in val variable
                     Conf.set(CortxProvisioner._solution_index, key, val.decode('utf-8'))
             CortxProvisioner.apply_cortx_config(cortx_conf, CortxProvisioner.cortx_release)
+            # Adding array count key in conf
+            cortx_conf.add_num_keys()
 
     @staticmethod
     def apply_cortx_config(cortx_conf, cortx_release):


### PR DESCRIPTION
# Problem Statement
- Missing num_data & num_metadata keys in cluster.conf
cvg:
- devices:
data:
- /dev/sdd
- /dev/sde
metadata:
- /dev/sdc
name: cvg-01
type: ios

Expected num keys for data & metadata (wherever applicable)

cvg:
- devices:
    data:
    num_data: 2
    - /dev/sdd
    - /dev/sde
    metadata:
    num_metadata: 1
    - /dev/sdc
  name: cvg-01
  type: ios

# Design
-  https://jts.seagate.com/browse/CORTX-29052

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide