### PR TITLE
CORTX-30863: fix: Handled the conf save invoke at caller end instead …

### DIFF
--- a/conf/solution/config.yaml.sample
+++ b/conf/solution/config.yaml.sample
@@ -99,7 +99,7 @@ cortx:
           min: 1000m                                           # 1000m * N where N = Num of "ios" Containers
           max: 1500m                                           # 1500m * N where N = Num of "ios" Containers
       - name: confd
-          memory:
+        memory:
           min: 128Mi
           max: 512Mi
         cpu:

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -127,7 +127,8 @@ class CortxProvisioner:
                     Conf.set(CortxProvisioner._solution_index, key, val.decode('utf-8'))
             CortxProvisioner.apply_cortx_config(cortx_conf, CortxProvisioner.cortx_release)
             # Adding array count key in conf
-            CortxProvisioner._add_num_keys(cortx_conf)
+            cortx_conf.add_num_keys()
+            Conf.save(cortx_conf._conf_idx)
 
     @staticmethod
     def apply_cortx_config(cortx_conf, cortx_release):
@@ -415,14 +416,3 @@ class CortxProvisioner:
         """API call to get cluster health."""
         # TODO Make a call to HA Health API to get the resource status
         return "OK"
-
-    @staticmethod
-    def _add_num_keys(cortx_conf:MappedConf):
-        """
-        Add num_xxx keys that holds the count of list items in gconf.
-
-        Keywords:
-        cortx_conf: Conf store mapped to gconf URL path
-        """
-        cortx_conf.add_num_keys()
-        Conf.save(cortx_conf._conf_idx)

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -127,7 +127,7 @@ class CortxProvisioner:
                     Conf.set(CortxProvisioner._solution_index, key, val.decode('utf-8'))
             CortxProvisioner.apply_cortx_config(cortx_conf, CortxProvisioner.cortx_release)
             # Adding array count key in conf
-            cortx_conf.add_num_keys()
+            CortxProvisioner._add_num_keys(cortx_conf)
 
     @staticmethod
     def apply_cortx_config(cortx_conf, cortx_release):
@@ -415,3 +415,14 @@ class CortxProvisioner:
         """API call to get cluster health."""
         # TODO Make a call to HA Health API to get the resource status
         return "OK"
+
+    @staticmethod
+    def _add_num_keys(cortx_conf:MappedConf):
+        """
+        Add num_xxx keys that holds the count of list items in gconf.
+
+        Keywords:
+        cortx_conf: Conf store mapped to gconf URL path
+        """
+        cortx_conf.add_num_keys()
+        Conf.save(cortx_conf._conf_idx)

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -21,6 +21,7 @@ import os
 import traceback
 import unittest
 from cortx.provisioner.provisioner import CortxProvisioner
+from cortx.utils.conf_store import Conf
 
 solution_cluster_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "cluster.yaml"))
 solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "config.yaml"))
@@ -50,6 +51,25 @@ class TestProvisioner(unittest.TestCase):
             sys.stderr.write("%s\n" % traceback.format_exc())
             rc = 1
         self.assertEqual(rc, 0)
+
+    def test_num_cvg_in_gconf(self):
+        """Test if num_cvg key is present in gconf (CORTX-30863)"""
+        rc = 0
+        try:
+            CortxProvisioner.config_apply(solution_cluster_url, cortx_conf_url)
+            CortxProvisioner.config_apply(solution_conf_url, cortx_conf_url, force_override=True)
+        except Exception as e:
+            print('Exception: ', e)
+            sys.stderr.write("%s\n" % traceback.format_exc())
+            rc = 1
+        self.assertEqual(rc, 0)
+        Conf.load('test_index', cortx_conf_url)
+        all_keys = Conf.get_keys('test_index')
+        is_num_cvg = False
+        for key in all_keys:
+            if 'num_cvg' in key:
+                is_num_cvg = True
+        self.assertTrue(is_num_cvg, "The key num_cvg is not present in Gconf")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -73,7 +73,8 @@ class TestProvisioner(unittest.TestCase):
                 'c' : [{'5' : ['6', '7']}, '8']
         }
         test_index = 'test_index'
