### PR TITLE
CORTX-31277: add node_group for data nodes in gconf

### DIFF
--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -16,8 +16,10 @@
 import errno
 from cortx.provisioner.error import CortxProvisionerError
 from cortx.utils.validator.error import VError
+from cortx.utils.cortx.const import Const
 from cortx.provisioner.log import Log
-
+import socket
+import os
 
 class CortxCluster:
     """Represents CORTX Cluster"""
@@ -131,6 +133,8 @@ class CortxCluster:
             for node in self._node_list:
                 node_id = node.pop('id')
                 key_prefix = f'node>{node_id}'
+                if socket.gethostname() == node['hostname'] and node['type'] == 'data_node':
+                    kvs.append((f'{key_prefix}>node_group', os.getenv('NODE_NAME')))
                 # confstore keys
                 kvs.extend((
                     (f'{key_prefix}>cluster_id', node['cluster_id']),

--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -133,7 +133,7 @@ class CortxCluster:
             for node in self._node_list:
                 node_id = node.pop('id')
                 key_prefix = f'node>{node_id}'
-                if socket.gethostname() == node['hostname'] and node['type'] == 'data_node':
+                if socket.gethostname() == node['hostname'] and node['type'] in Const.NODE_TYPE_DATA.value:
                     kvs.append((f'{key_prefix}>node_group', os.getenv('NODE_NAME')))
                 # confstore keys
                 kvs.extend((

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -246,7 +246,7 @@ class CortxProvisioner:
     @staticmethod
     def _apply_consul_config(cortx_conf: MappedConf):
         num_endpoints = cortx_conf.get('cortx>external>consul>num_endpoints')
-        for idx in range(0, num_endpoints): 
+        for idx in range(0, num_endpoints):
             if 'http' in Conf.get(f'cortx>external>consul>endpoints[{idx}]'):
                 consul_endpoint = Conf.get(f'cortx>external>consul>endpoints[{idx}]')
                 break

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -243,6 +243,17 @@ class CortxProvisioner:
                 cortx_conf.set(f'{key_prefix}>version', component_version)
 
     @staticmethod
+    def _apply_consul_config(cortx_conf: MappedConf):
+        consul_endpoints = cortx_conf.get('cortx>external>consul>endpoints')
+        print(consul_endpoints)
+        gconf_consul_url = consul_endpoints[1].replace('http','consul') + '/conf'
+        print(gconf_consul_url)
+        Conf.load('consul_index', gconf_consul_url)
+        gconf_keys = Conf.get_keys(cortx_conf._conf_idx)
+        Conf.copy(cortx_conf._conf_idx, 'consul_index', gconf_keys)
+        Conf.save('consul_index')
+
+    @staticmethod
     def cluster_bootstrap(cortx_conf_url: str, force_override: bool = False):
         """
         Description:
@@ -254,6 +265,7 @@ class CortxProvisioner:
         [IN] CORTX Config URL
         """
         cortx_conf = MappedConf(cortx_conf_url)
+        CortxProvisioner._apply_consul_config(cortx_conf)
         apply_phase = ProvisionerStages.DEPLOYMENT.value
         node_id, node_name = CortxProvisioner._get_node_info(cortx_conf)
         is_valid, ret_code = CortxProvisioner._validate_provisioning_status(

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -54,6 +54,7 @@ class CortxProvisioner:
     _solution_index = "solution_conf"
     _secrets_path = "/etc/cortx/solution/secret"
     _rel_secret_path = "/solution/secret"
+    _cortx_gconf_consul_index = "consul_index"
     cortx_release = Release(const.RELEASE_INFO_URL)
 
     @staticmethod
@@ -244,14 +245,11 @@ class CortxProvisioner:
 
     @staticmethod
     def _apply_consul_config(cortx_conf: MappedConf):
-        consul_endpoints = cortx_conf.get('cortx>external>consul>endpoints')
-        print(consul_endpoints)
-        gconf_consul_url = consul_endpoints[1].replace('http','consul') + '/conf'
-        print(gconf_consul_url)
-        Conf.load('consul_index', gconf_consul_url)
-        gconf_keys = Conf.get_keys(cortx_conf._conf_idx)
-        Conf.copy(cortx_conf._conf_idx, 'consul_index', gconf_keys)
-        Conf.save('consul_index')
+        consul_endpoint = cortx_conf.get('cortx>external>consul>endpoints[1]')
+        gconf_consul_url = consul_endpoint.replace('http','consul') + '/conf'
+        Conf.load(CortxProvisioner._cortx_gconf_consul_index, gconf_consul_url)
+        Conf.copy(cortx_conf._conf_idx, 'consul_index', Conf.get_keys(cortx_conf._conf_idx))
+        Conf.save(CortxProvisioner._cortx_gconf_consul_index)
 
     @staticmethod
     def cluster_bootstrap(cortx_conf_url: str, force_override: bool = False):

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -247,12 +247,12 @@ class CortxProvisioner:
     def _apply_consul_config(cortx_conf: MappedConf):
         num_endpoints = cortx_conf.get('cortx>external>consul>num_endpoints')
         for idx in range(0, num_endpoints):
-            if 'http' in Conf.get(f'cortx>external>consul>endpoints[{idx}]'):
-                consul_endpoint = Conf.get(f'cortx>external>consul>endpoints[{idx}]')
+            if 'http' in cortx_conf.get(f'cortx>external>consul>endpoints[{idx}]'):
+                consul_endpoint = cortx_conf.get(f'cortx>external>consul>endpoints[{idx}]')
                 break
         gconf_consul_url = consul_endpoint.replace('http','consul') + '/conf'
         Conf.load(CortxProvisioner._cortx_gconf_consul_index, gconf_consul_url)
-        Conf.copy(cortx_conf._conf_idx, 'consul_index', Conf.get_keys(cortx_conf._conf_idx))
+        Conf.copy(cortx_conf._conf_idx, CortxProvisioner._cortx_gconf_consul_index, Conf.get_keys(cortx_conf._conf_idx))
         Conf.save(CortxProvisioner._cortx_gconf_consul_index)
 
     @staticmethod

--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -245,7 +245,11 @@ class CortxProvisioner:
 
     @staticmethod
     def _apply_consul_config(cortx_conf: MappedConf):
-        consul_endpoint = cortx_conf.get('cortx>external>consul>endpoints[1]')
+        num_endpoints = cortx_conf.get('cortx>external>consul>num_endpoints')
+        for idx in range(0, num_endpoints): 
+            if 'http' in Conf.get(f'cortx>external>consul>endpoints[{idx}]'):
+                consul_endpoint = Conf.get(f'cortx>external>consul>endpoints[{idx}]')
+                break
         gconf_consul_url = consul_endpoint.replace('http','consul') + '/conf'
         Conf.load(CortxProvisioner._cortx_gconf_consul_index, gconf_consul_url)
         Conf.copy(cortx_conf._conf_idx, 'consul_index', Conf.get_keys(cortx_conf._conf_idx))


### PR DESCRIPTION
# Problem Statement

*   Update generated cluster configuration at provisioning time with node_group set to Kubernetes worker node name

## Design

As part of [CORTX-29695](https://jts.seagate.com/browse/CORTX-29695), the node_group information will be injected at deployment time and available when the initContainer is running the provisioning logic. The cortx-k8s code will inject the Kubernetes worker node name into the initContainer as an environment variable (NODE_NAME) and the Provisioner logic will need to update the generated configuration information to set `node_group` to the value defined in NODE_NAME environment variable.

## Coding

Checklist for Author

*   \[x] Coding conventions are followed and code is consistent

## Testing

Checklist for Author

*   \[ ] Unit and System Tests are added
*   \[x] Test Cases cover Happy Path, Non-Happy Path and Scalability
*   \[x] Testing was performed with RPM

## Impact Analysis

Checklist for Author/Reviewer/GateKeeper

*   \[ ] Interface change (if any) are documented
*   \[ ] Side effects on other features (deployment/upgrade)
*   \[x] Dependencies on other component(s)

## Review Checklist

Checklist for Author

*   \[x] JIRA number/GitHub Issue added to PR
*   \[x] PR is self reviewed
*   \[x] Jira and state/status is updated and JIRA is updated with PR link
*   \[x] Check if the description is clear and explained

## Documentation

Checklist for Author

*   \[ ] Changes done to WIKI / Confluence page / Quick Start Guide
