### PR TITLE
CORTX-31132: Implementation for gconf upgrade

### DIFF
--- a/conf/solution/config.yaml.sample
+++ b/conf/solution/config.yaml.sample
@@ -156,8 +156,7 @@ cortx:
       - https://control-svc:8081
     email_address: cortx@seagate.com # Optional 
     mgmt_admin: cortxadmin
-    mgmt_secret: !!binary |
-      UlU1U0NrYklraS0ta3BOamN5X2J1VmUwRnJXTUFlb2JDdkItY1B3ZEE9PQ==
+    mgmt_secret: csm_mgmt_admin_secret
     limits:   
       services:              
       - name: agent

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -27,5 +27,5 @@ UPGRADE_MODE_VAL = ""
 REQUIRED_EXTERNAL_SW = ['kafka', 'consul']
 DELTA_PATH = "yaml:///etc/cortx/delta.conf"
 DELTA_IDX = 'delta_index'
-CORTX_TMP_URL = "yaml:///etc/cortx/tmp.conf"
+CORTX_TMP_URL = "yaml://tmp/tmp.conf"
 TMP_IDX = "tmp_conf"

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -25,4 +25,4 @@ UPGRADE_MODE_KEY = "UPGRADE_MODE"
 # 'UPGRADE_MODE_VAL' constant for default upgrade mode.
 UPGRADE_MODE_VAL = ""
 REQUIRED_EXTERNAL_SW = ['kafka', 'consul']
-CORTX_DELTA_URL = "yaml:///etc/cortx/delta.conf"
+CORTX_DELTA_URL = "yaml:///etc/cortx/changeset.conf"

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -25,7 +25,5 @@ UPGRADE_MODE_KEY = "UPGRADE_MODE"
 # 'UPGRADE_MODE_VAL' constant for default upgrade mode.
 UPGRADE_MODE_VAL = ""
 REQUIRED_EXTERNAL_SW = ['kafka', 'consul']
-DELTA_PATH = "yaml:///etc/cortx/delta.conf"
-DELTA_IDX = 'delta_index'
-CORTX_TMP_URL = "yaml://tmp/tmp.conf"
-TMP_IDX = "tmp_conf"
+CORTX_DELTA_URL = "yaml:///etc/cortx/delta.conf"
+TMP_CORTX_CONF_URL = "yaml:///tmp/tmp.conf"

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -25,3 +25,7 @@ UPGRADE_MODE_KEY = "UPGRADE_MODE"
 # 'UPGRADE_MODE_VAL' constant for default upgrade mode.
 UPGRADE_MODE_VAL = ""
 REQUIRED_EXTERNAL_SW = ['kafka', 'consul']
+DELTA_PATH = "yaml:///etc/cortx/delta.conf"
+DELTA_IDX = 'delta_index'
+CORTX_TMP_URL = "yaml:///etc/cortx/tmp.conf"
+TMP_IDX = "tmp_conf"

--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -26,4 +26,3 @@ UPGRADE_MODE_KEY = "UPGRADE_MODE"
 UPGRADE_MODE_VAL = ""
 REQUIRED_EXTERNAL_SW = ['kafka', 'consul']
 CORTX_DELTA_URL = "yaml:///etc/cortx/delta.conf"
-TMP_CORTX_CONF_URL = "yaml:///tmp/tmp.conf"

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -368,7 +368,7 @@ class CortxProvisioner:
             value= Conf.get(_tmp_idx, key)
             Conf.set(_conf_idx, key, value)
         for key in changed_keys:
-            if key.stratswith('cortx>common'):
+            if key.startswith('cortx>common'):
                 value= Conf.get(_tmp_idx, key)
                 Conf.set(_conf_idx, key, value)
         Conf.save(_conf_idx)

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -77,13 +77,7 @@ class CortxProvisioner:
 
         if cortx_conf_url is None:
             cortx_conf_url = CortxProvisioner._cortx_conf_url
-        cortx_conf = MappedConf(cortx_conf_url)
-
-        # Check if config is already applied on node.
-        node_id = Conf.machine_id
-        if cortx_conf.get(f'node>{node_id}>provisioning>version') and force_override is False:
-            Log.info('CORTX config already applied on this node.')
-            return 0
+        tmp_conf = MappedConf(const.CORTX_TMP_URL)
 
         # Load same config again if force_override is True
         try:
@@ -95,19 +89,19 @@ class CortxProvisioner:
             Log.error(f'Unable to load {solution_config_url} url, Error:{e}')
 
         # Secrets path from config file
-        if cortx_conf.get('cortx>common>storage>local'):
-            CortxProvisioner._secrets_path = cortx_conf.get('cortx>common>storage>local')+CortxProvisioner._rel_secret_path
+        if tmp_conf.get('cortx>common>storage>local'):
+            CortxProvisioner._secrets_path = tmp_conf.get('cortx>common>storage>local')+CortxProvisioner._rel_secret_path
 
         # source code for encrypting and storing secret key
         if Conf.get(CortxProvisioner._solution_index, 'cluster') is not None:
-            CortxProvisioner.apply_cluster_config(cortx_conf, CortxProvisioner.cortx_release)
+            CortxProvisioner.apply_cluster_config(tmp_conf, CortxProvisioner.cortx_release)
 
         if Conf.get(CortxProvisioner._solution_index, 'cortx') is not None:
             # generating cipher key
             cipher_key = None
             cluster_id = Conf.get(CortxProvisioner._solution_index, 'cluster>id')
             if cluster_id is None:
-                cluster_id = cortx_conf.get('cluster>id')
+                cluster_id = tmp_conf.get('cluster>id')
                 if cluster_id is None:
                     raise CortxProvisionerError(errno.EINVAL, 'Cluster ID not specified')
             cipher_key = Cipher.gen_key(cluster_id, 'cortx')
@@ -126,20 +120,20 @@ class CortxProvisioner:
                     val = Cipher.encrypt(cipher_key, val)
                     # decoding the byte string in val variable
                     Conf.set(CortxProvisioner._solution_index, key, val.decode('utf-8'))
-            CortxProvisioner.apply_cortx_config(cortx_conf, CortxProvisioner.cortx_release)
+            CortxProvisioner.apply_cortx_config(tmp_conf, CortxProvisioner.cortx_release)
             # Adding array count key in conf
-            cortx_conf.add_num_keys()
-            Conf.save(cortx_conf._conf_idx)
+            tmp_conf.add_num_keys()
+            Conf.save(tmp_conf._conf_idx)
 
     @staticmethod
-    def apply_cortx_config(cortx_conf, cortx_release):
+    def apply_cortx_config(tmp_conf, cortx_release):
         """Convert CORTX config into confstore keys"""
         config_info = Conf.get(CortxProvisioner._solution_index, 'cortx')
         cortx_solution_config = CortxConfig(config_info, cortx_release)
-        cortx_solution_config.save(cortx_conf, CortxProvisioner._solution_index)
+        cortx_solution_config.save(tmp_conf, CortxProvisioner._solution_index)
 
     @staticmethod
-    def apply_cluster_config(cortx_conf, cortx_release):
+    def apply_cluster_config(tmp_conf, cortx_release):
         node_map = {}
         try:
             node_types = Conf.get(CortxProvisioner._solution_index, 'cluster>node_types')
@@ -156,7 +150,7 @@ class CortxProvisioner:
                 node_map[node_type['name']] = node_type
             cluster_keys = [('cluster>id', cluster_id),
                 ('cluster>name', cluster_name)]
-            cortx_conf.set_kvs(cluster_keys)
+            tmp_conf.set_kvs(cluster_keys)
 
             nodes = []
             for storage_set in storage_sets:
@@ -168,9 +162,9 @@ class CortxProvisioner:
                     nodes.append(node)
 
             solution_config_nodes = CortxCluster(nodes, cortx_release)
-            solution_config_nodes.save(cortx_conf)
+            solution_config_nodes.save(tmp_conf)
             solution_config_storagesets = CortxStorageSet(storage_sets)
-            solution_config_storagesets.save(cortx_conf)
+            solution_config_storagesets.save(tmp_conf)
         except KeyError as e:
             raise CortxProvisionerError(
                 errno.EINVAL,
@@ -227,9 +221,14 @@ class CortxProvisioner:
                         continue
                 CortxProvisioner._update_provisioning_status(
                         cortx_conf, node_id, apply_phase, ProvisionerStatus.PROGRESS.value)
-                cmd = (
-                    f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
-                    f" --config {cortx_conf._conf_url} --services {service}")
+                if interface.value == 'upgrade':
+                    cmd = (
+                        f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
+                        f" --delta {const.DELTA_PATH} --config {cortx_conf._conf_url} --services {service}")
+                else:
+                    cmd = (
+                        f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
+                        f" --config {cortx_conf._conf_url} --services {service}")
                 Log.info(f"{cmd}")
                 cmd_proc = SimpleProcess(cmd)
                 _, err, rc = cmd_proc.run()
@@ -261,6 +260,44 @@ class CortxProvisioner:
         Description:
 
         Configures Cluster Components
+        1. Compares current installed version with New version
+        2. Invoke Mini Provisioners of cluster components deploy/upgrade based on version compatibility
+        Paramaters:
+        [IN] CORTX Config URL
+        """
+        cortx_conf = MappedConf(cortx_conf_url)
+        node_id = Conf.machine_id
+        Conf.load(const.TMP_IDX, const.CORTX_TMP_URL)
+        tmp_conf_keys = Conf.get_keys(const.TMP_IDX)
+        installed_version = cortx_conf.get(f'node>{node_id}>provisioning>version')
+        release_version = CortxProvisioner.cortx_release.get_release_version()
+        if installed_version is None:
+            cortx_conf.copy(const.TMP_IDX, tmp_conf_keys)
+            Conf.save(cortx_conf._conf_idx)
+            CortxProvisioner.cluster_deploy(cortx_conf_url, force_override)
+        else:
+            # TODO: add a case where release_version > installed_version but is not compatible.
+            ret_code = CortxProvisioner.cortx_release.version_check(
+                release_version, installed_version)
+            if ret_code == 1:
+                CortxProvisioner.Prepare_upgrade(cortx_conf._conf_idx, const.TMP_IDX)
+                CortxProvisioner.cluster_upgrade(cortx_conf_url, force_override)
+                CortxProvisioner.Post_upgrade(cortx_conf, const.TMP_IDX, tmp_conf_keys)
+            # TODO: This will be removed once downgrade is also supported.
+            elif ret_code == -1:
+                raise CortxProvisionerError(errno.EINVAL, 'Downgrade is Not Supported')
+            elif ret_code == 0:
+                cortx_conf.copy(const.TMP_IDX, tmp_conf_keys)
+                Conf.save(cortx_conf._conf_idx)
+                CortxProvisioner.cluster_deploy(cortx_conf_url, force_override)
+            else:
+                raise CortxProvisionerError(errno.EINVAL, 'Internal error. Could not determine version. Invalid image.')
+
+    @staticmethod
+    def cluster_deploy(cortx_conf_url: str, force_override: bool = False):
+        """
+        Description:
+        Configures Cluster Components
         1. Reads Cortx Config and obtain cluster components
         2. Invoke Mini Provisioners of cluster components
         Paramaters:
@@ -288,6 +325,27 @@ class CortxProvisioner:
             cortx_conf, node_id, apply_phase, ProvisionerStatus.SUCCESS.value)
         Log.info(f"Finished cluster bootstrap on {node_id}:{node_name}")
 
+    @staticmethod
+    def Prepare_upgrade(_conf_idx: str, _tmp_idx: str):
+        new_keys, deleted_keys, updated_keys = Conf.compare(_conf_idx, _tmp_idx)
+        Conf.load(const.DELTA_IDX, const.DELTA_PATH)
+        for key in new_keys:
+            Conf.set(const.DELTA_IDX, f'new>{key}', Conf.get(_tmp_idx, key))
+        for key in deleted_keys:
+            Conf.set(const.DELTA_IDX, f'deleted>{key}', Conf.get(_conf_idx, key))
+        for key in updated_keys:
+            value = f"{Conf.get(_conf_idx, key)}|{Conf.get(_tmp_idx, key)}"
+            Conf.set(const.DELTA_IDX, f'updated>{key}', value)
+        Conf.save(const.DELTA_IDX)
+
+    @staticmethod
+    def Post_upgrade(cortx_conf: MappedConf, _tmp_idx: str, keys: list):
+        _, deleted_keys, _ = Conf.compare(cortx_conf._conf_idx, _tmp_idx)
+        cortx_conf.copy(_tmp_idx, keys)
+        for key in deleted_keys:
+            Conf.delete(cortx_conf._conf_idx, key)
+        Conf.save(cortx_conf._conf_idx)
+    
     @staticmethod
     def cluster_upgrade(cortx_conf_url: str, force_override: bool = False):
         """

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -348,7 +348,7 @@ class CortxProvisioner:
         for key in deleted_keys:
             cortx_conf.delete(key)
         Conf.save(cortx_conf._conf_idx)
-    
+
     @staticmethod
     def cluster_upgrade(cortx_conf_url: str, force_override: bool = False):
         """

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -343,13 +343,13 @@ class CortxProvisioner:
         [idx2] conf index 2
         [diff_idx] delta diff index
         """
-        new_keys, deleted_keys, updated_keys = Conf.compare(idx1, idx2)
+        new_keys, deleted_keys, changed_keys = Conf.compare(idx1, idx2)
         Conf.load(diff_idx, const.CORTX_DELTA_URL)
         for key in new_keys:
             Conf.set(diff_idx, f'new>{key}', Conf.get(idx2, key))
         for key in deleted_keys:
             Conf.set(diff_idx, f'deleted>{key}', Conf.get(idx1, key))
-        for key in updated_keys:
+        for key in changed_keys:
             value = f"{Conf.get(idx1, key)}|{Conf.get(idx2, key)}"
             Conf.set(diff_idx, f'changed>{key}', value)
         Conf.save(diff_idx)
@@ -361,11 +361,16 @@ class CortxProvisioner:
         Updates conf by updating new keys/values post upgrade.
         1. Fetch new keys using conf compare
         2. Update gconf by adding new keys.
+        3. Update gconf by updating changed values for cortx>common
         """
-        new_keys, _, _ = Conf.compare(_conf_idx, _tmp_idx)
+        new_keys, _, changed_keys = Conf.compare(_conf_idx, _tmp_idx)
         for key in new_keys:
             value= Conf.get(_tmp_idx, key)
             Conf.set(_conf_idx, key, value)
+        for key in changed_keys:
+            if key.stratswith('cortx>common'):
+                value= Conf.get(_tmp_idx, key)
+                Conf.set(_conf_idx, key, value)
         Conf.save(_conf_idx)
 
     @staticmethod

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -226,10 +226,10 @@ class CortxProvisioner:
                 CortxProvisioner._update_provisioning_status(
                         _conf_idx, node_id, apply_phase, ProvisionerStatus.PROGRESS.value)
                 if interface.value == 'upgrade':
-                    # TODO: Remove config parameter for upgrade once all components will have --delta implementation
+                    # TODO: add --changeset parameter once all components support config upgrade
                     cmd = (
                         f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
-                        f" --changeset {const.CORTX_DELTA_URL} --config {cortx_conf_url} --services {service}")
+                        f" --config {cortx_conf_url} --services {service}")
                 else:
                     cmd = (
                         f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -54,6 +54,7 @@ class CortxProvisioner:
     _solution_index = "solution_conf"
     _tmp_index = "temp_conf"
     _delta_index = "delta_index"
+    _conf_index = "conf_index"
     _secrets_path = "/etc/cortx/solution/secret"
     _rel_secret_path = "/solution/secret"
     _cortx_gconf_consul_index = "consul_index"
@@ -174,7 +175,7 @@ class CortxProvisioner:
                 f'Error occurred while applying cluster_config {e}')
 
     @staticmethod
-    def _get_node_info(cortx_conf: MappedConf):
+    def _get_node_info(_conf_idx: str):
         """To get the node information."""
         node_id = Conf.machine_id
         if node_id is None:
@@ -183,79 +184,79 @@ class CortxProvisioner:
 
         # Reinitialize logging with configured log path
         log_path = os.path.join(
-            cortx_conf.get('cortx>common>storage>log'), const.APP_NAME, node_id)
+            Conf.get(_conf_idx, 'cortx>common>storage>log'), const.APP_NAME, node_id)
         log_level = os.getenv('CORTX_PROVISIONER_DEBUG_LEVEL', const.DEFAULT_LOG_LEVEL)
         CortxProvisionerLog.reinitialize(
             const.SERVICE_NAME, log_path, level=log_level)
 
-        if cortx_conf.get(f'node>{node_id}>name') is None:
+        if Conf.get(_conf_idx, f'node>{node_id}>name') is None:
             raise CortxProvisionerError(
                 errno.EINVAL, f'Node name not found in cortx config for node {node_id}.')
 
-        node_name = cortx_conf.get(f'node>{node_id}>name')
+        node_name = Conf.get(_conf_idx, f'node>{node_id}>name')
 
         return node_id, node_name
 
     @staticmethod
-    def _provision_components(cortx_conf: MappedConf, interfaces: Enum, apply_phase: str):
+    def _provision_components(cortx_conf_url: str, _conf_idx: str, interfaces: Enum, apply_phase: str):
         """Invoke Mini Provisioners of cluster components."""
-        node_id, _ = CortxProvisioner._get_node_info(cortx_conf)
-        num_components = int(cortx_conf.get(f'node>{node_id}>num_components'))
+        node_id, _ = CortxProvisioner._get_node_info(_conf_idx)
+        num_components = int(Conf.get(_conf_idx, f'node>{node_id}>num_components'))
         for interface in interfaces:
             for comp_idx in range(0, num_components):
                 key_prefix = f'node>{node_id}>components[{comp_idx}]'
-                component_name = cortx_conf.get(f'{key_prefix}>name')
+                component_name = Conf.get(_conf_idx, f'{key_prefix}>name')
                 # Check if RPM exists for the component, if it does exist get the build version
                 component_version = CortxProvisioner.cortx_release.get_component_version(
                     component_name)
                 # Get services.
                 service_idx = 0
                 services = []
-                while (cortx_conf.get(f'{key_prefix}>services[{service_idx}]') is not None):
-                    services.append(cortx_conf.get(f'{key_prefix}>services[{service_idx}]'))
+                while (Conf.get(_conf_idx, f'{key_prefix}>services[{service_idx}]') is not None):
+                    services.append(Conf.get(_conf_idx, f'{key_prefix}>services[{service_idx}]'))
                     service_idx = service_idx + 1
                 service = 'all' if service_idx == 0 else ','.join(services)
                 if apply_phase == ProvisionerStages.UPGRADE.value:
-                    version = cortx_conf.get(f'{key_prefix}>version')
+                    version = Conf.get(_conf_idx, f'{key_prefix}>version')
                     # Skip update for component if it is already updated.
                     is_updated = CortxProvisioner._is_component_updated(component_name, version)
                     if is_updated is True:
                         Log.info(f'{component_name} is already updated with {version} version.')
                         continue
                 CortxProvisioner._update_provisioning_status(
-                        cortx_conf, node_id, apply_phase, ProvisionerStatus.PROGRESS.value)
+                        _conf_idx, node_id, apply_phase, ProvisionerStatus.PROGRESS.value)
                 if interface.value == 'upgrade':
                     # TODO: Remove config parameter for upgrade once all components will have --delta implementation
                     cmd = (
                         f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
-                        f" --changeset {const.CORTX_DELTA_URL} --config {cortx_conf._conf_url} --services {service}")
+                        f" --changeset {const.CORTX_DELTA_URL} --config {cortx_conf_url} --services {service}")
                 else:
                     cmd = (
                         f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
-                        f" --config {cortx_conf._conf_url} --services {service}")
+                        f" --config {cortx_conf_url} --services {service}")
                 Log.info(f"{cmd}")
                 cmd_proc = SimpleProcess(cmd)
                 _, err, rc = cmd_proc.run()
                 if rc != 0:
                     CortxProvisioner._update_provisioning_status(
-                        cortx_conf, node_id, apply_phase, ProvisionerStatus.ERROR.value)
+                        _conf_idx, node_id, apply_phase, ProvisionerStatus.ERROR.value)
                     raise CortxProvisionerError(
                         rc, "%s phase of %s, failed. %s", interface.value,
                         component_name, err)
 
                 # Update version for each component if Provisioning successful.
-                cortx_conf.set(f'{key_prefix}>version', component_version)
+                Conf.set(_conf_idx, f'{key_prefix}>version', component_version)
 
     @staticmethod
-    def _apply_consul_config(cortx_conf: MappedConf):
-        num_endpoints = cortx_conf.get('cortx>external>consul>num_endpoints')
+    def _apply_consul_config(_conf_idx: str):
+        num_endpoints = Conf.get(_conf_idx, 'cortx>external>consul>num_endpoints')
         for idx in range(0, num_endpoints):
-            if 'http' in cortx_conf.get(f'cortx>external>consul>endpoints[{idx}]'):
-                consul_endpoint = cortx_conf.get(f'cortx>external>consul>endpoints[{idx}]')
+            if 'http' in Conf.get(_conf_idx, f'cortx>external>consul>endpoints[{idx}]'):
+                consul_endpoint = Conf.get(_conf_idx, f'cortx>external>consul>endpoints[{idx}]')
                 break
         gconf_consul_url = consul_endpoint.replace('http','consul') + '/conf'
         Conf.load(CortxProvisioner._cortx_gconf_consul_index, gconf_consul_url)
