### PR TITLE
CORTX-29379 fix: Validation of cortx-rgw-integration rpm is missing i…

### DIFF
--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -209,6 +209,9 @@ class CortxProvisioner:
             for comp_idx in range(0, num_components):
                 key_prefix = f'node>{node_id}>components[{comp_idx}]'
                 component_name = cortx_conf.get(f'{key_prefix}>name')
+                # Check if RPM exists for the component, if it does exist get the build version
+                component_version = CortxProvisioner.cortx_release.get_component_version(
+                    component_name)
                 # Get services.
                 service_idx = 0
                 services = []
@@ -239,8 +242,6 @@ class CortxProvisioner:
                         component_name, err)
 
                 # Update version for each component if Provisioning successful.
-                component_version = CortxProvisioner.cortx_release.get_component_version(
-                    component_name)
                 cortx_conf.set(f'{key_prefix}>version', component_version)
 
     @staticmethod


### PR DESCRIPTION
…n the input docker images

Signed-off-by: Kailash Yadav <kailash.yadav@seagate.com>

# Problem Statement
- Observed this issue multiple times.
In solution.yaml file, if end user specifies cortx-all image for serverpod instead of cortx-rgw docker image . then deployment fails without proper error.
error message :

cortx.provisioner.error.CortxProvisionerError: error(-1): post_install phase of rgw, failed. SubProcess Error: [Errno 2] No such file or directory: '/opt/seagate/cortx/rgw/bin/rgw_setup': '/opt/seagate/cortx/rgw/bin/rgw_setup'


Expected error message :

Deployment should fail with validation error saying "cortx-rgw-integration rpm is missing. Please check if you are using correct docker image for server pod"

# Design
-  https://jts.seagate.com/browse/CORTX-29379
- RPM version check need to be placed before calling the mini provisioner of a component

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide