### PR TITLE
CORTX-28518 fix: Replaced insensitive usage of words reported in alex…

### DIFF
--- a/api/python/README.md
+++ b/api/python/README.md
@@ -83,8 +83,8 @@ provisioner.auth_init(username=username, password=password)
 ```
 
 where `username` is a name of the user that is added to `prvsnrusers` group.
-So you should either add and existent user to that group or create new one and
-pass his name along with his password to `auth_init`.
+So you should either add an existent user to that group or create a new one and
+pass their name along with their password to `auth_init`.
 
 ## API
 

--- a/api/python/provisioner/api.py
+++ b/api/python/provisioner/api.py
@@ -506,9 +506,9 @@ def cmd_run(cmd_name: str, cmd_args: str = "", cmd_stdin: str = "",
             targets: str = ALL_MINIONS, nowait: bool = False,
             dry_run: bool = False):
     """
-    Execute given command on targets nodes
+    Run given command on targets nodes
 
-    :param cmd_name: command to be executed
+    :param cmd_name: command to be run
     :param cmd_args: (optional) commands' arguments
     :param cmd_stdin: (optional) commands stdin parameters like username or
                       password
@@ -706,7 +706,7 @@ def check(check_name, check_args: str = "",
     :param check_name: name of validation. Use `all` parameter to trigger all
                        supported checks
     :param check_args: arguments and parameters for check (if supported)
-    :param targets: targets where to execute validations (optional)
+    :param targets: targets where to perform validations (optional)
     :return:
     """
     return _api_call('check', check_name,

--- a/api/python/provisioner/commands/check.py
+++ b/api/python/provisioner/commands/check.py
@@ -571,7 +571,7 @@ class Check(CommandParserFillerMixin):
 
         :param args: communicability check specific parameters and arguments
         :param Optional[Union[list, tuple, set]] targets:
-               target nodes where network checks will be executed
+               target nodes where network checks will be performed
         :return:
         """
         res: CheckEntry = CheckEntry(cfg.Checks.COMMUNICABILITY.value)
@@ -1397,7 +1397,7 @@ class Check(CommandParserFillerMixin):
         Basic run method to execute checks specified by `check_name` or
         perform all checks if `check_name` is omitted
 
-        :param str check_name: specific command to be executed on target nodes
+        :param str check_name: specific command to be run on target nodes
         :param str check_args: check specific arguments
 
         :return:

--- a/api/python/provisioner/commands/cluster_id.py
+++ b/api/python/provisioner/commands/cluster_id.py
@@ -78,7 +78,7 @@ class ClusterId(CommandParserFillerMixin):
                         raise ValueError(
                            "ClusterID can be set only on the Primary node "
                            f"of the cluster. Role of current node: '{role}'. "
-                           "Execute the same command from the Primary node."
+                           "Run the same command from the Primary node."
                         )
                     else:
                         logger.debug("ClusterID file does not exist "
@@ -163,7 +163,7 @@ class ClusterId(CommandParserFillerMixin):
         Execution:
         `provisioner cluster_id`
         Takes no mandatory argument as input.
-        Executed only on primary node.
+        Run only on primary node.
 
         """
         try:

--- a/api/python/provisioner/commands/cmd_run.py
+++ b/api/python/provisioner/commands/cmd_run.py
@@ -29,7 +29,7 @@ class CmdRunArgs:
     cmd_name: str = attr.ib(
         metadata={
             inputs.METADATA_ARGPARSER: {
-                'help': ("command to be executed on target nodes. "
+                'help': ("command to be run on target nodes. "
                          "Case sensitive")
             }
         }
@@ -59,7 +59,7 @@ class CmdRunArgs:
 @attr.s(auto_attribs=True)
 class CmdRun(CommandParserFillerMixin):
     """
-    Base class to support remote commands execution
+    Base class to support remote commands run
     """
 
     input_type: Type[inputs.NoParams] = inputs.NoParams
@@ -75,9 +75,9 @@ class CmdRun(CommandParserFillerMixin):
         :param args: `cortxcli` specific command parameters and arguments
         :param stdin: `cortxcli` stdin parameters like username and password.
                       NOTE: Parameters should be '\n' new line seperated
-        :param targets: target nodes where `cortxcli` command will be executed
-        :param bool dry_run: for debugging purposes. Execute method without
-                             real command execution on target nodes
+        :param targets: target nodes where `cortxcli` command will be run
+        :param bool dry_run: for debugging purposes. Run method without
+                             real command run on target nodes
         :return:
         """
 
@@ -93,16 +93,16 @@ class CmdRun(CommandParserFillerMixin):
     def run(self, cmd_name: str, cmd_args: str = "", cmd_stdin: str = None,
             targets: str = ALL_MINIONS, dry_run: bool = False):
         """
-        Basic run method to execute remote commands on targets nodes:
+        Basic run method to run remote commands on targets nodes:
 
-        :param str cmd_name: specific command to be executed on target nodes
+        :param str cmd_name: specific command to be run on target nodes
         :param str cmd_args: command specific arguments
         :param cmd_stdin: command specific stdin parameters like username and
                           password.
         :param str targets: target nodes where command is planned
-                            to be executed
-        :param bool dry_run: for debugging purposes. Execute method without
-                             real command execution on target nodes
+                            to be run
+        :param bool dry_run: for debugging purposes. Run method without
+                             real command running on target nodes
         :return:
         """
         cmd = cmd_name.strip()

--- a/api/python/provisioner/commands/deploy_vm.py
+++ b/api/python/provisioner/commands/deploy_vm.py
@@ -146,7 +146,7 @@ class DeployVM(Deploy):
         if self._is_hw():
             # TODO EOS-12076 less generic error
             logger.error(
-                "Setup Type is HW. Executed command is specific for VM. "
+                "Setup Type is HW. Run command is specific for VM. "
                 "For HW please run `deploy`"
             )
             raise errors.ProvisionerError(

--- a/cli/src/factory_ops/boxing/prov_tasks
+++ b/cli/src/factory_ops/boxing/prov_tasks
@@ -31,7 +31,7 @@
 #   9. Create unboxing user.
 #   10. Create boxing flag file on primary node:
 #       /opt/seagate/cortx/provisioner/generated_config/boxed
-#       Creating file on only one node ensures that the unboxing is executed only on primary node.
+#       Creating file on only one node ensures that the unboxing is run only on primary node.
 set -euE
 
 export LOG_FILE="${LOG_FILE:-/var/log/seagate/provisioner/boxing_prov_tasks.log}"
@@ -304,7 +304,7 @@ function reset_pub_mgmt_ips {
 
 function boxing_flag {
     #Flag file is created only on primary node,
-    # as this helps to ensure unboxing is executed only on primary node.
+    # as this helps to ensure unboxing is run only on primary node.
     echo -n "INFO: Creating flag file on primary node....." | tee -a ${LOG_FILE}
 
     local file_name=${1:-/opt/seagate/cortx_configs/provisioner_generated/boxed}

--- a/devops/jenkins/README.md
+++ b/devops/jenkins/README.md
@@ -126,7 +126,7 @@ Possible actions:
 
 *   `create`: builds and starts server docker container
 
-*   `start`/`stop`/`restart`/`remove`: to start/stop/restart/destroy server
+*   `start`/`stop`/`restart`/`remove`: to start/stop/restart/remove server
     container
 
 Options:

--- a/docs/Architecture/Architectural-Overview.md
+++ b/docs/Architecture/Architectural-Overview.md
@@ -19,19 +19,19 @@ SaltStack has 3 possible modes of operation that were tried out before arriving 
 
 * SSH: This mechanism is similar to Ansible, which primarily performs remote executions over SSH protocol. Salt-SSH requires each node to be configured in roster file and thus the execution is limited to the number of entries in Roster file.
 
-  cortx-prvsnr uses Salt-SSH for initial provisioner bootstrap. This installs and configures Salt in master-minion configuration along with cortx-prvsnr itself.
+  cortx-prvsnr uses Salt-SSH for initial provisioner bootstrap. This installs and configures Salt in primary and minion configuration along with cortx-prvsnr itself.
 
   The cortx-prvsnr API (`provisioner --help`) provides various commands to perform this bootstrap on various environments and is also capable of remotely performing bootstrap on a system from a jump server/host.
 
-* Masterless: Salt formulae would be executed on each minion independently in absence of Salt master (using salt-call --local). This has lower overhead and works fine with single node configuration.
+* Without Primary: Salt formulae would be executed on each minion independently in absence of Salt primary (using salt-call --local). This has lower overhead and works fine with single node configuration.
 
   With multi-node configuration, the setup still was workable, however, the source of Salt formulae (cortx-prvsnr repo) requires replication on each node. Also, assigning role to each node independently becomes challenging.
 
   This mechanism is preferred to make local calls to fetch data (grains/pillar) from Salt.
 
-* Master-Minion: Primary node is elected as Salt master and minions installed on primary and non-primary nodes are connected to the master. This configuration allows better source code management, centralized control and possibility to remotely trigger execution using delegation (salt-syndic).
+* Master-Minion: Primary node is elected as Salt primary and minions installed on primary and non-primary nodes are connected to the primary node. This configuration allows better source code management, centralized control and possibility to remotely trigger execution using delegation (salt-syndic).
   
-  Master-Minion configuration is the backbone of cortx-prvsnr. Deployment, updates, Northbound API execution (and monitoring in future) are all designed around the capability of salt-minions to communicate with salt-master. This configuration allows for scalability and asynchronous mode of operations.
+  Master-Minion configuration is the backbone of cortx-prvsnr. Deployment, updates, Northbound API execution (and monitoring in future) are all designed around the capability of salt-minions to communicate with salt-primary. This configuration allows for scalability and asynchronous mode of operations.
 
 
 # High Level Repository Structure
@@ -165,7 +165,7 @@ Each sub-level file would consist of calls to respective southbound API as:
 * `start`: Start component services.
 * `stop`: Stop component services.
 
-* `housekeeping`: Any expected clean-up activities for junk files created during setup and if required, during operation phase.
+* `housekeeping`: Any expected clean-up activities for scrap files created during setup and if required, during operation phase.
 
 * `sanity_check`: This is a crucial stage as its outcome would determine and confirm the healthy state of the component in operation (post setup). This should be an independently reusable component.
 

--- a/docs/Architecture/Architectural-Overview.md
+++ b/docs/Architecture/Architectural-Overview.md
@@ -23,7 +23,7 @@ SaltStack has 3 possible modes of operation that were tried out before arriving 
 
   The cortx-prvsnr API (`provisioner --help`) provides various commands to perform this bootstrap on various environments and is also capable of remotely performing bootstrap on a system from a jump server/host.
 
-* Without Primary: Salt formulae would be executed on each minion independently in absence of Salt primary (using salt-call --local). This has lower overhead and works fine with single node configuration.
+* Without Primary: Salt formulae would be run on each minion independently in absence of Salt primary (using salt-call --local). This has lower overhead and works fine with single node configuration.
 
   With multi-node configuration, the setup still was workable, however, the source of Salt formulae (cortx-prvsnr repo) requires replication on each node. Also, assigning role to each node independently becomes challenging.
 
@@ -159,7 +159,7 @@ Each sub-level file would consist of calls to respective southbound API as:
     * `post_install` : After installing the component , post_install call will be made through `/opt/seagate/cortx/csm/conf/setup.yaml` and it will call `[component]:post_install` command.  
     * `prepare` : This is a preparatory step that sets up the platform before initiating the setup. Pre-checks before the   components installation, configuration is attempted through prepare.    
     * `config` : Copying configuration files to target directories and Modifying the Configuration to suit the target node environment will be covered from config , and these steps will be invoked from config command respective to the component.  
-    * `init_mod` : Execute initialization and configuration scripts of component will get covered with init_mod.  
+    * `init_mod` : Run initialization and configuration scripts of component will get covered with init_mod.  
 
 
 * `start`: Start component services.

--- a/docs/Architecture/Southbound-Interface.md
+++ b/docs/Architecture/Southbound-Interface.md
@@ -76,7 +76,7 @@ support_bundle:
 
 Each of the sub-sections (unless mentioned explicitly) will have the following parameters:
 
-  * `cmd`:  Command to be executed provided by component pertaining to this section.
+  * `cmd`:  Command to be run provided by component pertaining to this section.
   * `args`:  A list of arguments (in YAML format) to be passed to the script.
   * `--config <URL>`:  Source URL with cluster info
   * `--location <URL>`:  Target URL as specific end-point to backup/restore config info

--- a/docs/Architecture/Test-Guidelines.md
+++ b/docs/Architecture/Test-Guidelines.md
@@ -17,7 +17,7 @@ Test Design implementation is written in PyTest tool in Provisioner. The scope o
 
 PyTest is full-featured Python testing tool currently implemented in Provisioner. 
 It is installed along with other dependencies as part of `test-requirements.txt` file execution. The latest installed version is 5.1.x.
-Execute the test cases in the directory with the command,
+Run the test cases in the directory with the command,
 
 ```
 python3 -m pytest <test_case>
