### PR TITLE
CORTX-32710: add deployment_time field in gconf priovisioner

### DIFF
--- a/src/provisioner/provisioner.py
+++ b/src/provisioner/provisioner.py
@@ -16,6 +16,7 @@
 import errno
 import os
 from enum import Enum
+import time
 from urllib.parse import urlparse
 from cortx.utils.process import SimpleProcess
 from cortx.utils.conf_store import Conf, MappedConf
@@ -453,6 +454,9 @@ class CortxProvisioner:
         CortxProvisioner._load_consul_conf(CortxProvisioner._cortx_gconf_consul_index)
         Conf.set(CortxProvisioner._cortx_gconf_consul_index, f'{key_prefix}>phase', phase)
         Conf.set(CortxProvisioner._cortx_gconf_consul_index, f'{key_prefix}>status', status)
+        if phase is ProvisionerStages.DEPLOYMENT.value:
+            Conf.set(_conf_idx, f'{key_prefix}>time', int(time.time()))
+            Conf.set(CortxProvisioner._cortx_gconf_consul_index, f'{key_prefix}>time', int(time.time()))
         Conf.save(CortxProvisioner._cortx_gconf_consul_index)
 
     @staticmethod


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement

CORTX-32710: add deployment_time field in gconf priovisioner

## Design

Deployment time in epoch format needs to be added for each node once mini provisioning is successful.

## Coding

Checklist for Author

*   \[x] Coding conventions are followed and code is consistent

## Testing

Checklist for Author

*   \[x] Unit and System Tests are added
*   \[x] Test Cases cover Happy Path, Non-Happy Path and Scalability
*   \[x] Testing was performed with RPM

## Impact Analysis

Checklist for Author/Reviewer/GateKeeper

*   \[ ] Interface change (if any) are documented
*   \[ ] Side effects on other features (deployment/upgrade)
*   \[ ] Dependencies on other component(s)

## Review Checklist

Checklist for Author

*   \[x] JIRA number/GitHub Issue added to PR
*   \[x] PR is self reviewed
*   \[x] Jira and state/status is updated and JIRA is updated with PR link
*   \[x] Check if the description is clear and explained

## Documentation

Checklist for Author

*   \[ ] Changes done to WIKI / Confluence page / Quick Start Guide