-        Conf.copy(cortx_conf._conf_idx, CortxProvisioner._cortx_gconf_consul_index, Conf.get_keys(cortx_conf._conf_idx))
+        Conf.copy(_conf_idx, CortxProvisioner._cortx_gconf_consul_index, Conf.get_keys(_conf_idx))
         Conf.save(CortxProvisioner._cortx_gconf_consul_index)
 
     @staticmethod
@@ -269,32 +270,33 @@ class CortxProvisioner:
         Paramaters:
         [IN] CORTX Config URL
         """
-        cortx_conf = MappedConf(cortx_conf_url)
-        node_id = Conf.machine_id
+        Conf.load(CortxProvisioner._conf_index, cortx_conf_url)
         Conf.load(CortxProvisioner._tmp_index, CortxProvisioner._tmp_cortx_conf_url)
         tmp_conf_keys = Conf.get_keys(CortxProvisioner._tmp_index)
-        installed_version = cortx_conf.get(f'node>{node_id}>provisioning>version')
+        node_id = Conf.machine_id
+        installed_version = Conf.get(CortxProvisioner._conf_index, f'node>{node_id}>provisioning>version')
         release_version = CortxProvisioner.cortx_release.get_release_version()
         if installed_version is None:
-            cortx_conf.copy(CortxProvisioner._tmp_index, tmp_conf_keys)
-            Conf.save(cortx_conf._conf_idx)
+            Conf.copy(CortxProvisioner._tmp_index, CortxProvisioner._conf_index, tmp_conf_keys)
+            Conf.save(CortxProvisioner._conf_index)
+            CortxProvisioner._apply_consul_config(CortxProvisioner._conf_index)
             CortxProvisioner.cluster_deploy(cortx_conf_url, force_override)
         else:
             # TODO: add a case where release_version > installed_version but is not compatible.
             ret_code = CortxProvisioner.cortx_release.version_check(
                 release_version, installed_version)
             if ret_code == 1:
-                CortxProvisioner._prepare_diff(cortx_conf._conf_idx, CortxProvisioner._tmp_index, CortxProvisioner._delta_index)
+                CortxProvisioner._prepare_diff(CortxProvisioner._conf_index, CortxProvisioner._tmp_index, CortxProvisioner._delta_index)
                 CortxProvisioner.cluster_upgrade(cortx_conf_url, force_override)
                 # TODO: update_conf needs to be removed once gconf moves to consul.
                 # Gconf update after upgrade should not be handled here if gconf is in consul.
-                CortxProvisioner._update_conf(cortx_conf, CortxProvisioner._tmp_index, tmp_conf_keys)
+                CortxProvisioner._update_conf(CortxProvisioner._conf_index, CortxProvisioner._tmp_index)
             # TODO: This will be removed once downgrade is also supported.
             elif ret_code == -1:
                 raise CortxProvisionerError(errno.EINVAL, 'Downgrade is Not Supported')
             elif ret_code == 0:
-                cortx_conf.copy(CortxProvisioner._tmp_index, tmp_conf_keys)
-                Conf.save(cortx_conf._conf_idx)
+                Conf.copy(CortxProvisioner._tmp_index, CortxProvisioner._conf_index, tmp_conf_keys)
+                Conf.save(CortxProvisioner._conf_index)
                 CortxProvisioner.cluster_deploy(cortx_conf_url, force_override)
             else:
                 raise CortxProvisionerError(errno.EINVAL, 'Internal error. Could not determine version. Invalid image.')
@@ -309,12 +311,10 @@ class CortxProvisioner:
         Paramaters:
         [IN] CORTX Config URL
         """
-        cortx_conf = MappedConf(cortx_conf_url)
-        CortxProvisioner._apply_consul_config(cortx_conf)
         apply_phase = ProvisionerStages.DEPLOYMENT.value
-        node_id, node_name = CortxProvisioner._get_node_info(cortx_conf)
+        node_id, node_name = CortxProvisioner._get_node_info(CortxProvisioner._conf_index)
         is_valid, ret_code = CortxProvisioner._validate_provisioning_status(
-            cortx_conf, node_id, apply_phase)
+            CortxProvisioner._conf_index, node_id, apply_phase)
         if is_valid is False:
             if force_override is False:
                 Log.warn('Validation check failed, Aborting cluster bootstarp'
@@ -324,11 +324,11 @@ class CortxProvisioner:
                 Log.info('Validation check failed, Forcefully overriding deployment.')
         Log.info(f"Starting cluster bootstrap on {node_id}:{node_name}")
         CortxProvisioner._update_provisioning_status(
-            cortx_conf, node_id, apply_phase)
-        CortxProvisioner._provision_components(cortx_conf, DeploymentInterfaces, apply_phase)
-        CortxProvisioner._add_version_info(cortx_conf, node_id)
+            CortxProvisioner._conf_index, node_id, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf_url, CortxProvisioner._conf_index, DeploymentInterfaces, apply_phase)
+        CortxProvisioner._add_version_info(CortxProvisioner._conf_index, node_id)
         CortxProvisioner._update_provisioning_status(
-            cortx_conf, node_id, apply_phase, ProvisionerStatus.SUCCESS.value)
+            CortxProvisioner._conf_index, node_id, apply_phase, ProvisionerStatus.SUCCESS.value)
         Log.info(f"Finished cluster bootstrap on {node_id}:{node_name}")
 
     @staticmethod
@@ -351,22 +351,22 @@ class CortxProvisioner:
             Conf.set(diff_idx, f'deleted>{key}', Conf.get(idx1, key))
         for key in updated_keys:
             value = f"{Conf.get(idx1, key)}|{Conf.get(idx2, key)}"
-            Conf.set(diff_idx, f'updated>{key}', value)
+            Conf.set(diff_idx, f'changed>{key}', value)
         Conf.save(diff_idx)
 
     @staticmethod
-    def _update_conf(cortx_conf: MappedConf, _tmp_idx: str, keys: list):
+    def _update_conf(_conf_idx: str, _tmp_idx: str):
         """
         Description:
         Updates conf by updating new keys/values post upgrade.
         1. Fetch new keys using conf compare
         2. Update gconf by adding new keys.
         """
-        new_keys, _, _ = Conf.compare(cortx_conf._conf_idx, _tmp_idx)
+        new_keys, _, _ = Conf.compare(_conf_idx, _tmp_idx)
         for key in new_keys:
             value= Conf.get(_tmp_idx, key)
-            cortx_conf.set(key, value)
-        Conf.save(cortx_conf._conf_idx)
+            Conf.set(_conf_idx, key, value)
+        Conf.save(_conf_idx)
 
     @staticmethod
     def cluster_upgrade(cortx_conf_url: str, force_override: bool = False):
@@ -383,11 +383,10 @@ class CortxProvisioner:
         if upgrade_mode != "COLD" and not CortxProvisioner.is_cluster_healthy():
             Log.error('Cluster is unhealthy, Aborting upgrade with return code 1')
             return 1
-        cortx_conf = MappedConf(cortx_conf_url)
         apply_phase = ProvisionerStages.UPGRADE.value
-        node_id, node_name = CortxProvisioner._get_node_info(cortx_conf)
+        node_id, node_name = CortxProvisioner._get_node_info(CortxProvisioner._conf_index)
         is_valid, ret_code = CortxProvisioner._validate_provisioning_status(
-            cortx_conf, node_id, apply_phase)
+            CortxProvisioner._conf_index, node_id, apply_phase)
         if is_valid is False:
             if force_override is False:
                 Log.warn('Validation check failed, Aborting upgrade with '
@@ -398,17 +397,17 @@ class CortxProvisioner:
 
         Log.info(f"Starting cluster upgrade on {node_id}:{node_name}")
         CortxProvisioner._update_provisioning_status(
-            cortx_conf, node_id, apply_phase)
+            CortxProvisioner._conf_index, node_id, apply_phase)
 
