### PR TITLE
CORTX-32413: remove const.data_node from cluster.py

### DIFF
--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -148,8 +148,7 @@ class CortxCluster:
                 if socket.getfqdn() == node['hostname']:
                     with open(const.MACHINE_ID_PATH,'w') as machine_id_path:
                         machine_id_path.write(machine_id)
-                    storage_spec = node.get('storage')
-                    if storage_spec:
+                    if node.get('storage'):
                         kvs.append((f'{key_prefix}>node_group', os.getenv('NODE_NAME')))
                 # confstore keys
                 kvs.extend((
@@ -162,6 +161,7 @@ class CortxCluster:
                     ))
                 component_list = node['components']
                 kvs.extend(CortxCluster._get_component_kv_list(component_list, machine_id))
+                storage_spec = node.get('storage')
                 if storage_spec:
                     kvs.extend(self._get_storage_kv_list(storage_spec, machine_id))
             cortx_conf.set_kvs(kvs)

--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -149,7 +149,8 @@ class CortxCluster:
                 if socket.getfqdn() == node['hostname']:
                     with open(const.MACHINE_ID_PATH,'w') as machine_id_path:
                         machine_id_path.write(machine_id)
-                    if node['type'] in Const.NODE_TYPE_DATA.value:
+                        storage_spec = node.get('storage')
+                    if storage_spec:
                         kvs.append((f'{key_prefix}>node_group', os.getenv('NODE_NAME')))
                 # confstore keys
                 kvs.extend((
@@ -162,7 +163,6 @@ class CortxCluster:
                     ))
                 component_list = node['components']
                 kvs.extend(CortxCluster._get_component_kv_list(component_list, machine_id))
-                storage_spec = node.get('storage')
                 if storage_spec:
                     kvs.extend(self._get_storage_kv_list(storage_spec, machine_id))
             cortx_conf.set_kvs(kvs)

--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -148,7 +148,7 @@ class CortxCluster:
                 if socket.getfqdn() == node['hostname']:
                     with open(const.MACHINE_ID_PATH,'w') as machine_id_path:
                         machine_id_path.write(machine_id)
-                        storage_spec = node.get('storage')
+                    storage_spec = node.get('storage')
                     if storage_spec:
                         kvs.append((f'{key_prefix}>node_group', os.getenv('NODE_NAME')))
                 # confstore keys

--- a/src/provisioner/cluster.py
+++ b/src/provisioner/cluster.py
@@ -19,7 +19,6 @@ import socket
 import os
 from cortx.provisioner.error import CortxProvisionerError
 from cortx.utils.validator.error import VError
-from cortx.utils.cortx.const import Const
 from cortx.provisioner.log import Log
 from cortx.provisioner import const
 


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement

*  Remove Const.data_node from provisioner

## Design

Data_node type values are prone to change with respect to multiple data pods, hence we need to remove the hard dependency from this constants and recognize data pods based on storage key.

## Coding

Checklist for Author

*   \[x] Coding conventions are followed and code is consistent

## Testing

Checklist for Author

*   \[x] Unit and System Tests are added
*   \[ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
*   \[x] Testing was performed with RPM

## Impact Analysis

Checklist for Author/Reviewer/GateKeeper

*   \[ ] Interface change (if any) are documented
*   \[ ] Side effects on other features (deployment/upgrade)
*   \[ ] Dependencies on other component(s)

## Review Checklist

Checklist for Author

*   \[x] JIRA number/GitHub Issue added to PR
*   \[x] PR is self reviewed
*   \[x] Jira and state/status is updated and JIRA is updated with PR link
*   \[x] Check if the description is clear and explained

## Documentation

Checklist for Author

*   \[ ] Changes done to WIKI / Confluence page / Quick Start Guide