@@ -29,7 +29,7 @@ In the current directory and its subdirectories, PyTest will run all test files 
 test_*.py
 ```
 
-**Execute Multiple test cases as a Group:**
+**Run Multiple test cases as a Group:**
 
 A group of test cases can be run together by placing them under a common “marker” name or by a common string in the method name as `test_deploy` or file name as `test_deploy.py`.
 
@@ -49,7 +49,7 @@ A better approach would be to follow the use of string in file name, as we have 
 
 * The proposed design will not deviate a lot from the existing architecture, instead will only aim to streamline some scattered tests. This design will be updated/changed based on further discussions and design requirements.
 
-* The idea is to create a "Suite"-like design which will group all the related test cases and execute.
+* The idea is to create a "Suite"-like design which will group all the related test cases and run.
 
 
 ### Integration Tests
@@ -73,7 +73,7 @@ A better approach would be to follow the use of string in file name, as we have 
 * Test Suite and Test Module are always directories and Test Case is a python file with one or more methods implemented.
 
 * Each Test Suite (sub-directories) may contain a config file `pytest.ini` which would ideally contain the file names inside that directory.
-  * This is an option to make testing easier. As we add or remove more files in future to a particular directory, the file names can be listed here and only those would be executed.
+  * This is an option to make testing easier. As we add or remove more files in future to a particular directory, the file names can be listed here and only those would be run.
   * Removing any file name from `pytest.ini` will not have an overall effect in execution of that Test Module. This is only for testing the methods in given Test Suite.
 
   * Example, say a Test Suite (sub-directory named `pre_deploy`) has 5 files, and only 2 have to be tested new, then it can included as,

--- a/docs/Architecture/Validation.md
+++ b/docs/Architecture/Validation.md
@@ -27,7 +27,7 @@ Table of Contents:
   Python helps us in 2 ways:
 
   1. Better control over `stdout` and `stderr`.
-  2. Possibility of easily converting Python module to Salt module.
+  2. Possibility of smoothly converting Python module to Salt module.
 
   If you have concerns regarding Python code or lack confidence in Python, it is absolutely ok to capture the logic in a bash script and place it under `_cortx-prvsnr/validation/scripts/utils/uncategorized_`.
 

--- a/docs/Architecture/Validation.md
+++ b/docs/Architecture/Validation.md
@@ -76,9 +76,9 @@ Output shall always be a single JSON format string:
 
 Legend:
 
-* `check`: This is the check that has been performed by the called. It could be the command executed or a short string describing check performed.
+* `check`: This is the check that has been performed by the called. It could be the command run or a short string describing check performed.
 
-* `retcode`: Return code either from shell for an executed command or a preferable code decided by the called module to help understand the area of failure.
+* `retcode`: Return code either from shell for a run command or a preferable code decided by the called module to help understand the area of failure.
 
 * `stdout`: The `stdout` from shell command or a string that describes a success scenario.
 
@@ -395,7 +395,7 @@ provisioner check unboxing_pre_checks
 provisioner check unboxing_post_checks
 ```
 
