### PR TITLE
CORTX-30265 - paramiko upgrade to 2.10.4

### DIFF
--- a/jenkins/docker/python_requirements.txt
+++ b/jenkins/docker/python_requirements.txt
@@ -14,7 +14,7 @@ marshmallow==3.2.1
 matplotlib==3.1.3
 netifaces==0.10.9
 networkx==2.4
-paramiko==2.7.1
+paramiko==2.10.4
 pathlib==1.0.1
 pika==1.1.0
 prettytable==0.7.2


### PR DESCRIPTION
Signed-off-by: swanand-gadre <swanand.s.gadre@seagate.com>

# Problem Statement

*   Problem statement
Paramiko package 2.7.X is vulnerable.
It needs to be upgraded to version 2.10.4
This PR is raised to upgrade this version.

## Design

*   For Bug, Describe the fix here.
*   For Feature, Post the link for design
This PR is raised to upgrade paramiko package from 2.7.X to 2.10.4

## Coding

Checklist for Author

*   \[X] Coding conventions are followed and code is consistent

## Testing

Checklist for Author

*   \[X] Unit and System Tests are added
*   \[X] Test Cases cover Happy Path, Non-Happy Path and Scalability
*   \[X] Testing was performed with RPM
All test details are available in a document attached to this ticket -> https://jts.seagate.com/browse/CORTX-30265

## Impact Analysis

Checklist for Author/Reviewer/GateKeeper

*   \[ ] Interface change (if any) are documented
*   \[ ] Side effects on other features (deployment/upgrade)
*   \[ ] Dependencies on other component(s)

## Review Checklist

Checklist for Author

*   \[X] JIRA number/GitHub Issue added to PR
*   \[X] PR is self reviewed
*   \[X] Jira and state/status is updated and JIRA is updated with PR link
*   \[X] Check if the description is clear and explained

## Documentation

Checklist for Author

*   \[ ] Changes done to WIKI / Confluence page / Quick Start Guide
Not applicable