-        CortxProvisioner._provision_components(cortx_conf, UpgradeInterfaces, apply_phase)
+        CortxProvisioner._provision_components(cortx_conf_url, CortxProvisioner._conf_index, UpgradeInterfaces, apply_phase)
         # Update CORTX version, once the upgrade is successful
-        CortxProvisioner._add_version_info(cortx_conf, node_id)
+        CortxProvisioner._add_version_info(CortxProvisioner._conf_index, node_id)
         CortxProvisioner._update_provisioning_status(
-            cortx_conf, node_id, apply_phase, ProvisionerStatus.SUCCESS.value)
+            CortxProvisioner._conf_index, node_id, apply_phase, ProvisionerStatus.SUCCESS.value)
         Log.info(f"Finished cluster upgrade on {node_id}:{node_name}")
 
     @staticmethod
-    def _update_provisioning_status(cortx_conf: MappedConf, node_id: str,
+    def _update_provisioning_status(_conf_idx: str, node_id: str,
         phase: str, status: str = ProvisionerStatus.DEFAULT.value):
         """
         Description:
@@ -419,9 +418,10 @@ class CortxProvisioner:
         node_id: machine-id
         phase: deployment/upgrade
         status: default/progress/success/error."""
-        key_prefix = f'node>{node_id}>provisioning>'
-        keys = [(key_prefix + 'phase', phase), (key_prefix + 'status', status)]
-        cortx_conf.set_kvs(keys)
+        key_prefix = f'node>{node_id}>provisioning'
+        Conf.set(_conf_idx, f'{key_prefix}>phase', phase)
+        Conf.set(_conf_idx, f'{key_prefix}>status', status)
+        Conf.save(_conf_idx)
 
     @staticmethod
     def _is_component_updated(component_name: str, deploy_version: str):
@@ -436,18 +436,18 @@ class CortxProvisioner:
         return is_updated
 
     @staticmethod
-    def _add_version_info(cortx_conf: MappedConf, node_id):
+    def _add_version_info(_conf_idx: str, node_id):
         """Add version in confstore."""
         version = CortxProvisioner.cortx_release.get_release_version()
-        cortx_conf.set('cortx>common>release>version', version)
-        cortx_conf.set(f'node>{node_id}>provisioning>version', version)
+        Conf.set(_conf_idx, 'cortx>common>release>version', version)
+        Conf.set(_conf_idx, f'node>{node_id}>provisioning>version', version)
 
     @staticmethod
-    def _validate_provisioning_status(cortx_conf: MappedConf, node_id: str, apply_phase: str):
+    def _validate_provisioning_status(_conf_idx: str, node_id: str, apply_phase: str):
         """Validate provisioning."""
         ret_code = 0
-        recent_phase = cortx_conf.get(f'node>{node_id}>provisioning>phase')
-        recent_status = cortx_conf.get(f'node>{node_id}>provisioning>status')
+        recent_phase = Conf.get(_conf_idx, f'node>{node_id}>provisioning>phase')
+        recent_status = Conf.get(_conf_idx, f'node>{node_id}>provisioning>status')
         msg = f'Recent phase for this node is {recent_phase} and ' + \
                 f'recent status is {recent_status}. '
         # {apply_phase: {recent_phase: {recent_status: [boolean_result,rc]}}}
@@ -495,7 +495,7 @@ class CortxProvisioner:
             Log.error(msg + f'{apply_phase} is not possible on this node.')
             if apply_phase == ProvisionerStages.UPGRADE.value:
                 # Reset status.
-                recent_status = cortx_conf.set(f'node>{node_id}>provisioning>status',
+                recent_status = Conf.set(_conf_idx, f'node>{node_id}>provisioning>status',
                     ProvisionerStatus.DEFAULT.value)
         else:
             Log.info(msg)

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -57,6 +57,7 @@ class CortxProvisioner:
     _secrets_path = "/etc/cortx/solution/secret"
     _rel_secret_path = "/solution/secret"
     _cortx_gconf_consul_index = "consul_index"
+    _tmp_cortx_conf_url = "yaml:///tmp/tmp.conf"
     cortx_release = Release(const.RELEASE_INFO_URL)
 
     @staticmethod
@@ -79,7 +80,7 @@ class CortxProvisioner:
 
         if cortx_conf_url is None:
             cortx_conf_url = CortxProvisioner._cortx_conf_url
-        cortx_conf = MappedConf(const.TMP_CORTX_CONF_URL)
+        cortx_conf = MappedConf(CortxProvisioner._tmp_cortx_conf_url)
 
         # Load same config again if force_override is True
         try:
@@ -270,7 +271,7 @@ class CortxProvisioner:
         """
         cortx_conf = MappedConf(cortx_conf_url)
         node_id = Conf.machine_id
-        Conf.load(CortxProvisioner._tmp_index, const.TMP_CORTX_CONF_URL)
+        Conf.load(CortxProvisioner._tmp_index, CortxProvisioner._tmp_cortx_conf_url)
         tmp_conf_keys = Conf.get_keys(CortxProvisioner._tmp_index)
         installed_version = cortx_conf.get(f'node>{node_id}>provisioning>version')
         release_version = CortxProvisioner.cortx_release.get_release_version()

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -228,7 +228,7 @@ class CortxProvisioner:
                     # TODO: Remove config parameter for upgrade once all components will have --delta implementation
                     cmd = (
                         f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
-                        f" --delta {const.CORTX_DELTA_URL} --config {cortx_conf._conf_url} --services {service}")
+                        f" --changeset {const.CORTX_DELTA_URL} --config {cortx_conf._conf_url} --services {service}")
                 else:
                     cmd = (
                         f"/opt/seagate/cortx/{component_name}/bin/{component_name}_setup {interface.value}"
@@ -359,14 +359,13 @@ class CortxProvisioner:
         """
         Description:
         Updates conf by updating new keys/values post upgrade.
-        1. Fetch deleted keys usinf conf compare
-        2. Update gconf by adding new keys as well as updated values
-        3. Delete all deleted keys from gconf.
+        1. Fetch new keys using conf compare
+        2. Update gconf by adding new keys.
         """
-        _, deleted_keys, _ = Conf.compare(cortx_conf._conf_idx, _tmp_idx)
-        cortx_conf.copy(_tmp_idx, keys)
-        for key in deleted_keys:
-            cortx_conf.delete(key)
+        new_keys, _, _ = Conf.compare(cortx_conf._conf_idx, _tmp_idx)
+        for key in new_keys:
+            value= Conf.get(_tmp_idx, key)
+            cortx_conf.set(key, value)
         Conf.save(cortx_conf._conf_idx)
 
     @staticmethod

--- a/src/setup/cortx_deploy
+++ b/src/setup/cortx_deploy
@@ -84,39 +84,11 @@ function validate_config {
     done
 }
 
-function compare {
-    # Returns
-    # -1 if $1 < v2
-    # 0 if $1 == $2
-    # 1 if $1 > $2
-    deploy_ver_spec=${1%-[0-9]*}
-    release_ver_spec=${2%-[0-9]*}
-
-    deploy_ver=${deploy_ver_spec%.[0-9]}
-    release_ver=${release_ver_spec%.[0-9]}
-    [[ $deploy_ver < $release_ver ]] && echo "-1" && return
-    [[ $deploy_ver > $release_ver ]] && echo "1" && return
-
-    deploy_ver=${deploy_ver_spec#[0-9].[0-9].}
-    release_ver=${release_ver_spec#[0-9].[0-9].}
-    [[ $deploy_ver -lt $release_ver ]] && echo "-1" && return
-    [[ $deploy_ver -gt $release_ver ]] && echo "1" && return
-
-    deploy_build=${1#[0-9.]*-}
-    release_build=${2#[0-9.]*-}
-    [[ $deploy_build -lt $release_build ]] && echo "-1" && return
-    [[ $deploy_build -gt $release_build ]] && echo "1" && return
-
-    echo "0"
-}
-
 # Constants
 DEBUG_FLAG=false
 SOLUTION_CONFIG="/etc/cortx/solution"
 CORTX_CONFSTORE="yaml:///etc/cortx/cluster.conf"
 RELEASE_INFO="yaml:///opt/seagate/cortx/RELEASE.INFO"
-
-action="" # upgrade|deploy|downgrade|replace|recover|etc.
 
 while [ $# -gt 0 ];  do
     case $1 in
@@ -159,43 +131,12 @@ done
 
 export PATH=$PATH:/opt/seagate/provisioner/bin
 
-node_id=`cat /etc/machine-id`
-log $INFO "Starting provisioning on node $node_id."
+# Apply Configuration
+apply_config
+[ ! -z $VALIDATE_CONF ] && validate_config
+# Deploy cortx
+deploy
 
-# Check current image version
-installed_version=$(conf_get $CORTX_CONFSTORE "node>$node_id>provisioning>version")
-release_version=$(conf_get $RELEASE_INFO "VERSION")
-
-if [ $installed_version == "null" ]
-then
-    action="deploy"
-else
-    ret_code=$(compare $installed_version $release_version)
-    [[ "$ret_code" == "0" && -z $FORCE_PROVISIONING ]] &&
-        log $INFO "installed_version ($installed_version) = release_version ($release_version)" &&
-        exit 0
-    [[ "$ret_code" == "1" ]] &&
-        log $ERROR "Invalid image. installed_version ($installed_version) > release_version ($release_version)" &&
-        exit 1
-
-    [[ ! -z $installed_version ]] && [[ "$ret_code" == "-1" ]] && action="upgrade"
-fi
-
-case $action in
-    deploy)
-        apply_config
-        [ ! -z $VALIDATE_CONF ] && validate_config
-        # Deploy cortx
-        deploy
-        ;;
-    upgrade)
-        # Upgrade cortx
-        upgrade
-        ;;
-    *)
-        log $ERROR "Internal error. Could not determine version. Invalid image. current_version is ($installed_version) and release_version is ($release_version)"
-        ;;
-esac
 # Check if debugging is enabled
 if [ $DEBUG_FLAG = true ]; then
     log $INFO "cortx_setup DEBUG enabled...";

--- a/test/setup/cluster.yaml
+++ b/test/setup/cluster.yaml
@@ -1,59 +1,75 @@
 cluster:
   name: cortx-cluster
-  id: 'C01'
+  id: 0007ec45379e36d9fa089a3d615c32a3
   node_types:
-  - name: storage_node
+  - name: client_node        # Optional
     components:
     - name: utils
     - name: motr
       services:
-      - io
+      - motr_client          # motr_setup --services=motr_client
     - name: hare
-    - name: s3
+  - name: data_node/1        # For multiple pods per node, there will another type "data_node/2"
+    components:
+    - name: utils
+    - name: motr
       services:
-      - io
-      - auth
-      - bg_consumer
+        - io
+    - name: hare
     storage:
     - name: cvg-01
       type: ios
       devices:
-        metadata: /dev/sdc
+        metadata:
+        - /dev/sdb
         data:
-          - /dev/sdd
-          - /dev/sde
+        - /dev/sdc
+        - /dev/sdd
     - name: cvg-02
       type: ios
       devices:
-        metadata: /dev/sdf
+        metadata:
+        - /dev/sde
         data:
-          - /dev/sdg
-          - /dev/sdh
+        - /dev/sdf
+        - /dev/sdg
+  - name: server_node
+    components:
+    - name: utils
+    - name: hare
+    - name: rgw
+      services:
+      - rgw_s3               # rgw_setup --services=rgw_s3
   - name: control_node
     components:
     - name: utils
-    - name: motr
-      services:
-      - fsm
-    - name: s3
-      services:
-      - bg_producer
-      - openldap
     - name: csm
       services:
       - agent
+  - name: ha_node
+    components:
+    - name: utils
+    - name: ha
   storage_sets:
   - name: storage-set-1
     durability:
       sns: 1+0+0
       dix: 1+0+0
     nodes:
-    - name: pod-1
-      id: 97085a8ab7cf42669c94963929864a70
-      hostname: pod-1.colo.seagate.com
-      type: control_node
-    - name: pod-2
+    - name: control-node
       id: 8efd697708a8f7e428d3fd520c180795
-      hostname: pod-2.colo.seagate.com
-      type: storage_node
-
+      hostname: control-node
+      type: control_node
+    - name: ha-node
+      id: 1115f539f4f770e2a3fe9e2e615c32a8
+      hostname: ha-node
+      type: ha_node
+    - name: data-node1
+      id: aaa120a9e051d103c164f605615c32a4
+      hostname: data-node1
+      type: data_node/1
+      node_group: data-node-1              # Node group can be physical host name or node label
+    - name: server-node1
+      id: ddd120a9e051d103c164f605615c32a4
+      hostname: server-node1
+      type: server_node

--- a/test/setup/config.yaml
+++ b/test/setup/config.yaml
@@ -1,39 +1,26 @@
 cortx:
   external:
-    kafka:
-      endpoints:
-        - tcp://kafka.default.svc.cluster.local:9092
-      admin: admin
-      secret: kafka_admin_secret
-    openldap:
-      endpoints:
-        - ldap://openldap-svc.default.svc.cluster.local:389
-        - ssl://openldap-svc.default.svc.cluster.local:636
-      servers:
-        - openldap-0.openldap-svc.default.svc.cluster.local
-        - openldap-1.openldap-svc.default.svc.cluster.local
-        - openldap-2.openldap-svc.default.svc.cluster.local
-      admin: admin
-      secret: openldap_admin_secret
-      base_dn: dc=seagate,dc=com
     consul:
-      endpoints:
-        - tcp://consul-server.default.svc.cluster.local:8301
       admin: admin
-      secret: consul_admin_secret
+      endpoints:
+      - tcp://consul-server.default.svc.cluster.local:8301
+      - http://consul-server.default.svc.cluster.local:8500
+      secret: consul_admin_secret                              # Key in the list of secrets  
+    kafka:
+      admin: admin
+      endpoints:
+      - tcp://kafka.default.svc.cluster.local:9092
+      secret: kafka_admin_secret                               # Key in the list of secrets
   common:
     release:
       name: CORTX
       version: 2.0.0-1111
-    environment_type: K8
-    setup_size: small
     service:
       admin: admin
       secret: common_admin_secret
     storage:
-      shared: /share
+      log: /var/log/cortx/
       local: /etc/cortx
-      log: /etc/cortx/log
       config: /etc/cortx
     security:
       ssl_certificate: /etc/cortx/solution/ssl/s3.seagate.com.pem
@@ -41,38 +28,168 @@ cortx:
       device_certificate: /etc/cortx/solution/ssl/stx.pem
   utils:
     message_bus_backend: kafka
-  s3:
-    iam:
-      endpoints:
-      - https://cortx-io-svc:9443
-      - http://cortx-io-svc:9080
-    data:
-      endpoints:
-      - http://cortx-io-svc:80
-      - https://cortx-io-svc:443
-    internal:
-      endpoints:
-      - http://cortx-io-svc:28049
-    service_instances: 2
-    io_max_units: 8
-    max_start_timeout: 240
+  rgw:
+    auth_user: user_name
     auth_admin: sgiamadmin
     auth_secret: s3_auth_admin_secret
+
+    thread_pool_size: 10                                       # To be tuned as we go
+    data_path: /var/cortx/radosgw/$clusterid                   # Needs to be under Local PVC
+    init_timeout: 300                                          # In seconds
+    gc_max_objs: 32                                            # In seconds
+    gc_obj_min_wait: 1800                                      # In seconds
+    gc_processor_max_time: 3600                                # In seconds
+    gc_processor_period: 3600                                  # In seconds
+    
+    motr_layout_id: 9                          
+    motr_unit_size: 1048576 
+    motr_max_units_per_request: 8
+    motr_max_idx_fetch_count: 30
+    motr_max_rpc_msg_size: 524288                              # In bytes
+    motr_reconnect_interval: 10                                # Wait for Seconds before reconnect 
+    motr_reconnect_retry_count: 10                             # Give up after these many retries
+    public:                                                    # NOTE: was s3 earlier 
+      endpoints:                                               # S3 IO K8s service endpoint
+      - http://s3-rgw-svc:80                                   # Optional (if http needs to be enabled)
+      - https://s3-rgw-svc:443                                 # There will be one endpoint (http/https)
+    service:
+      endpoints:                                               # RGW Service Endpoint
+      - http://:22751                                          # S ports. S = # of RGW Instances
+      - https://:23001
+    io_max_units: 8
+    max_start_timeout: <<.Values.cortx.max_start_timeout>>
+    limits:
+      services:
+      - name: rgw
+        memory:
+          min: 128Mi
+          max: 1Gi
+        cpu:
+          min: 250m
+          max: 1000m 
   motr:
-    client_instances: 0
-    interface_type: tcp
-    interface_family: inet
-    transport_type: libfab
+    interface_family: inet                                     # Optional: inet (default) | inet6
+    transport_type: libfab                                     # libfab | lnet (libfab==inet)
+    md_size: 10                                                # % MD size w.r.t. total capacity
+    ios:
+      group_size: 1                                            # Number of services to be started in a group
+                                                               # N = Total CVG / group_size. N must be <=24. 
+      endpoints:
+      - tcp://data1-node1:21002                                # Format: <protocol>://<hostname_ip>:<port>
+                                                               # N endpoints one for each Pod, first mentioned here
+                                                               # N == Number of CVGs in the Pod
+                                                               # Ports: 21002 - (21002 + Number of CVGs)
+      - tcp://data2-node1:21002                                # Same thing for the second pod
+      - tcp://data1-node2:21002                                # of for Pods on the other nodes
+
+    confd:
+      endpoints:
+      - tcp://data1-node1:21001                               # Format: <protocol>://<hostname_ip>:21001
+      - tcp://data1-node2:21001       
+      - tcp://data1-node3:21001  
+    limits:
+      services:
+      - name: ios
+        memory:
+          min: 1Gi                                             # Needs to compute this dynamically 
+                                                               # min = Max. of (K * 0.5 /N, ((M/N) * 5% * (K/N)) Gi)
+                                                               # where K= Num CVGs, N=Num Containers
+          max: 0                                               # max = 1.1 * min. For now set to 0.
+        cpu:                         
+          min: 1000m                                           # 1000m * N where N = Num of "ios" Containers
+          max: 1500m                                           # 1500m * N where N = Num of "ios" Containers
+      - name: confd
+        memory:
+          min: 128Mi
+          max: 512Mi
+        cpu:
+          min: 250m
+          max: 500m
+    clients:                                                   # Motr Client Settings
+      - name: rgw_s3                                           # rgw|s3|motr_client (Motr Clients)
+        num_instances: 1                                       # Client instances per node (pod)
+        endpoints:
+        - tcp://server1-node1:22501                            # Format: <protocol>://<hostname_ip>:22501 
+        - tcp://server2-node1:22501                            # This is for client>type == "s3"
+                                                               # This is a starting endpoint and num of s3
+                                                               # endpoints will be equal to num of s3 instances 
+                                                               # in this pod. Port range would be 
+                                                               # 22501 to (22501 + "motr>client>{rgw_s3}>num_instances")
+        - tcp://server-node1:22501
+      - name: motr_client
+        num_instances: 0                                       # Optional client. Only for Dev.
+        num_subscriptions: 1
+        subscriptions:                                         # NEW: Optional: Services subscribed for client
+        - fdmi
+        endpoints:
+        - tcp://client1-node1:21501                            # Port range would be 
+                                                               # 21501 to (21501 + "motr>client>{motr_client}>num_instances")
+
+  hare:
+    hax:
+      endpoints:
+      - https://motr-hax-svc:22003                             # Control endpoint
+      - tcp://data1-node1:22001                                # For motr and Hax communication
+      - tcp://data1-node2:22001                                # For motr and Hax communication
+      - tcp://data1-node3:22001                                # For motr and Hax communication
+      - tcp://server-node1:22001                               # if s3 client is configured
+      - tcp://server-node2:22001                               # if s3 client is configured
+      - tcp://server-node3:22001                               # if s3 client is configured
+      - tcp://client-node1:22001                               # Only if motr_client is configured
+      - tcp://client-node2:22001                               # Only if motr_client is configured
+      - tcp://client-node3:22001                               # Only if motr_client is configured
+    limits:
+      services:
+      - name: hax
+        memory:
+          min: 128Mi
+          max: 1Gi
+        cpu:
+          min: 250m
+          max: 500m
   csm:
-    auth_admin: authadmin
-    auth_secret: csm_auth_admin_secret
-    mgmt_admin: cortxadmin
-    mgmt_secret: csm_mgmt_admin_secret
-    email_address: cortx@seagate.com
     agent:
       endpoints:
-      - https://cortx-io-svc:8081
+      - https://:23256
+    public:                                                    # Public Control Endpoint
+      endpoints:
+      - https://control-svc:8081
+    email_address: cortx@seagate.com # Optional 
+    mgmt_admin: cortxadmin
+    mgmt_secret: csm_mgmt_admin_secret
+    limits:   
+      services:              
+      - name: agent
+        memory:
+          min: 128Mi
+          max: 256Mi
+        cpu:
+          min: 250m
+          max: 500m
   ha:
     service:
       endpoints:
       - http://cortx-ha-svc:23501
+    limits:         
+      services:        
+      - name: fault_tolerance
+        memory:
+          min: 128Mi
+          max: 1Gi
+        cpu:
+          min: 250m
+          max: 500m
+      - name: health_monitor
+        memory:
+          min: 128Mi
+          max: 1Gi
+        cpu:
+          min: 250m
+          max: 500m
+      - name: k8s_monitor
+        memory:
+          min: 128Mi
+          max: 1Gi
+        cpu:
+          min: 250m
+          max: 500m

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -26,6 +26,7 @@ from cortx.provisioner.provisioner import CortxProvisioner
 solution_cluster_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "cluster.yaml"))
 solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "config.yaml"))
 cortx_conf_url = "yaml:///tmp/test_conf_store.conf"
+tmp_conf_url = "yaml:///tmp/tmp.conf"
 
 def check_num_xx_keys(data):
     """Returns true if all the xxx list have respective num_xxx key."""
@@ -68,16 +69,7 @@ class TestProvisioner(unittest.TestCase):
 
     def test_num_xxx_in_gconf(self):
         """Test if num_xxx key is saved in gconf for list items(CORTX-30863)."""
-        rc = 0
-        try:
-            CortxProvisioner.config_apply(solution_cluster_url, cortx_conf_url)
-            CortxProvisioner.config_apply(solution_conf_url, cortx_conf_url, force_override=True)
-        except Exception as e:
-            print('Exception: ', e)
-            sys.stderr.write("%s\n" % traceback.format_exc())
-            rc = 1
-        self.assertEqual(rc, 0)
-        conf_path = cortx_conf_url.split('//')[1]
+        conf_path = tmp_conf_url.split('//')[1]
         with open(conf_path, 'r') as stream:
             try:
                 gconf = yaml.safe_load(stream)

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -71,6 +71,15 @@ class TestProvisioner(unittest.TestCase):
 
     def test_num_xxx_in_gconf(self):
         """Test if num_xxx key is saved in gconf for list items(CORTX-30863)."""
+        rc = 0
+        try:
+            CortxProvisioner.config_apply(solution_cluster_url, cortx_conf_url)
+            CortxProvisioner.config_apply(solution_conf_url, cortx_conf_url, force_override=True)
+        except Exception as e:
+            print('Exception: ', e)
+            sys.stderr.write("%s\n" % traceback.format_exc())
+            rc = 1
+        self.assertEqual(rc, 0)
         conf_path = cortx_conf_url.split('//')[1]
         rc = 0
         with open(conf_path, 'r') as stream:

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -25,8 +25,7 @@ from cortx.provisioner.provisioner import CortxProvisioner
 
 solution_cluster_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "cluster.yaml"))
 solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "config.yaml"))
-cortx_conf_url = "yaml:///tmp/test_conf_store.conf"
-tmp_conf_url = "yaml:///tmp/tmp.conf"
+cortx_conf_url = "yaml:///tmp/tmp.conf"
 
 def check_num_xx_keys(data):
     """Returns true if all the xxx list have respective num_xxx key."""
@@ -69,7 +68,7 @@ class TestProvisioner(unittest.TestCase):
 
     def test_num_xxx_in_gconf(self):
         """Test if num_xxx key is saved in gconf for list items(CORTX-30863)."""
-        conf_path = tmp_conf_url.split('//')[1]
+        conf_path = cortx_conf_url.split('//')[1]
         with open(conf_path, 'r') as stream:
             try:
                 gconf = yaml.safe_load(stream)

--- a/test/setup/test_provisioner.py
+++ b/test/setup/test_provisioner.py
@@ -22,10 +22,13 @@ import traceback
 import unittest
 import yaml
 from cortx.provisioner.provisioner import CortxProvisioner
+from cortx.utils.conf_store import Conf
 
 solution_cluster_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "cluster.yaml"))
 solution_conf_url = "yaml://" + os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "config.yaml"))
-cortx_conf_url = "yaml:///tmp/tmp.conf"
+cortx_conf_url = "yaml:///tmp/test.conf"
+tmp_conf_url = "yaml:///tmp/tmp.conf"
+delta_url = "yaml:///etc/cortx/changeset.conf"
 
 def check_num_xx_keys(data):
     """Returns true if all the xxx list have respective num_xxx key."""
@@ -69,6 +72,7 @@ class TestProvisioner(unittest.TestCase):
     def test_num_xxx_in_gconf(self):
         """Test if num_xxx key is saved in gconf for list items(CORTX-30863)."""
         conf_path = cortx_conf_url.split('//')[1]
+        rc = 0
         with open(conf_path, 'r') as stream:
             try:
                 gconf = yaml.safe_load(stream)
@@ -78,6 +82,39 @@ class TestProvisioner(unittest.TestCase):
         self.assertEqual(rc, 0)
         is_key_present, message = check_num_xx_keys(gconf)
         self.assertTrue(is_key_present, message)
+    
+    def test_prepare_diff(self):
+        """Test if changeset file is getting generated with new/changes/deleted keys"""
+        Conf.load('index1', tmp_conf_url)
+        Conf.load('index2', cortx_conf_url)
+        # add 1 new key in tmp conf
+        Conf.set('index1', 'cortx>common>name', 'CORTX')
+        # Change previous key from tmp conf
+        Conf.set('index1', 'cortx>common>security>device_certificate', '/etc/cortx/solution/security.pem')
+        # Delete one key from tmp conf
+        Conf.delete('index1', 'cortx>common>security>domain_certificate')
+        Conf.save('index1')
+        rc = 0
+        try:
+            CortxProvisioner._prepare_diff('index2','index1', 'index3')
+        except Exception as e:
+            print('Exception: ', e)
+            sys.stderr.write("%s\n" % traceback.format_exc())
+            rc = 1
+        self.assertEqual(rc, 0)
+        self.assertEqual(Conf.get('index3','new>cortx>common>name'),'CORTX')
+    
+    def test_update_conf(self):
+        """Test if new keys from changeset are getting updated in conf"""
+        rc = 0
+        try:
+            CortxProvisioner._update_conf('index2','index1')
+        except Exception as e:
+            print('Exception: ', e)
+            sys.stderr.write("%s\n" % traceback.format_exc())
+            rc = 1
+        self.assertEqual(rc, 0)
+        self.assertEqual(Conf.get('index2','cortx>common>name'),'CORTX')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
Implement GCONF Upgrade, In a way that before calling upgrade mini provisioner of components, prepare a delta diff which will be passed to component miniprovisioner as part of cortx upgrade.
gconf should be only updated once all component mini provisioning is done.

## Design

*  Implement pre_upgrade and post_upgrade interfaces in provisioner which will handle gconf upgrade

## Coding

Checklist for Author

*   \[x] Coding conventions are followed and code is consistent

## Testing

Checklist for Author

*   \[x] Unit and System Tests are added
*   \[ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
*   \[x] Testing was performed with RPM

## Impact Analysis

Checklist for Author/Reviewer/GateKeeper

*   \[ ] Interface change (if any) are documented
*   \[ ] Side effects on other features (deployment/upgrade)
*   \[ ] Dependencies on other component(s)

## Review Checklist

Checklist for Author

*   \[x] JIRA number/GitHub Issue added to PR
*   \[x] PR is self reviewed
*   \[x] Jira and state/status is updated and JIRA is updated with PR link
*   \[x] Check if the description is clear and explained

## Documentation

Checklist for Author

*   \[x] Changes done to WIKI / Confluence page / Quick Start Guide
