### PR TITLE
CORTX-32256 Provisioner Logs for cortx_setup commands are not getting…

### DIFF
--- a/src/provisioner/const.py
+++ b/src/provisioner/const.py
@@ -30,3 +30,4 @@ REQUIRED_EXTERNAL_SW = ['kafka', 'consul']
 # Path to the location that holds the cortx gconf consul url.
 CONSUL_CONF_URL = "/etc/cortx/consul_conf"
 CORTX_CHANGESET_URL = "yaml:///etc/cortx/changeset.conf"
+DEFAULT_CONSOLE_OUTPUT_LEVEL = "INFO"

--- a/src/provisioner/log.py
+++ b/src/provisioner/log.py
@@ -38,7 +38,8 @@ class CortxProvisionerLog(Log):
         if not CortxProvisionerLog.logger:
             if level not in const.SUPPORTED_LOG_LEVELS:
                 level = const.DEFAULT_LOG_LEVEL
-            Log.init(service_name, log_path, level=level, console_output=console_output)
+            Log.init(service_name, log_path, level=level, console_output=console_output,
+             console_output_level=const.DEFAULT_CONSOLE_OUTPUT_LEVEL)
             CortxProvisionerLog.logger = Log.logger
 
 
@@ -74,4 +75,5 @@ class CortxProvisionerLog(Log):
                         'a+') as f:
                     f.writelines(lines)
 
-        Log.init(const.SERVICE_NAME, log_path, level=level, console_output=console_output)
+        Log.init(const.SERVICE_NAME, log_path, level=level, console_output=console_output,
+         console_output_level=const.DEFAULT_CONSOLE_OUTPUT_LEVEL)


### PR DESCRIPTION
CORTX-32256 - Provisioner Logs for cortx_setup commands are not getting displayed in deployment pod logs

Redirecting log to console for provisioner

Signed-off-by: Zahid Shaikh <zahid.shaikh@seagate.com>

# Problem Statement

*   [CORTX-32256](https://jts.seagate.com/browse/CORTX-32256)
Provisioner Logs for cortx_setup commands are not getting displayed in deployment pod logs

## Design

*   For Bug, Describe the fix here.
*   For Feature, Post the link for design

## Coding

Checklist for Author

*   \[x] Coding conventions are followed and code is consistent

## Testing

Checklist for Author

*   \[ ] Unit and System Tests are added
*   \[ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
*   \[x] Testing was performed with RPM

## Impact Analysis

Checklist for Author/Reviewer/GateKeeper

*   \[ ] Interface change (if any) are documented
*   \[ ] Side effects on other features (deployment/upgrade)
*   \[ ] Dependencies on other component(s)

## Review Checklist

Checklist for Author

*   \[x] JIRA number/GitHub Issue added to PR
*   \[x] PR is self reviewed
*   \[x] Jira and state/status is updated and JIRA is updated with PR link
*   \[ ] Check if the description is clear and explained

## Documentation

Checklist for Author

*   \[ ] Changes done to WIKI / Confluence page / Quick Start Guide
