### PR TITLE
CORTX-27923 - Upgrade aiohttp from version 3.6.1 to 3.8.1

### DIFF
--- a/jenkins/docker/python_requirements.txt
+++ b/jenkins/docker/python_requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.6.1
+aiohttp==3.8.1
 argparse==1.4.0
 boto3==1.10.27
 configparser==4.0.2

--- a/srv/components/system/files/cortx_py_utils_requirements.txt
+++ b/srv/components/system/files/cortx_py_utils_requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.6.1
+aiohttp==3.8.1
 argparse==1.4.0
 boto3==1.10.27
 configparser==4.0.2


### PR DESCRIPTION
# Problem Statement
- Problem statement

Upgrade aiohttp version from 3.6.1 to 3.8.1
This upgrade is expected to resolve security vulnerabilities.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

This fix require changes in python_requirement.txt file to upgrade library version from 3.6.1 to 3.8.1
Corresponding story is - https://jts.seagate.com/browse/CORTX-27923

# Coding
   Checklist for Author
-  [X] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [X] Unit and System Tests are added
- [X] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [X] Testing was performed with RPM

All the test details are documented. Corresponding document is attached to -> https://jts.seagate.com/browse/CORTX-27923

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [X] JIRA number/GitHub Issue added to PR
- [X] PR is self reviewed
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained



# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

No documentation updates