-To execute ALL of the above validations, the below command works,
+To run ALL of the above validations, the below command works,
 
 `provisioner check all`  
 

--- a/docs/User-Guides/Deploy VM Hosted Repo.md
+++ b/docs/User-Guides/Deploy VM Hosted Repo.md
@@ -144,7 +144,7 @@ Checklist:
 
 # Deploy VM Manually:
 
-Manual deployment of VM consists of following steps from Auto-Deploy, which could be individually executed:  
+Manual deployment of VM consists of following steps from Auto-Deploy, which could be individually run:  
 **NOTE**: Ensure [VM Preparation for Deployment](#vm-preparation-for-deployment) has been addressed successfully before proceeding  
 
 **Bootstrap VM(s)**: Run setup_provisioner provisioner cli command:
@@ -199,7 +199,7 @@ This is one time activity required to setup passwordless ssh across nodes.
 
 
 ## Bootstrap Validation
-Once deployment is bootstrapped (auto_deploy or setup_provisioner) command is executed successfully, verify salt-master setup on both nodes (setup verification checklist)
+Once deployment is bootstrapped (auto_deploy or setup_provisioner) command is run successfully, verify salt-master setup on both nodes (setup verification checklist)
 ```
 salt '*' test.ping  
 salt "*" service.stop puppet
@@ -268,7 +268,7 @@ If provisioner setup is completed and you want to deploy in stages based on comp
     ```
 
 ### Start cluster (irrespective of number of nodes):  
-1.  Execute the following command on primary node to start the cluster:
+1.  Run the following command on primary node to start the cluster:
     ```
     cortx cluster start
     ```
@@ -311,7 +311,7 @@ If provisioner setup is completed and you want to deploy in stages based on comp
     ```
 
 1.  Start cluster (irrespective of number of nodes):  
-    **NOTE**: Execute this command only on primary node (srvnode-1).  
+    **NOTE**: Run this command only on primary node (srvnode-1).  
     ```
     cortx cluster start
     ```

--- a/docs/User-Guides/Deploy VM Hosted Repo.md
+++ b/docs/User-Guides/Deploy VM Hosted Repo.md
@@ -199,7 +199,7 @@ This is one time activity required to setup passwordless ssh across nodes.
 
 
 ## Bootstrap Validation
-Once deployment is bootstrapped (auto_deploy or setup_provisioner) command is executed successfully, verify salt master setup on both nodes (setup verification checklist)
+Once deployment is bootstrapped (auto_deploy or setup_provisioner) command is executed successfully, verify salt-master setup on both nodes (setup verification checklist)
 ```
 salt '*' test.ping  
 salt "*" service.stop puppet

--- a/docs/User-Guides/Deploy VM ISO Repo.md
+++ b/docs/User-Guides/Deploy VM ISO Repo.md
@@ -58,7 +58,7 @@ Checklist:
 1.  Prepare cortx-prvsnr API
     ```
     pushd /opt/isos
-    # Execute cortx-prep script
+    # Run cortx-prep script
     sh /opt/isos/cortx-prep*.sh
     popd
     ```
@@ -136,7 +136,7 @@ Checklist:
 
 # Deploy VM Manually:
 
-Manual deployment of VM consists of following steps from Auto-Deploy, which could be individually executed:  
+Manual deployment of VM consists of following steps from Auto-Deploy, which could be individually run:  
 **NOTE**: Ensure [VM Preparation for Deployment](#vm-preparation-for-deployment) has been addressed successfully before proceeding  
 
 1.  **Bootstrap VM(s)**: Run setup_provisioner provisioner cli command:
@@ -185,7 +185,7 @@ Manual deployment of VM consists of following steps from Auto-Deploy, which coul
 
 
 1.  Bootstrap Validation
-    Once deployment is bootstrapped (auto_deploy or setup_provisioner) command is executed successfully, verify salt-master setup on both nodes (setup verification checklist)
+    Once deployment is bootstrapped (auto_deploy or setup_provisioner) command is run successfully, verify salt-master setup on both nodes (setup verification checklist)
     ```
     salt '*' test.ping  
     salt "*" service.stop puppet
@@ -241,7 +241,7 @@ Manual deployment of VM consists of following steps from Auto-Deploy, which coul
         ```
 
     ### Start Cluster (irrespective of number of nodes):  
-    1.  Execute the following command on primary node to start the cluster:
+    1.  Run the following command on primary node to start the cluster:
         ```
         cortx cluster start
         ```
@@ -293,7 +293,7 @@ Manual deployment of VM consists of following steps from Auto-Deploy, which coul
     1.  [OPTIONAL] For setting up a cluster of more than 3 nodes do append `--name <setup_profile_name>` to auto_deploy_vm command input parameters.  
 
 1.  Start cluster (irrespective of number of nodes):  
-    **NOTE**: Execute this command only on primary node (srvnode-1).  
+    **NOTE**: Run this command only on primary node (srvnode-1).  
     ```
     cortx cluster start
     ```

--- a/docs/mocks.md
+++ b/docs/mocks.md
@@ -6,7 +6,7 @@ components issues and integration difficulties.
 
 For that cases mocked deployment should help. It comes with the following mocks and features:
 
-- dummy component packages which includes only `setup.yaml` (provisioner mini specification)
+- placeholder component packages which includes only `setup.yaml` (provisioner mini specification)
 - `setup.yaml` itself is a very simple spec that just logs (registers) all the calls from provisioner
   (pushes logs to `/tmp/mock.log`)
 - automated logic can build various deployment and upgrade artifacts (as an ISO or a directory):

--- a/docs/protecting_os.md
+++ b/docs/protecting_os.md
@@ -34,7 +34,7 @@
 
 **User story:** As a field support engineer, I need a simple way to replace and restore failed server node in the field. 
 
-**User story:** As a field support engineer, I need to ensure that I’m able to collect support bundle logs in a case of catastrophic server crash. 
+**User story:** As a field support engineer, I need to ensure that I’m able to collect support bundle logs in a case of catastrophic server freeze. 
 
 **User story:** As a developer, I need to ensure that my component is fully functional regardless of the partitions’ layout changes. 
 
@@ -78,7 +78,7 @@ There are several ways the limitation described above could be resolved:
 
 2. **_Option-2:_** We could move the entire OS to the enclosure. The servers will be switched to booting from a LUN located on the enclosure. The OS partitions will be protected against the loss of up to three drives using enclosure’s built-in mechanisms. In this case, swap space shall be migrated to use the local servers’ drives. This swap should be set to a higher priority. An additional swap space (in form of a swap file with a lower swap priority) should be created on the root partition (located on the enclosure). The secondary swap will be used in case the appliance runs out of RAM and primary swap space.  
 
-	_Limitations of this option._ This option does not provide a clear way to collect support bundle in case of entire server crash or replacement. The performance impact, while predicted to be minimal, is also unknown and shall be assessed before this solution is implemented. Also, in their current implementation, RAS mechanisms are relying on local access to IPMI and should be changed to use out of band approach. And the last but not least, this solution is completely dependent on the health of enclosure: its failure will make the system completely unusable, without any ability to collect logs or debug.  
+	_Limitations of this option._ This option does not provide a clear way to collect support bundle in case of entire server freeze or replacement. The performance impact, while predicted to be minimal, is also unknown and shall be assessed before this solution is implemented. Also, in their current implementation, RAS mechanisms are relying on local access to IPMI and should be changed to use out of band approach. And the last but not least, this solution is completely dependent on the health of enclosure: its failure will make the system completely unusable, without any ability to collect logs or debug.  
 
 3. **_Option-3:_** We could use a mixed approach and utilize both RAID-1 and moving OS partitions to the enclosure. With such approach, one half of the RAID-1 volume will be located on the server while another will be located on the enclosure. In case of the server failure, customers will be able to replace the server and boot from the part of the RAID, located on the enclosure. In case of the enclosure failure, ability to access the system and collect logs and debug the failure will remain, since the servers will remain accessible. The location of the swap space will change to use second HDD in the server (as primary swap space). The secondary swap space will remain on enclosure. 
 
@@ -144,7 +144,7 @@ The initial release of CORTX software shall include the following changes:
 
 	* **_Option-1:_** Re-use the existing volume where swap and `/var/motr` is located. This will simplify and minimize the changes required for Provisioner. Swap space will be on the same volume; 
 
-	* **_Option-2:_** Create new, smaller volume on the enclosure for OS partitions. The biggest problem with this approach is the size of the volume. We could predict the size of `/boot`, `/boot/efi`, `/var/log/audit`, and `/` partitions. However, it’s harder to do that with `/var` and especially with `/var/log`. Moreover, this will complicate the Provisioner’s configuration. However, this may potentially make the layout more robust, especially if we decide to create a separate enclosure’s volume group (this idea, in its turn, has additional consequences: we’ll have to allocate additional disks to act as spares for this new group). 
+	* **_Option-2:_** Create new, smaller volume on the enclosure for OS partitions. The biggest problem with this approach is the size of the volume. We could predict the size of `/boot`, `/boot/efi`, `/var/log/audit`, and `/` partitions. However, it’s difficult to do that with `/var` and especially with `/var/log`. Moreover, this will complicate the Provisioner’s configuration. However, this may potentially make the layout more robust, especially if we decide to create a separate enclosure’s volume group (this idea, in its turn, has additional consequences: we’ll have to allocate additional disks to act as spares for this new group). 
 
 	**Decision: Option-1** will be used in our configuration. 
 
@@ -228,7 +228,7 @@ This challenge could be solved by utilizing PXE boot and kickstart setup. The fo
 2. The cluster should be completely stopped at the time, HA and the services shutdown to avoid any unpredicted situation. 
 3. Each server should have identical config and shall be able to re-install the partner node. 
 4. The software image used for the reinstallation could be outdated and a software update of the reinstalled server will be necessary immediately after the installation.  
-5. During reinstallation only the server should be reinstalled. That is, we shall not attempt to assembly the RAID but we shall create the partitions on server’s HDDs to be RAID-compatible. This way we can ensure that accidentally don’t destroy the data on the enclosure.  
+5. During reinstallation only the server should be reinstalled. That is, we shall not attempt to assembly the RAID but we shall create the partitions on server’s HDDs to be RAID-compatible. This way we can ensure that accidentally we don’t wipe off the data on the enclosure.  
 
 **Note:** This also means that an extra, perhaps manual step will be require to complete assembly of the RAID. We should provide instructions to the user how to complete the process. 
 

--- a/docs/protecting_os.md
+++ b/docs/protecting_os.md
@@ -106,7 +106,7 @@ The initial release of CORTX software shall include the following changes:
 
 * `/dev/md1` shall host LVM volume called `vg_sysvol`. The volume shall allocate the entire physical volume. 
 
-**Note:** `/boot/efi` cannot be placed on the RAID volume due to UEFI limitations. We will create two separate partitions called `/boot/efi` and `/boot/efi2`, respectively. The partitions will be kept in sync using rsync executed via crontab (once every 1 hr).
+**Note:** `/boot/efi` cannot be placed on the RAID volume due to UEFI limitations. We will create two separate partitions called `/boot/efi` and `/boot/efi2`, respectively. The partitions will be kept in sync using rsync run via crontab (once every 1 hr).
 
 **Note:** The size of `/boot/efi` and `/boot/efi2` is 256 MB each. Filesystem type must be `vfat` (`fat32`). 
 
@@ -152,7 +152,7 @@ The initial release of CORTX software shall include the following changes:
 
 
 ### Phase-2: Future release (prior to GA)
-During one of the updates, a special script will be executed to perform reconfiguration of the system in order to make it comply with the original design. 
+During one of the updates, a special script will be run to perform reconfiguration of the system in order to make it comply with the original design. 
 
 The script shall perform the following actions: 
 
@@ -236,4 +236,4 @@ This challenge could be solved by utilizing PXE boot and kickstart setup. The fo
 	* Firewall shall be disabled for this operation. This is necessary to avoid unforeseen issues; 
 	* DHCPd and TFTP/bootp services should be configured to listen/respond only on the direct connect interface; 
 	* Web-server serving the kickstart image should be configured to respond only on the direct connect interface; 
-	* The default state of the dhcpd, tftp/bootp, and web-server config for kickstart shall be “disabled”. The user will have to manually enable the required configuration (this can be done using a script that user will have to execute to turn the necessary parameters on. The same script (with a different option) will have to be executed to turn these configs off. Perhaps, this is an option for “Technical Access Portal” that can be used by trainer personnel only (e.g., Seagate support).  
+	* The default state of the dhcpd, tftp/bootp, and web-server config for kickstart shall be “disabled”. The user will have to manually enable the required configuration (this can be done using a script that user will have to run to turn the necessary parameters on. The same script (with a different option) will have to be run to turn these configs off. Perhaps, this is an option for “Technical Access Portal” that can be used by trainer personnel only (e.g., Seagate support).  

--- a/node_cli/nodecli.py
+++ b/node_cli/nodecli.py
@@ -84,9 +84,9 @@ class NodeCli(Cmd):
                 err_str = f"Invalid communication protocol {command.comm.get('type','')} selected."
                 raise Exception(err_str)
             getattr(self, channel_name)(command)
-            Log.debug(f"{line}: Command executed")
+            Log.debug(f"{line}: Command ran")
         except SystemExit:
-            Log.debug(f" Command executed system exit")
+            Log.debug(f" Command ran system exit")
         except KeyboardInterrupt:
             Log.debug(f"Stopped via keyboard interrupt.")
             self.do_exit()

--- a/src/README.md
+++ b/src/README.md
@@ -19,7 +19,7 @@ The same path needs to be passed to the provisioner entry point (cortx_deploy).
 ## Mini Provisioner Orchestration
 There will be CORTX Provisioner Node in the system . Provisioner runs all the phases of all the components in a round-robin manner, in sequence for a given node only. CORTX Provisioner triggers cortx_setup config apply and bootstrap commands in all the nodes in parallel. So effectively, all the phases are run in sequence within a node but they all run in parallel to other nodes.
 
-Following command is executed to invoke all the mini provisioners within the node. 
+Following command is run to invoke all the mini provisioners within the node. 
 ```bash
 cortx_setup cluster bootstrap -c <Confstore-URL>
 ```

--- a/srv/components/controller/files/scripts/provision.sh
+++ b/srv/components/controller/files/scripts/provision.sh
@@ -1221,7 +1221,7 @@ EOF
 fw_codeload_status_get()
 {
     _sftp_cmd="get progress:lastcodeload:text $ftp_log"
-    # Prepare the batch file of sftp commands to be executed over sftp.
+    # Prepare the batch file of sftp commands to be run over sftp.
     printf '%s\n' "$_sftp_cmd" > $tmpdir/fw_upd.bf
     echo "DEBUG: fw_codeload_status_get() _sftp_cmd=$_sftp_cmd." >> $logfile
     echo "DEBUG: fw_codeload_status_get() contents of $tmpdir/fw_upd.bf" >> $logfile

--- a/srv/components/csm/init.sls
+++ b/srv/components/csm/init.sls
@@ -30,5 +30,5 @@ Generate csm checkpoint flag:
 {%- else -%}
 CSM already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.csm.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.csm.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/ha/cortx-ha/init.sls
+++ b/srv/components/ha/cortx-ha/init.sls
@@ -29,5 +29,5 @@ Generate cortx_ha checkpoint flag:
 {%- else -%}
 cortx-ha already applied:
   test.show_notification:
-    - text: "cortx-ha states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.ha.cortx-ha.teardown' to reprovision these states."
+    - text: "cortx-ha states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.ha.cortx-ha.teardown' to reprovision these states."
 {%- endif -%}

--- a/srv/components/misc_pkgs/build_ssl_cert_rpms/init.sls
+++ b/srv/components/misc_pkgs/build_ssl_cert_rpms/init.sls
@@ -68,5 +68,5 @@ Generate openldap checkpoint flag:
 {%- else -%}
 SSL cert rpms built already:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.build_ssl_cert_rpms.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.build_ssl_cert_rpms.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/consul/init.sls
+++ b/srv/components/misc_pkgs/consul/init.sls
@@ -31,5 +31,5 @@ Generate Consul checkpoint flag:
 {%- else -%}
 Consul already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.consul.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.consul.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/elasticsearch/init.sls
+++ b/srv/components/misc_pkgs/elasticsearch/init.sls
@@ -31,5 +31,5 @@ Generate ElasticSearch checkpoint flag:
 {%- else -%}
 ElasticSearch already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.elasticsearch.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.elasticsearch.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/kafka/init.sls
+++ b/srv/components/misc_pkgs/kafka/init.sls
@@ -30,5 +30,5 @@ Generate kafka checkpoint flag:
 {%- else -%}
 Kafka already applied:
   test.show_notification:
-    - text: "Kafka states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.Kafka.teardown' to reprovision these states."
+    - text: "Kafka states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.Kafka.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/kibana/init.sls
+++ b/srv/components/misc_pkgs/kibana/init.sls
@@ -31,5 +31,5 @@ Generate Kibana checkpoint flag:
 {%- else -%}
 Kibana already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.kibana.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.kibana.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/lustre/init.sls
+++ b/srv/components/misc_pkgs/lustre/init.sls
@@ -31,5 +31,5 @@ Generate lustre checkpoint flag:
 {%- else -%}
 Lustre already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.lustre.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.lustre.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/nodejs/init.sls
+++ b/srv/components/misc_pkgs/nodejs/init.sls
@@ -31,6 +31,6 @@ Generate checkpoint flag:
 
 nodejs already applied:
   test.show_notification:
-    - text: "NodeJS states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.nodejs.teardown' to reprovision these states."
+    - text: "NodeJS states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.nodejs.teardown' to reprovision these states."
 
 {%- endif %}

--- a/srv/components/misc_pkgs/openldap/init.sls
+++ b/srv/components/misc_pkgs/openldap/init.sls
@@ -31,5 +31,5 @@ Generate openldap checkpoint flag:
 {%- else -%}
 OpenLDAP already applied:
   test.show_notification:
-    - text: "OpenLDAP states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.openldap.teardown' to reprovision these states."
+    - text: "OpenLDAP states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.openldap.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/openldap/replication/init.sls
+++ b/srv/components/misc_pkgs/openldap/replication/init.sls
@@ -29,5 +29,5 @@ Generate openldap replication checkpoint flag:
 {%- else -%}
 OpenLDAP replication already applied:
   test.show_notification:
-    - text: "OpenLDAP replication states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.openldap.teardown' to reprovision these states."
+    - text: "OpenLDAP replication states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.openldap.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/rabbitmq/init.sls
+++ b/srv/components/misc_pkgs/rabbitmq/init.sls
@@ -30,5 +30,5 @@ Generate RabbitMQ checkpoint flag:
 {%- else -%}
 RabbitMQ already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.misc_pkgs.rabbitmq.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.misc_pkgs.rabbitmq.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/misc_pkgs/statsd/init.sls
+++ b/srv/components/misc_pkgs/statsd/init.sls
@@ -33,6 +33,6 @@ Generate statsd checkpoint flag:
 
 statsd already applied:
   test.show_notification:
-    - text: "Statsd states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.statsd.teardown' to reprovision these states."
+    - text: "Statsd states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.statsd.teardown' to reprovision these states."
 
 {%- endif %}

--- a/srv/components/motr/init.sls
+++ b/srv/components/motr/init.sls
@@ -32,6 +32,6 @@ Generate motr checkpoint flag:
 
 motr already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.motr.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.motr.teardown' to reprovision these states."
 
 {%- endif %}

--- a/srv/components/provisioner/salt_master/files/master
+++ b/srv/components/provisioner/salt_master/files/master
@@ -88,7 +88,7 @@ timeout: 1200
 
 # The loop_interval option controls the seconds for the salt-master's maintenance
 # process check cycle. This process updates file server backends, cleans the
-# job cache and executes the scheduler.
+# job cache and runs the scheduler.
 #loop_interval: 60
 
 # Set the default outputter used by the salt command. The default is "nested".
@@ -135,7 +135,7 @@ cli_summary: True
 
 # The salt-master maintains a job cache. While this is a great addition, it can be
 # a burden on the salt-master for larger deployments (over 5000 minions).
-# Disabling the job cache will make previously executed jobs unavailable to
+# Disabling the job cache will make previously run jobs unavailable to
 # the jobs system and is not generally recommended.
 #job_cache: True
 
@@ -365,7 +365,7 @@ worker_threads: 10
 # specific file.
 #permissive_pki_access: False
 
-# Allow users on the salt-master access to execute specific commands on minions.
+# Allow users on the salt-master access to run specific commands on minions.
 # This setting should be treated with care since it opens up execution
 # capabilities to non root users. By default this capability is completely
 # disabled.
@@ -1068,14 +1068,14 @@ pillar_roots:
 
 # The configuration uses regular expressions to match minions and then a list
 # of regular expressions to match functions. The following will allow the
-# minion authenticated as foo.example.com to execute functions from the test
+# minion authenticated as foo.example.com to run functions from the test
 # and pkg modules.
 #peer:
 #  foo.example.com:
 #    - test.*
 #    - pkg.*
 #
-# This will allow all minions to execute all commands:
+# This will allow all minions to run all commands:
 #peer:
 #  .*:
 #    - .*
@@ -1083,7 +1083,7 @@ pillar_roots:
 # This is not recommended, since it would allow anyone who gets root on any
 # single minion to instantly have root on all of the minions!
 
-# Minions can also be allowed to execute runners from the salt salt-master.
+# Minions can also be allowed to run runners from the salt salt-master.
 # Since executing a runner from the minion could be considered a security risk,
 # it needs to be enabled. This setting functions just like the peer setting
 # except that it opens up runners instead of module functions.

--- a/srv/components/provisioner/salt_master/files/master_factory
+++ b/srv/components/provisioner/salt_master/files/master_factory
@@ -84,7 +84,7 @@ timeout: 1200
 
 # The loop_interval option controls the seconds for the salt-master's maintenance
 # process check cycle. This process updates file server backends, cleans the
-# job cache and executes the scheduler.
+# job cache and runs the scheduler.
 #loop_interval: 60
 
 # Set the default outputter used by the salt command. The default is "nested".
@@ -131,7 +131,7 @@ cli_summary: True
 
 # The salt-master maintains a job cache. While this is a great addition, it can be
 # a burden on the salt-master for larger deployments (over 5000 minions).
-# Disabling the job cache will make previously executed jobs unavailable to
+# Disabling the job cache will make previously run jobs unavailable to
 # the jobs system and is not generally recommended.
 #job_cache: True
 
@@ -361,7 +361,7 @@ worker_threads: 10
 # specific file.
 #permissive_pki_access: False
 
-# Allow users on the salt-master access to execute specific commands on minions.
+# Allow users on the salt-master access to run specific commands on minions.
 # This setting should be treated with care since it opens up execution
 # capabilities to non root users. By default this capability is completely
 # disabled.
@@ -1094,14 +1094,14 @@ pillar_roots:
 
 # The configuration uses regular expressions to match minions and then a list
 # of regular expressions to match functions. The following will allow the
-# minion authenticated as foo.example.com to execute functions from the test
+# minion authenticated as foo.example.com to run functions from the test
 # and pkg modules.
 #peer:
 #  foo.example.com:
 #    - test.*
 #    - pkg.*
 #
-# This will allow all minions to execute all commands:
+# This will allow all minions to run all commands:
 #peer:
 #  .*:
 #    - .*
@@ -1109,7 +1109,7 @@ pillar_roots:
 # This is not recommended, since it would allow anyone who gets root on any
 # single minion to instantly have root on all of the minions!
 
-# Minions can also be allowed to execute runners from the salt salt-master.
+# Minions can also be allowed to run runners from the salt salt-master.
 # Since executing a runner from the minion could be considered a security risk,
 # it needs to be enabled. This setting functions just like the peer setting
 # except that it opens up runners instead of module functions.

--- a/srv/components/provisioner/salt_minion/files/minion
+++ b/srv/components/provisioner/salt_minion/files/minion
@@ -152,7 +152,7 @@ master_shuffle: False
 #verify_env: True
 
 # The minion can locally cache the return data from jobs sent to it, this
-# can be a good way to keep track of jobs the minion has executed
+# can be a good way to keep track of jobs the minion has performed
 # (on the minion side). By default this feature is disabled, to enable, set
 # cache_jobs to True.
 #cache_jobs: False
@@ -328,7 +328,7 @@ ping_interval: 2
 
 # Some installations choose to start all job returns in a cache or a returner
 # and forgo sending the results back to a salt-master. In this workflow, jobs
-# are most often executed with --async from the Salt CLI and then results
+# are most often run with --async from the Salt CLI and then results
 # are evaluated by examining job caches on the minions or any configured returners.
 # WARNING: Setting this to False will **disable** returns back to the salt-master.
 #pub_ret: True
@@ -466,7 +466,7 @@ mine_interval: 60
 
 #####    State Management Settings    #####
 ###########################################
-# The state management system executes all of the state templates on the minion
+# The state management system runs all of the state templates on the minion
 # to enable more granular control of system state management. The type of
 # template and serialization used for state management needs to be configured
 # on the minion, the default renderer is yaml_jinja. This is a yaml file
@@ -518,9 +518,9 @@ mine_interval: 60
 #state_top: top.sls
 #
 # Run states when the minion daemon starts. To enable, set startup_states to:
-# 'highstate' -- Execute state.highstate
-# 'sls' -- Read in the sls_list option and execute the named sls files
-# 'top' -- Read top_file option and execute based on that file on the Salt-Master
+# 'highstate' -- Run state.highstate
+# 'sls' -- Read in the sls_list option and run the named sls files
+# 'top' -- Read top_file option and run based on that file on the Salt-Master
 #startup_states: ''
 #
 # List of states to run when the minion starts up if startup_states is 'sls':
@@ -528,7 +528,7 @@ mine_interval: 60
 #  - edit.vim
 #  - hyper
 #
-# Top file to execute if startup_states is 'top':
+# Top file to run if startup_states is 'top':
 #top_file: ''
 
 # Automatically aggregate all states that have support for mod_aggregate by
@@ -721,7 +721,7 @@ state_output: changes
 ######         Thread settings        #####
 ###########################################
 # Disable multiprocessing support, by default when a minion receives a
-# publication a new process is spawned and the command is executed therein.
+# publication a new process is spawned and the command is run therein.
 #
 # WARNING: Disabling multiprocessing may result in substantial slowdowns
 # when processing large pillars. See https://github.com/saltstack/salt/issues/38758

--- a/srv/components/provisioner/salt_minion/files/minion_factory
+++ b/srv/components/provisioner/salt_minion/files/minion_factory
@@ -140,7 +140,7 @@ master_shuffle: False
 #verify_env: True
 
 # The minion can locally cache the return data from jobs sent to it, this
-# can be a good way to keep track of jobs the minion has executed
+# can be a good way to keep track of jobs the minion has performed.
 # (on the minion side). By default this feature is disabled, to enable, set
 # cache_jobs to True.
 #cache_jobs: False
@@ -316,7 +316,7 @@ ping_interval: 2
 
 # Some installations choose to start all job returns in a cache or a returner
 # and forgo sending the results back to a salt-master. In this workflow, jobs
-# are most often executed with --async from the Salt CLI and then results
+# are most often run with --async from the Salt CLI and then results
 # are evaluated by examining job caches on the minions or any configured returners.
 # WARNING: Setting this to False will **disable** returns back to the salt-master.
 #pub_ret: True
@@ -454,7 +454,7 @@ mine_interval: 60
 
 #####    State Management Settings    #####
 ###########################################
-# The state management system executes all of the state templates on the minion
+# The state management system runs all of the state templates on the minion
 # to enable more granular control of system state management. The type of
 # template and serialization used for state management needs to be configured
 # on the minion, the default renderer is yaml_jinja. This is a yaml file
@@ -506,9 +506,9 @@ mine_interval: 60
 #state_top: top.sls
 #
 # Run states when the minion daemon starts. To enable, set startup_states to:
-# 'highstate' -- Execute state.highstate
-# 'sls' -- Read in the sls_list option and execute the named sls files
-# 'top' -- Read top_file option and execute based on that file on the Salt-Master
+# 'highstate' -- Run state.highstate
+# 'sls' -- Read in the sls_list option and run the named sls files
+# 'top' -- Read top_file option and run based on that file on the Salt-Master
 #startup_states: ''
 #
 # List of states to run when the minion starts up if startup_states is 'sls':
@@ -516,7 +516,7 @@ mine_interval: 60
 #  - edit.vim
 #  - hyper
 #
-# Top file to execute if startup_states is 'top':
+# Top file to run if startup_states is 'top':
 #top_file: ''
 
 # Automatically aggregate all states that have support for mod_aggregate by
@@ -709,7 +709,7 @@ state_output: changes
 ######         Thread settings        #####
 ###########################################
 # Disable multiprocessing support, by default when a minion receives a
-# publication a new process is spawned and the command is executed therein.
+# publication a new process is spawned and the command is run therein.
 #
 # WARNING: Disabling multiprocessing may result in substantial slowdowns
 # when processing large pillars. See https://github.com/saltstack/salt/issues/38758

--- a/srv/components/provisioner/scripts/install.sh
+++ b/srv/components/provisioner/scripts/install.sh
@@ -425,7 +425,6 @@ install_cortx_pkgs()
         "cortx-libsspl_sec-method_pki"
         "cortx-csm_agent"
         "cortx-csm_web"
-        "udx-discovery"
         "uds-pyi"
         "stats_utils"
     )

--- a/srv/components/s3server/init.sls
+++ b/srv/components/s3server/init.sls
@@ -32,6 +32,6 @@ Generate s3server checkpoint flag:
 
 S3Server already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.s3server.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.s3server.teardown' to reprovision these states."
 
 {%- endif -%}

--- a/srv/components/sspl/health_view/config/generate.sls
+++ b/srv/components/sspl/health_view/config/generate.sls
@@ -17,7 +17,7 @@
 
 {% if not ("replace_node" in pillar["cluster"]
   and grains['id'] == pillar["cluster"]["replace_node"]["minion_id"]) %}
-# Should not be executed for replaced node
+# Should not be run for replaced node
 include:
   - components.sspl.config.commons
 {% endif %}
@@ -33,7 +33,7 @@ Run Resource Health View:
     - name: /usr/bin/resource_health_view -n {{ enclosure }} --path {{ pillar['sspl']['health_map_path'] }}
 {% if not ("replace_node" in pillar["cluster"]
   and grains['id'] == pillar["cluster"]["replace_node"]["minion_id"]) %}
-# Should not be executed for replaced node
+# Should not be run for replaced node
     - require:
       - Add common config - system information to Consul
       - Add common config - rabbitmq cluster to Consul

--- a/srv/components/sspl/init.sls
+++ b/srv/components/sspl/init.sls
@@ -33,6 +33,6 @@ Generate sspl checkpoint flag:
 
 SSPL already applied:
   test.show_notification:
-    - text: "SSPL states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.sspl.teardown' to reprovision these states."
+    - text: "SSPL states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.sspl.teardown' to reprovision these states."
 
 {%- endif -%}

--- a/srv/components/system/firewall/init.sls
+++ b/srv/components/system/firewall/init.sls
@@ -29,5 +29,5 @@ Generate firewall checkpoint flag:
 {%- else -%}
 Firewall already applied:
   test.show_notification:
-    - text: "Firewall states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.firewall.teardown' to reprovision these states."
+    - text: "Firewall states already Run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.firewall.teardown' to reprovision these states."
 {%- endif -%}

--- a/srv/components/system/logrotate/init.sls
+++ b/srv/components/system/logrotate/init.sls
@@ -27,5 +27,5 @@ Generate logrotate checkpoint flag:
 {%- else -%}
 logrotate already applied:
   test.show_notification:
-    - text: "logrotate states already executed on node: {{ grains['id'] }}. execute 'salt '*' state.apply components.system.logrotate.teardown' to reprovision these states."
+    - text: "logrotate states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.system.logrotate.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/system/storage/init.sls
+++ b/srv/components/system/storage/init.sls
@@ -28,5 +28,5 @@ Generate storage checkpoint flag:
 {%- else -%}
 Storage already applied:
   test.show_notification:
-    - text: "Storage states already executed on node: {{ grains['id'] }}. execute 'salt '*' state.apply components.system.storage.teardown' to reprovision these states."
+    - text: "Storage states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.system.storage.teardown' to reprovision these states."
 {% endif %}

--- a/srv/components/system/storage/multipath/init.sls
+++ b/srv/components/system/storage/multipath/init.sls
@@ -31,7 +31,7 @@ Generate multipath checkpoint flag:
 {%- else -%}
 multipath already applied:
   test.show_notification:
-    - text: "multipath states already executed on node: {{ grains['id'] }}. execute 'salt '*' state.apply components.system.multipath.teardown' to reprovision these states."
+    - text: "multipath states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.system.multipath.teardown' to reprovision these states."
 {% endif %}
 {%- else -%}
 multipath wont be applied on VM:

--- a/srv/components/uds/init.sls
+++ b/srv/components/uds/init.sls
@@ -31,6 +31,6 @@ Generate uds checkpoint flag:
 
 UDS already applied:
   test.show_notification:
-    - text: "UDS states already executed on node: {{ grains['id'] }}. Execute 'salt '*' state.apply components.uds.teardown' to reprovision these states."
+    - text: "UDS states already run on node: {{ grains['id'] }}. Run 'salt '*' state.apply components.uds.teardown' to reprovision these states."
 
 {%- endif -%}

--- a/test/deploy/kubernetes/README.md
+++ b/test/deploy/kubernetes/README.md
@@ -31,7 +31,7 @@ Run reimage.sh script to install helm, pull 3rd party as well as cortx-all docke
 
 Deploy Provisioner Deployment POD **(Run Only on Master Node)**  
 
-Run deploy.sh script to setup Runtime PODs on each nodes (example: 1 Control POD running on master node, Storage/Data POD running on all nodes). Each Runtime POD will have Init Container (Provisioner Deployment) which will execute cortx_setup config apply and cluster bootstrap commands.
+Run deploy.sh script to setup Runtime PODs on each nodes (example: 1 Control POD running on primary node, Storage/Data POD running on all nodes). Each Runtime POD will have Init Container (Provisioner Deployment) which will execute cortx_setup config apply and cluster bootstrap commands.
 ```bash
 Note: Before running the deploy.sh script, In test/deploy/kubernetes/solution-config/cluster.yaml 
 Make changes according to the number of nodes in the cluster.yaml and config.yaml. 

--- a/test/devops/rpms/test_buildrpm_sh.py
+++ b/test/devops/rpms/test_buildrpm_sh.py
@@ -424,8 +424,7 @@ def test_build_isos(
             'cortx-sspl-cli-1.0.0-33_gitf0c05e3.el7.noarch.rpm',
             'cortx-sspl-test-1.0.0-33_gitf0c05e3.el7.noarch.rpm',
             'python36-cortx-prvsnr-0.39.0-75_gitb9b751c.x86_64.rpm',
-            'uds-pyi-1.1.1-1.r6.el7.x86_64.rpm',
-            'udx-discovery-0.1.2-3.el7.x86_64.rpm'
+            'uds-pyi-1.1.1-1.r6.el7.x86_64.rpm'
         ]
     }
 

--- a/test/r2.md
+++ b/test/r2.md
@@ -54,8 +54,8 @@ Step-2: Create update_states.sls pillar and add provisioner commands stating whi
 Step-3: Reboot servers
 
 Step-4: Check update-post-boot.service status once the system's are back.
-        Service should be inactive but `/opt/seagate/cortx/provisioner/cli/update-post-reboot.sh` should have got executed.
-        Also commands added in update_states/post_boot should be executed.
+        Service should be inactive but `/opt/seagate/cortx/provisioner/cli/update-post-reboot.sh` should have got run.
+        Also commands added in update_states/post_boot should be run.
 
 ## EOS-15751: Setup R2 upgrade release bundle
 

--- a/test/r2.md
+++ b/test/r2.md
@@ -570,7 +570,7 @@ Step 2: Validate all open firewall ports and services with the below command,
 salt-call lyveutils.validate_firewall
 ```
 
-Negative scenario: Even if one port/service if not open from the list of all firewall ports in pillar, an error message saying `Validation of open ports failed` will pop-up.
+Negative scenario: Even if one port/service if not open from the list of all firewall ports in pillar, an error message saying `Validation of open ports failed` will appear.
 
 Test Execution : [EOS-19543](https://jts.seagate.com/browse/EOS-19543)
 
@@ -930,7 +930,7 @@ Test Execution : [EOS-21229](https://jts.seagate.com/browse/EOS-21229)
       1. Go to **Maintenance** tab  
 
       2. Click **Manage** link against **Firmware update**  
-         The link should open a new page without any error popups.
+         The link should open a new page with no error message coming up.
 
  4. Ensure requried Salt module is loaded  
       ```bash
@@ -975,4 +975,4 @@ Test Execution : [EOS-21229](https://jts.seagate.com/browse/EOS-21229)
       2. Click **Manage** link against **Firmware update**  
          The link should either be missing  
          or  
-         Should pop up an error **This feature is not supported on this environment**.  
+         Should surface an error **This feature is not supported on this environment**.  


### PR DESCRIPTION
… scan report with considerate alternatives

Signed-off-by: Kailash Yadav <kailash.yadav@seagate.com>

# Problem Statement
- Use of insensitive, inconsiderate  words are harmful such as gender favoring, polarizing, race related, religion inconsiderate, or other unequal phrasing in text.
# Design
-  https://jts.seagate.com/browse/CORTX-28518
-  

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

-----
[View rendered api/python/README.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/api/python/README.md)
[View rendered devops/jenkins/README.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/devops/jenkins/README.md)
[View rendered docs/Architecture/Architectural-Overview.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/docs/Architecture/Architectural-Overview.md)
[View rendered docs/Architecture/Validation.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/docs/Architecture/Validation.md)
[View rendered docs/User-Guides/Deploy VM Hosted Repo.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/docs/User-Guides/Deploy VM Hosted Repo.md)
[View rendered docs/mocks.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/docs/mocks.md)
[View rendered docs/protecting_os.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/docs/protecting_os.md)
[View rendered test/deploy/kubernetes/README.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/test/deploy/kubernetes/README.md)
[View rendered test/r2.md](https://github.com/Seagate/cortx-prvsnr/blob/CORTX-28518_Alex_Report/test/r2.md)