-        config_path = "/tmp/sample_config.yaml"
+        working_directory = os.path.realpath(sys.argv[0])
+        config_path = os.path.join(working_directory,"/sample_config.yaml")
         with open(config_path, 'w+') as config:
             config.write(yaml.dump(data))
         config_url = f"yaml://{config_path}"

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -29,7 +29,6 @@ cortx_conf_url = "yaml:///tmp/test_conf_store.conf"
 
 def check_num_xx_keys(data):
     """Returns true if all the xxx list have respective num_xxx key"""
-    result = False
     if isinstance(data, dict):
         for k, v in data.items():
             if isinstance(v, dict):
@@ -83,7 +82,6 @@ class TestProvisioner(unittest.TestCase):
         with open(conf_path, 'r') as stream:
             try:
                 gconf =yaml.safe_load(stream)
-                print(gconf)
             except yaml.YAMLError as exc:
                 print(exc)
                 rc = 1

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -81,7 +81,6 @@ class TestProvisioner(unittest.TestCase):
         cortx_conf = MappedConf(config_url)
         cortx_conf.add_num_keys()
         Conf.load(test_index, config_url)
-        print(Conf.get_keys(test_index))
         self.assertEqual(None, Conf.get(test_index, 'num_a'))
         self.assertEqual(None, Conf.get(test_index, 'c[0]>num_5'))
         delete_file(config_path)

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -49,7 +49,7 @@ class TestProvisioner(unittest.TestCase):
             print('Exception: ', e)
             sys.stderr.write("%s\n" % traceback.format_exc())
             rc = 1
-        self.assertEqual(rc, 0)  
+        self.assertEqual(rc, 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -72,7 +72,8 @@ class TestProvisioner(unittest.TestCase):
                 'b' : '4',
                 'c' : [{'5' : ['6', '7']}, '8']
         }
-        test_index = 'test_index'
+        test_index1 = 'test_index1'
+        test_index2 = 'test_index2'
         working_directory = os.path.realpath(sys.argv[0])
         config_path = os.path.join(working_directory,"/sample_config.yaml")
         with open(config_path, 'w+') as config:
@@ -80,9 +81,13 @@ class TestProvisioner(unittest.TestCase):
         config_url = f"yaml://{config_path}"
         cortx_conf = MappedConf(config_url)
         cortx_conf.add_num_keys()
-        Conf.load(test_index, config_url)
-        self.assertEqual(None, Conf.get(test_index, 'num_a'))
-        self.assertEqual(None, Conf.get(test_index, 'c[0]>num_5'))
+        Conf.load(test_index1, config_url)
+        self.assertEqual(None, Conf.get(test_index1, 'num_a'))
+        self.assertEqual(None, Conf.get(test_index1, 'c[0]>num_5'))
+        Conf.save(cortx_conf._conf_idx)
+        Conf.load(test_index2, config_url)
+        self.assertEqual(3, Conf.get(test_index2, 'num_a'))
+        self.assertEqual(2, Conf.get(test_index2, 'c[0]>num_5'))
         delete_file(config_path)
 
 if __name__ == '__main__':

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -32,7 +32,6 @@ class TestProvisioner(unittest.TestCase):
 
     def test_config_apply_bootstrap(self):
         """ Test Config Apply """
-
         rc = 0
         try:
             CortxProvisioner.config_apply(solution_cluster_url, cortx_conf_url)
@@ -41,9 +40,7 @@ class TestProvisioner(unittest.TestCase):
             print('Exception: ', e)
             sys.stderr.write("%s\n" % traceback.format_exc())
             rc = 1
-
         self.assertEqual(rc, 0)
-
         rc = 0
         try:
             CortxProvisioner.cluster_bootstrap(cortx_conf_url)
@@ -52,7 +49,6 @@ class TestProvisioner(unittest.TestCase):
             print('Exception: ', e)
             sys.stderr.write("%s\n" % traceback.format_exc())
             rc = 1
-
         self.assertEqual(rc, 0)  
 
 if __name__ == '__main__':

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -28,14 +28,6 @@ solution_cluster_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(
 solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "config.yaml"))
 cortx_conf_url = "yaml:///tmp/test_conf_store.conf"
 
-def delete_file(file):
-    """Delete Temporary file."""
-    try:
-        if os.path.exists(file):
-            os.remove(file)
-    except OSError as e:
-        print(e)
-
 class TestProvisioner(unittest.TestCase):
 
     """Test cortx_setup config and cluster functionality."""
@@ -64,31 +56,6 @@ class TestProvisioner(unittest.TestCase):
             rc = 1
 
         self.assertEqual(rc, 0)
-
-    def test_add_num_keys(self):
-        """Test add_num_keys interface."""
-        data = {
-                'a' : ['1', '2', '3'],
-                'b' : '4',
-                'c' : [{'5' : ['6', '7']}, '8']
-        }
-        test_index1 = 'test_index1'
-        test_index2 = 'test_index2'
-        working_directory = os.path.realpath(sys.argv[0])
-        config_path = os.path.join(working_directory,"/sample_config.yaml")
-        with open(config_path, 'w+') as config:
-            config.write(yaml.dump(data))
-        config_url = f"yaml://{config_path}"
-        cortx_conf = MappedConf(config_url)
-        cortx_conf.add_num_keys()
-        Conf.load(test_index1, config_url)
-        self.assertEqual(None, Conf.get(test_index1, 'num_a'))
-        self.assertEqual(None, Conf.get(test_index1, 'c[0]>num_5'))
-        Conf.save(cortx_conf._conf_idx)
-        Conf.load(test_index2, config_url)
-        self.assertEqual(3, Conf.get(test_index2, 'num_a'))
-        self.assertEqual(2, Conf.get(test_index2, 'c[0]>num_5'))
-        delete_file(config_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -28,7 +28,7 @@ solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys
 cortx_conf_url = "yaml:///tmp/test_conf_store.conf"
 
 def check_num_xx_keys(data):
-    """Returns true if all the xxx list have respective num_xxx key"""
+    """Returns true if all the xxx list have respective num_xxx key."""
     if isinstance(data, dict):
         for k, v in data.items():
             if isinstance(v, dict):
@@ -40,7 +40,7 @@ def check_num_xx_keys(data):
     if isinstance(data, list):
         for v in data:
             check_num_xx_keys(v)
-    return True, f"The keys num_xx are saved in gconf"
+    return True, "The keys num_xx are saved in gconf"
 
 class TestProvisioner(unittest.TestCase):
 
@@ -68,7 +68,7 @@ class TestProvisioner(unittest.TestCase):
         self.assertEqual(rc, 0)
 
     def test_num_xxx_in_gconf(self):
-        """Test if num_xxx key is saved in gconf for list items(CORTX-30863)"""
+        """Test if num_xxx key is saved in gconf for list items(CORTX-30863)."""
         rc = 0
         try:
             CortxProvisioner.config_apply(solution_cluster_url, cortx_conf_url)

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -79,10 +79,11 @@ class TestProvisioner(unittest.TestCase):
             config.write(yaml.dump(data))
         config_url = f"yaml://{config_path}"
         cortx_conf = MappedConf(config_url)
-        CortxProvisioner._add_num_keys(cortx_conf)
+        cortx_conf.add_num_keys()
         Conf.load(test_index, config_url)
-        self.assertEqual(3, Conf.get(test_index, 'num_a'))
-        self.assertEqual(2, Conf.get(test_index, 'c[0]>num_5'))
+        print(Conf.get_keys(test_index))
+        self.assertEqual(None, Conf.get(test_index, 'num_a'))
+        self.assertEqual(None, Conf.get(test_index, 'c[0]>num_5'))
         delete_file(config_path)
 
 if __name__ == '__main__':

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -20,12 +20,21 @@ import sys
 import os
 import traceback
 import unittest
+import yaml
 from cortx.provisioner.provisioner import CortxProvisioner
+from cortx.utils.conf_store import MappedConf, Conf
 
 solution_cluster_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "cluster.yaml"))
 solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "config.yaml"))
 cortx_conf_url = "yaml:///tmp/test_conf_store.conf"
 
+def delete_file(file):
+    """Delete Temporary file."""
+    try:
+        if os.path.exists(file):
+            os.remove(file)
+    except OSError as e:
+        print(e)
 
 class TestProvisioner(unittest.TestCase):
 
@@ -56,6 +65,24 @@ class TestProvisioner(unittest.TestCase):
 
         self.assertEqual(rc, 0)
 
+    def test_add_num_keys(self):
+        """Test add_num_keys interface."""
+        data = {
+                'a' : ['1', '2', '3'],
+                'b' : '4',
+                'c' : [{'5' : ['6', '7']}, '8']
+        }
+        test_index = 'test_index'
+        config_path = "/tmp/sample_config.yaml"
+        with open(config_path, 'w+') as config:
+            config.write(yaml.dump(data))
+        config_url = f"yaml://{config_path}"
+        cortx_conf = MappedConf(config_url)
+        CortxProvisioner._add_num_keys(cortx_conf)
+        Conf.load(test_index, config_url)
+        self.assertEqual(3, Conf.get(test_index, 'num_a'))
+        self.assertEqual(2, Conf.get(test_index, 'c[0]>num_5'))
+        delete_file(config_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -81,7 +81,7 @@ class TestProvisioner(unittest.TestCase):
         conf_path = cortx_conf_url.split('//')[1]
         with open(conf_path, 'r') as stream:
             try:
-                gconf =yaml.safe_load(stream)
+                gconf = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 print(exc)
                 rc = 1

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -53,19 +53,7 @@ class TestProvisioner(unittest.TestCase):
             sys.stderr.write("%s\n" % traceback.format_exc())
             rc = 1
 
-        self.assertEqual(rc, 0)
-    
-    def test_001_motr_mini_provisioner(self):
-        """Test required keys e.g. num_cvg are present for Motr mini provisioner."""
-        rc = 0
-        try:
-            CortxProvisioner.config_apply(solution_cluster_url, cortx_conf_url)
-        except Exception as e:
-            print('Exception: ', e)
-            sys.stderr.write("%s\n" % traceback.format_exc())
-            rc = 1
-        self.assertEqual(rc, 0)
-        mini_provisioner(cortx_conf_url, 'storage>num_cvg')
+        self.assertEqual(rc, 0)  
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -20,9 +20,7 @@ import sys
 import os
 import traceback
 import unittest
-import yaml
 from cortx.provisioner.provisioner import CortxProvisioner
-from cortx.utils.conf_store import MappedConf, Conf
 
 solution_cluster_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "cluster.yaml"))
 solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "config.yaml"))
@@ -56,6 +54,18 @@ class TestProvisioner(unittest.TestCase):
             rc = 1
 
         self.assertEqual(rc, 0)
+    
+    def test_001_motr_mini_provisioner(self):
+        """Test required keys e.g. num_cvg are present for Motr mini provisioner."""
+        rc = 0
+        try:
+            CortxProvisioner.config_apply(solution_cluster_url, cortx_conf_url)
+        except Exception as e:
+            print('Exception: ', e)
+            sys.stderr.write("%s\n" % traceback.format_exc())
+            rc = 1
+        self.assertEqual(rc, 0)
+        mini_provisioner(cortx_conf_url, 'storage>num_cvg')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…of conf_store

Signed-off-by: Kailash Yadav <kailash.yadav@seagate.com>

# Problem Statement
-  Fix the problem where num_xxx keys for the list items are not being saved to the gconf.

# Design
-  [For Bug, Describe the fix here.](https://jts.seagate.com/browse/CORTX-30863)
-  Caller of the add_num_keys API should also explicitly call to save the confstore keys to Gconf.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-   [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
-   [x] Unit and System Tests are added
-   [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
-   [ ] Interface change (if any) are documented
-   [x] Side effects on other features (deployment/upgrade)
-   [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
-   [x] JIRA number/GitHub Issue added to PR
-   [x] PR is self reviewed
-   [x] Jira and state/status is updated and JIRA is updated with PR link
-   [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
-   [x] Changes done to WIKI / Confluence page / Quick Start Guide